### PR TITLE
Stream settings write via the Reolink HTTP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ the original Rust neolink are also accepted.
 |---|---|---|
 | `name` | *required* | Name used in the RTSP URL and web UI |
 | `address` | *required* | Camera IP/hostname; port defaults to `9000` |
+| `http_address` | *(none)* | The camera's HTTP(S) web interface (`host`, `host:port` or full URL). Enables changing stream profiles (resolution/fps/bitrate) from the web UI via the documented Reolink HTTP API |
 | `username` / `password` | *required* | The camera's own login (same as the Reolink app) |
 | `stream` | `both` | `mainStream`, `subStream`, `externStream`, `both`, or `all` |
 | `channel_id` | `0` | Channel when connecting through a Reolink NVR (0-based) |

--- a/src/Neolink.Server/Config/NeolinkConfig.cs
+++ b/src/Neolink.Server/Config/NeolinkConfig.cs
@@ -108,7 +108,7 @@ public sealed class NeolinkConfig
 
     private static CameraConfig ParseJsonCamera(JsonElement el)
     {
-        string? name = null, username = null, password = null, address = null, uid = null;
+        string? name = null, username = null, password = null, address = null, uid = null, httpAddress = null;
         string stream = "both";
         byte channelId = 0;
         List<string>? permitted = null;
@@ -121,6 +121,7 @@ public sealed class NeolinkConfig
                 case "username": username = prop.Value.GetString(); break;
                 case "password": password = prop.Value.GetString(); break;
                 case "address": address = prop.Value.GetString(); break;
+                case "httpaddress": httpAddress = prop.Value.GetString(); break;
                 case "uid": uid = prop.Value.GetString(); break;
                 case "stream": stream = prop.Value.GetString() ?? "both"; break;
                 case "channelid": channelId = prop.Value.GetByte(); break;
@@ -136,7 +137,7 @@ public sealed class NeolinkConfig
             }
         }
 
-        return BuildCamera(name, username, password, address, uid, stream, channelId, permitted);
+        return BuildCamera(name, username, password, address, uid, stream, channelId, permitted, httpAddress);
     }
 
     /// <summary>Normalizes JSON keys: case-insensitive, tolerates snake_case and kebab-case.</summary>
@@ -181,7 +182,8 @@ public sealed class NeolinkConfig
                 MiniToml.GetString(c, "uid"),
                 MiniToml.GetString(c, "stream") ?? "both",
                 (byte)(MiniToml.GetInt(c, "channel_id") ?? 0),
-                MiniToml.GetStringList(c, "permitted_users")));
+                MiniToml.GetStringList(c, "permitted_users"),
+                MiniToml.GetString(c, "http_address")));
         }
         return config;
     }
@@ -193,7 +195,8 @@ public sealed class NeolinkConfig
                  "Consider a TLS-terminating proxy if you need rtsps://");
 
     private static CameraConfig BuildCamera(string? name, string? username, string? password,
-        string? address, string? uid, string stream, byte channelId, List<string>? permitted)
+        string? address, string? uid, string stream, byte channelId, List<string>? permitted,
+        string? httpAddress = null)
     {
         if (name == null) throw new FormatException("camera entry missing \"name\"");
         if (username == null) throw new FormatException($"Camera \"{name}\" missing \"username\"");
@@ -215,6 +218,7 @@ public sealed class NeolinkConfig
             Stream = stream,
             ChannelId = channelId,
             PermittedUsers = permitted,
+            HttpAddress = string.IsNullOrWhiteSpace(httpAddress) ? null : httpAddress.Trim(),
         };
     }
 
@@ -295,4 +299,9 @@ public sealed class CameraConfig
     public string Stream { get; init; } = "both";
     public byte ChannelId { get; init; }
     public List<string>? PermittedUsers { get; init; }
+    /// <summary>
+    /// The camera's Reolink HTTP(S) API ("host", "host:port" or full URL), used for
+    /// the settings Baichuan has no verified write path for (stream encode profiles).
+    /// </summary>
+    public string? HttpAddress { get; init; }
 }

--- a/src/Neolink.Server/Program.cs
+++ b/src/Neolink.Server/Program.cs
@@ -123,8 +123,11 @@ foreach (var cam in config.Cameras)
 
     // Control commands (capabilities, PTZ, LED, ...) ride the primary stream's
     // connection — cameras have session limits, so no extra login is spent.
+    // Stream encode settings are written via the camera's HTTP API when configured.
+    var httpApi = cam.HttpAddress == null ? null
+        : new ReolinkHttpApi(cam.HttpAddress, cam.Username, cam.Password, cam.ChannelId);
     ICameraControl control = new CameraControl(primaryService
-        ?? throw new InvalidOperationException($"camera '{cam.Name}' has no streams"));
+        ?? throw new InvalidOperationException($"camera '{cam.Name}' has no streams"), httpApi);
     webCameras.Add(new WebCameraInfo(cam.Name, webStreams, control, permitted));
 }
 

--- a/src/Neolink.Server/Protocol/ReolinkHttpApi.cs
+++ b/src/Neolink.Server/Protocol/ReolinkHttpApi.cs
@@ -1,0 +1,187 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Neolink.Protocol;
+
+/// <summary>The camera's HTTP API rejected a command or sent a reply we cannot use.</summary>
+public sealed class ReolinkApiException : Exception
+{
+    public ReolinkApiException(string message) : base(message) { }
+}
+
+/// <summary>
+/// Minimal client for the documented Reolink HTTP API (POST /api.cgi with a JSON
+/// command array). Used only for what Baichuan cannot do — today that is writing
+/// stream encode settings (GetEnc/SetEnc); the BC set-encode message format is
+/// unverified, and the reference Rust neolink implements no setter either.
+///
+/// Sessions are token-based: cmd=Login yields a token with a lease time that every
+/// later call carries as a query parameter. The token is cached and renewed shortly
+/// before the lease runs out, or when the camera reports it invalid (rspCode -6,
+/// e.g. after a reboot). Requests are serialized through one gate; Reolink
+/// firmwares are happiest answering API calls one at a time.
+/// </summary>
+public sealed class ReolinkHttpApi : IDisposable
+{
+    private static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(10);
+    /// <summary>Renew the token this long before its lease actually runs out.</summary>
+    private static readonly TimeSpan LeaseMargin = TimeSpan.FromSeconds(60);
+
+    private readonly HttpClient _http;
+    private readonly string _apiUrl;
+    private readonly string _username;
+    private readonly string _password;
+    private readonly byte _channelId;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    private string? _token;
+    private DateTime _tokenExpiry;
+
+    /// <param name="address">"host", "host:port" or a full "http(s)://host[:port]" URL.</param>
+    public ReolinkHttpApi(string address, string username, string? password, byte channelId)
+    {
+        var baseUrl = (address.Contains("://") ? address : $"http://{address}").TrimEnd('/');
+        _apiUrl = $"{baseUrl}/api.cgi";
+        _username = username;
+        _password = password ?? "";
+        _channelId = channelId;
+
+        var handler = new HttpClientHandler();
+        if (baseUrl.StartsWith("https:", StringComparison.OrdinalIgnoreCase))
+        {
+            // Cameras serve their HTTPS API with a self-signed certificate.
+            handler.ServerCertificateCustomValidationCallback = (_, _, _, _) => true;
+        }
+        _http = new HttpClient(handler) { Timeout = RequestTimeout };
+    }
+
+    public void Dispose() => _http.Dispose();
+
+    /// <summary>Reads the current encode settings (per-stream resolution/framerate/bitrate).</summary>
+    public async Task<JsonObject> GetEncAsync(CancellationToken ct)
+    {
+        var value = await ExecAsync("GetEnc", new JsonObject { ["channel"] = _channelId }, ct).ConfigureAwait(false);
+        return value?["Enc"] as JsonObject
+            ?? throw new ReolinkApiException("GetEnc reply carries no Enc settings");
+    }
+
+    /// <summary>Writes encode settings; pass a (modified) object from <see cref="GetEncAsync"/>.</summary>
+    public Task SetEncAsync(JsonObject enc, CancellationToken ct) =>
+        ExecAsync("SetEnc", new JsonObject { ["Enc"] = enc.DeepClone() }, ct);
+
+    // ------------------------------------------------------------------ plumbing
+
+    private async Task<JsonNode?> ExecAsync(string cmd, JsonObject param, CancellationToken ct)
+    {
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            for (int attempt = 0; ; attempt++)
+            {
+                if (_token == null || DateTime.UtcNow >= _tokenExpiry)
+                    await LoginAsync(ct).ConfigureAwait(false);
+
+                var reply = await PostAsync($"{_apiUrl}?cmd={cmd}&token={Uri.EscapeDataString(_token!)}",
+                    cmd, param.DeepClone(), ct).ConfigureAwait(false);
+                if (reply.Code == 0)
+                    return reply.Value;
+
+                // -6: token invalid/expired despite the lease (camera rebooted, session
+                // table flushed) — log in again and retry the command once.
+                if (reply.RspCode == -6 && attempt == 0)
+                {
+                    _token = null;
+                    continue;
+                }
+                throw new ReolinkApiException(
+                    $"camera HTTP API rejected {cmd}: {reply.Detail ?? "unknown error"} (rspCode {reply.RspCode})");
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private async Task LoginAsync(CancellationToken ct)
+    {
+        var param = new JsonObject
+        {
+            ["User"] = new JsonObject
+            {
+                ["Version"] = "0",
+                ["userName"] = _username,
+                ["password"] = _password,
+            },
+        };
+        var reply = await PostAsync($"{_apiUrl}?cmd=Login", "Login", param, ct).ConfigureAwait(false);
+        if (reply.Code != 0)
+            throw new ReolinkApiException(
+                $"camera HTTP API login failed: {reply.Detail ?? "unknown error"} (rspCode {reply.RspCode})");
+
+        var token = reply.Value?["Token"];
+        _token = (string?)token?["name"]
+            ?? throw new ReolinkApiException("camera HTTP API login reply carries no token");
+        int lease = (int?)token?["leaseTime"] ?? 3600;
+        var lifetime = TimeSpan.FromSeconds(lease) - LeaseMargin;
+        if (lifetime <= TimeSpan.Zero) lifetime = TimeSpan.FromSeconds(lease / 2.0);
+        _tokenExpiry = DateTime.UtcNow + lifetime;
+    }
+
+    private sealed record Reply(int Code, int RspCode, string? Detail, JsonNode? Value);
+
+    private async Task<Reply> PostAsync(string url, string cmd, JsonNode param, CancellationToken ct)
+    {
+        var body = new JsonArray(new JsonObject
+        {
+            ["cmd"] = cmd,
+            ["action"] = 0,
+            ["param"] = param,
+        });
+        using var content = new StringContent(body.ToJsonString(), Encoding.UTF8, "application/json");
+
+        HttpResponseMessage res;
+        try
+        {
+            res = await _http.PostAsync(url, content, ct).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new IOException($"camera HTTP API unreachable: {ex.Message}", ex);
+        }
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            throw new TimeoutException("camera HTTP API did not reply");
+        }
+
+        using (res)
+        {
+            if (!res.IsSuccessStatusCode)
+                throw new ReolinkApiException($"camera HTTP API returned HTTP {(int)res.StatusCode} for {cmd}");
+            var text = await res.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+
+            JsonNode? root;
+            try
+            {
+                root = JsonNode.Parse(text);
+            }
+            catch (JsonException)
+            {
+                throw new ReolinkApiException($"camera HTTP API sent malformed JSON for {cmd}");
+            }
+
+            // Replies come as a one-element array; tolerate a bare object too.
+            var first = root is JsonArray arr ? arr.FirstOrDefault() : root;
+            if (first is not JsonObject obj)
+                throw new ReolinkApiException($"camera HTTP API sent an unexpected reply for {cmd}");
+
+            var error = obj["error"];
+            return new Reply(
+                Code: (int?)obj["code"] ?? -1,
+                RspCode: (int?)error?["rspCode"] ?? 0,
+                Detail: (string?)error?["detail"],
+                Value: obj["value"]);
+        }
+    }
+}

--- a/src/Neolink.Server/Streaming/CameraControl.cs
+++ b/src/Neolink.Server/Streaming/CameraControl.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Nodes;
 using System.Xml.Linq;
 using Neolink.Bc.Xml;
 using Neolink.Protocol;
@@ -29,6 +30,17 @@ public interface ICameraControl
     Task<CameraCapabilities> GetCapabilitiesAsync(CancellationToken ct);
 
     Task<StreamInfoListXml?> GetStreamInfoAsync(CancellationToken ct);
+
+    /// <summary>Whether stream encode settings can be written (the camera's HTTP API is configured).</summary>
+    bool CanSetStreamSettings { get; }
+
+    /// <summary>
+    /// Changes one stream's encode settings via the camera's Reolink HTTP API.
+    /// The camera restarts the affected stream to apply them.
+    /// </summary>
+    Task SetStreamSettingsAsync(string stream, uint? width, uint? height,
+        uint? framerate, uint? bitrate, CancellationToken ct);
+
     Task<XElement?> GetBatteryInfoAsync(CancellationToken ct);
     Task<XElement?> GetLedStateAsync(CancellationToken ct);
     Task SetLedStateAsync(string? state, string? lightState, CancellationToken ct);
@@ -50,6 +62,7 @@ public sealed class CameraControl : ICameraControl
     private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(4);
 
     private readonly ILiveCameraSource _source;
+    private readonly ReolinkHttpApi? _httpApi;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
     // Capabilities are cached for the lifetime of one camera session; a reconnect
@@ -57,7 +70,11 @@ public sealed class CameraControl : ICameraControl
     private IBcCamera? _capsSession;
     private CameraCapabilities? _caps;
 
-    public CameraControl(ILiveCameraSource source) => _source = source;
+    public CameraControl(ILiveCameraSource source, ReolinkHttpApi? httpApi = null)
+    {
+        _source = source;
+        _httpApi = httpApi;
+    }
 
     public string CameraName => _source.Name;
     public bool Online => _source.LiveCamera != null;
@@ -103,6 +120,36 @@ public sealed class CameraControl : ICameraControl
 
     public Task<StreamInfoListXml?> GetStreamInfoAsync(CancellationToken ct) =>
         WithCameraAsync(camera => camera.GetStreamInfoAsync(ct: ct), ct);
+
+    public bool CanSetStreamSettings => _httpApi != null;
+
+    // Rides the camera's HTTP API, not the BC connection (no verified BC setter
+    // exists), so it works even while the BC session is mid-reconnect and does
+    // not take the command gate. Read-modify-write, like the LED/PIR setters.
+    public async Task SetStreamSettingsAsync(string stream, uint? width, uint? height,
+        uint? framerate, uint? bitrate, CancellationToken ct)
+    {
+        if (_httpApi == null)
+            throw new NotSupportedException(
+                $"changing stream settings requires the camera's HTTP API; set \"http_address\" for '{CameraName}' in the config");
+
+        // Baichuan and the HTTP API name the third stream differently.
+        string key = stream == "externStream" ? "extStream" : stream;
+        var enc = await _httpApi.GetEncAsync(ct).ConfigureAwait(false);
+        if (enc[key] is not JsonObject encStream)
+            throw new NotSupportedException($"{CameraName} does not expose '{stream}' encode settings over its HTTP API");
+
+        if (width != null && height != null) encStream["size"] = $"{width}*{height}";
+        if (framerate != null) encStream["frameRate"] = framerate.Value;
+        if (bitrate != null) encStream["bitRate"] = bitrate.Value;
+        await _httpApi.SetEncAsync(enc, ct).ConfigureAwait(false);
+
+        Log.Info($"{CameraName}: {stream} encode settings changed" +
+                 $"{(width != null ? $" to {width}x{height}" : "")}" +
+                 $"{(framerate != null ? $" @{framerate}fps" : "")}" +
+                 $"{(bitrate != null ? $" {bitrate}kbps" : "")}" +
+                 " — the camera restarts the stream to apply");
+    }
 
     public Task<XElement?> GetBatteryInfoAsync(CancellationToken ct) =>
         WithCameraAsync(camera => camera.GetBatteryInfoAsync(ct: ct), ct);

--- a/src/Neolink.Server/Web/WebApi.cs
+++ b/src/Neolink.Server/Web/WebApi.cs
@@ -24,6 +24,7 @@ public sealed record WebCameraInfo(string Name, List<WebStreamInfo> Streams, ICa
 ///   WS  /api/stream?path=...                — live fMP4 video (MSE-compatible)
 ///   GET /api/cameras/{name}/capabilities    — discovered device info + feature flags
 ///   GET /api/cameras/{name}/streaminfo      — encode profiles (resolution/fps/bitrate tables)
+///   POST/PUT .../settings/stream            — change an encode profile (needs http_address)
 ///   GET/POST .../led /pir; POST .../ptz /reboot; GET .../battery — camera control
 ///   /                                       — web UI (when enabled in the config)
 /// Mutating endpoints require HTTP Basic auth when users are configured (same
@@ -34,6 +35,8 @@ public static class WebApi
     private sealed record LedRequest(string? State, string? LightState);
     private sealed record PirRequest(bool? Enabled);
     private sealed record PtzRequest(string? Command, float? Speed);
+    private sealed record StreamSettingsRequest(string? Stream, uint? Width, uint? Height,
+        uint? Framerate, uint? Bitrate);
 
     public static async Task RunAsync(string bindAddr, int port, bool webUi,
         IReadOnlyList<WebCameraInfo> cameras, IReadOnlyDictionary<string, string> users,
@@ -137,6 +140,10 @@ public static class WebApi
             {
                 return Results.Json(new { error = ex.Message }, statusCode: 502);
             }
+            catch (ReolinkApiException ex)
+            {
+                return Results.Json(new { error = ex.Message }, statusCode: 502);
+            }
             catch (TimeoutException)
             {
                 return Results.Json(new { error = "camera did not reply" }, statusCode: 504);
@@ -171,6 +178,7 @@ public static class WebApi
                         led = caps.Features.Led,
                         pir = caps.Features.Pir,
                         battery = caps.Features.Battery,
+                        streamSettings = control.CanSetStreamSettings,
                     },
                     support = caps.Support == null ? null : XmlToJson(caps.Support),
                 });
@@ -194,6 +202,26 @@ public static class WebApi
                     .ToList();
                 return Results.Json(new { profiles = (object?)profiles ?? Array.Empty<object>() });
             }));
+
+        // Stream encode settings ride the camera's Reolink HTTP API (http_address in
+        // the config); the Baichuan protocol has no verified setter. The camera
+        // restarts the affected stream to apply — CameraService reconnects on its own.
+        Task<IResult> SetStreamSettings(string name, StreamSettingsRequest req, HttpContext ctx) =>
+            ExecAsync(name, ctx, mutating: true, async (control, reqCt) =>
+            {
+                string[] streams = { "mainStream", "subStream", "externStream" };
+                if (req.Stream == null || !streams.Contains(req.Stream))
+                    return Results.Json(new { error = "provide stream: mainStream|subStream|externStream" }, statusCode: 400);
+                if ((req.Width == null) != (req.Height == null))
+                    return Results.Json(new { error = "width and height must be given together" }, statusCode: 400);
+                if (req.Width == null && req.Framerate == null && req.Bitrate == null)
+                    return Results.Json(new { error = "provide width+height, framerate and/or bitrate" }, statusCode: 400);
+                await control.SetStreamSettingsAsync(req.Stream, req.Width, req.Height,
+                    req.Framerate, req.Bitrate, reqCt);
+                return Results.Json(new { ok = true, note = "the camera restarts its stream to apply the change" });
+            });
+        app.MapPost("/api/cameras/{name}/settings/stream", SetStreamSettings);
+        app.MapPut("/api/cameras/{name}/settings/stream", SetStreamSettings);
 
         app.MapGet("/api/cameras/{name}/battery", (string name, HttpContext ctx) =>
             ExecAsync(name, ctx, mutating: false, async (control, reqCt) =>

--- a/src/Neolink.Server/config.example.json
+++ b/src/Neolink.Server/config.example.json
@@ -33,6 +33,11 @@
       // IP or hostname of the camera. Port defaults to 9000 if omitted.
       "address": "192.168.1.187:9000",
 
+      // Optional: the camera's HTTP(S) web interface ("host", "host:port" or full URL).
+      // Enables changing stream profiles (resolution/fps/bitrate) from the web UI;
+      // most non-battery Reolink cameras serve it on port 80/443.
+      // "http_address": "192.168.1.187",
+
       // Which streams to serve: "mainStream", "subStream", "externStream", "both", or "all".
       // "both" serves /driveway (+ /driveway/mainStream) and /driveway/subStream.
       "stream": "both",

--- a/src/Neolink.WebClient/Components/CameraPanel.razor
+++ b/src/Neolink.WebClient/Components/CameraPanel.razor
@@ -44,6 +44,7 @@
 
         @if (_profiles is { Count: > 0 })
         {
+            var canSetStream = _caps.Features?.StreamSettings == true;
             <div class="campanel-section">
                 <div class="campanel-section-title">STREAMS</div>
                 @foreach (var group in _profiles.GroupBy(p => p.Type))
@@ -58,16 +59,30 @@
                         <div class="stream-options">
                             @foreach (var p in options)
                             {
-                                <span class="chip stream-chip @(IsActiveProfile(p) ? "chip-active" : "")"
-                                      title="Framerates: @string.Join(", ", p.Framerates) fps — Bitrates: @string.Join(", ", p.Bitrates) kbps">
-                                    @(p.Width)×@(p.Height) · @p.DefaultFramerate fps · @p.DefaultBitrate kbps
-                                </span>
+                                @if (canSetStream)
+                                {
+                                    <button class="chip stream-chip clickable @(IsActiveProfile(p) ? "chip-active" : "")"
+                                            disabled="@_settingProfile"
+                                            title="Framerates: @string.Join(", ", p.Framerates) fps — Bitrates: @string.Join(", ", p.Bitrates) kbps"
+                                            @onclick="() => SetProfileAsync(p)">
+                                        @(p.Width)×@(p.Height) · @p.DefaultFramerate fps · @p.DefaultBitrate kbps
+                                    </button>
+                                }
+                                else
+                                {
+                                    <span class="chip stream-chip @(IsActiveProfile(p) ? "chip-active" : "")"
+                                          title="Framerates: @string.Join(", ", p.Framerates) fps — Bitrates: @string.Join(", ", p.Bitrates) kbps">
+                                        @(p.Width)×@(p.Height) · @p.DefaultFramerate fps · @p.DefaultBitrate kbps
+                                    </span>
+                                }
                             }
                         </div>
                     </div>
                 }
                 <div class="notice small">
-                    Read from the camera; the highlighted profile is live. Changing profiles from here isn't supported yet.
+                    @(canSetStream
+                        ? "Read from the camera; the highlighted profile is live. Click a profile to apply it — the camera restarts the stream briefly."
+                        : "Read from the camera; the highlighted profile is live. To change profiles from here, set the camera's \"http_address\" in the server config.")
                 </div>
             </div>
         }
@@ -195,6 +210,7 @@
     private string? _error;
     private string? _status;
     private bool _confirmReboot;
+    private bool _settingProfile;
     private int _ptzSpeed = 32;
     private string? _loadedFor;
 
@@ -239,6 +255,31 @@
 
     private bool IsActiveProfile(ApiEncodeProfile p) =>
         Camera?.Streams.Any(s => s.Kind == p.Type && s.Width == p.Width && s.Height == p.Height) == true;
+
+    private async Task SetProfileAsync(ApiEncodeProfile p)
+    {
+        if (_settingProfile) return;
+        _settingProfile = true;
+        try
+        {
+            if (await PostAsync("settings/stream", new
+                {
+                    stream = p.Type,
+                    width = p.Width,
+                    height = p.Height,
+                    framerate = p.DefaultFramerate,
+                    bitrate = p.DefaultBitrate,
+                }))
+            {
+                _status = $"{p.Label} stream set to {p.Width}×{p.Height} — " +
+                          "the camera restarts the stream; video resumes in a few seconds.";
+            }
+        }
+        finally
+        {
+            _settingProfile = false;
+        }
+    }
 
     private async Task SetLedAsync(string field, string? value)
     {

--- a/src/Neolink.WebClient/Models.cs
+++ b/src/Neolink.WebClient/Models.cs
@@ -21,7 +21,8 @@ public sealed record ApiCamera(string Name, bool Online, List<ApiStream> Streams
 public sealed record ApiVersion(string? Name, string? Model, string? Serial, string? Firmware,
     string? Hardware, string? Build);
 
-public sealed record ApiFeatures(bool Ptz, bool Led, bool Pir, bool Battery);
+public sealed record ApiFeatures(bool Ptz, bool Led, bool Pir, bool Battery,
+    bool StreamSettings = false);
 
 /// <summary>GET /api/cameras/{name}/capabilities — discovered device info and features.</summary>
 public sealed record ApiCapabilities(bool Online, ApiVersion? Version, ApiFeatures? Features, JsonElement Support);

--- a/src/Neolink.WebClient/wwwroot/css/app.css
+++ b/src/Neolink.WebClient/wwwroot/css/app.css
@@ -560,6 +560,11 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
 .stream-chip { cursor: default; }
 .stream-chip:hover { border-color: var(--line); color: var(--text); }
 
+/* Profiles become clickable when the camera's HTTP API is configured */
+.stream-chip.clickable { cursor: pointer; }
+.stream-chip.clickable:hover { border-color: var(--accent); color: var(--accent); }
+.stream-chip.clickable:disabled { opacity: 0.5; cursor: wait; }
+
 .chip-active {
     border-color: var(--accent);
     color: var(--accent);


### PR DESCRIPTION
## What

Makes the encode profiles (resolution / framerate / bitrate) shown in the web UI camera panel **changeable**, using the documented Reolink HTTP API (`POST /api.cgi`, `cmd=Login/GetEnc/SetEnc`) as the write path.

- **Config**: new optional per-camera `http_address` (`host`, `host:port`, or full `http(s)://` URL) pointing at the camera's own web interface. Documented in `config.example.json` and the README.
- **`ReolinkHttpApi`** (new, `src/Neolink.Server/Protocol/ReolinkHttpApi.cs`): zero-dependency client (HttpClient + System.Text.Json.Nodes). Token login with lease caching; a stale token (`rspCode -6`, e.g. after a camera reboot) triggers one transparent re-login + retry. Requests serialized through one gate; HTTPS accepts the cameras' self-signed certs.
- **`ICameraControl.SetStreamSettingsAsync`**: read-modify-write of the `Enc` object — only `size`/`frameRate`/`bitRate` of the targeted stream change, everything else is passed back verbatim. Runs independently of the Baichuan connection (works mid-reconnect). Baichuan's `externStream` maps to the HTTP API's `extStream`.
- **Web API**: `POST`/`PUT /api/cameras/{name}/settings/stream` behind the existing Basic-auth check, with request validation; `/capabilities` now reports `features.streamSettings`.
- **Web UI**: the stream profile chips in the camera panel become clickable buttons when the HTTP API is configured (disabled while a change is in flight); otherwise the footnote points at `http_address`.

## Why

The Baichuan set-encode message format is unverified — the reference Rust neolink implements no encode setter either — so profiles were read-only. Most Baichuan cameras (e.g. E1 Pro) also expose the documented Reolink HTTP API, which has a well-known `SetEnc` command.

## Reviewer notes

- **Tested end-to-end against a mock camera** (HttpListener implementing Login/GetEnc/SetEnc). Wire log verified: single cached token reused across calls; `SetEnc` payloads change only the requested fields; validation errors, the PUT verb, unsupported-stream 404, and the stale-token re-login all behave correctly. `dotnet build` clean, all 14 self-tests pass.
- **Recovery after `SetEnc`** (the camera restarts the affected stream): relies on the existing `CameraService` loop — end-of-stream or the 15 s receive timeout triggers a reconnect with backoff starting at 1 s. Verified by code inspection, not real hardware; worth a one-time check on a real camera.
- The HTTPS branch disables certificate validation because cameras serve self-signed certs; default remains plain HTTP like the Reolink apps use on the LAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)