### PR TITLE
Event recording: motion/AI detections with clips, review UI and retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,30 @@ the original Rust neolink are also accepted.
 | `webui` | `true` | Serve the browser UI on `web_port`; `false` = API only |
 | `web_bind` | = `bind` | Separate bind address for the web port |
 | `users` | *(none)* | RTSP Basic-auth users: `{ "name", "pass" }`. Omit for open access |
+| `recording` | *(none)* | Event recording (see below). Omit to disable |
+
+### Event recording (`"recording": { ... }`)
+
+Captures the camera's own motion/AI detections (person, vehicle, animal — pushed
+over the Baichuan connection, no polling and no server-side ML) as labeled events
+with video clips and thumbnails. New events appear in a review strip at the top of
+the web UI; click to play, ✕ to dismiss. The 🕘 Events button opens the full
+history grouped by day.
+
+| Option | Default | Description |
+|---|---|---|
+| `path` | *required* | Storage directory. In Docker, mount a volume here (e.g. `./recordings:/recordings`) |
+| `retention_days` | `7` | Events older than this are deleted (`0` = keep forever) |
+| `pre_seconds` | `5` | Video included from before the detection (pre-roll) |
+| `post_seconds` | `8` | Quiet time after the last detection before the event closes |
+| `max_clip_seconds` | `120` | Hard cap per event; continued activity starts a new event |
+| `stream` | `auto` | Stream to record: `auto` (main if served), `mainStream`, `subStream` |
+
+Clips are fragmented MP4 (H.264/H.265 passthrough, video-only) playable in the
+browser and by ffmpeg/VLC. Storage layout is plain files —
+`recordings/<camera>/<date>/<time>-<id>/{event.json, clip.mp4, thumb.jpg}` — so
+backups and external tooling are trivial. Set `"record": false` on a camera to
+exclude it.
 
 ### Per camera
 
@@ -246,6 +270,7 @@ the original Rust neolink are also accepted.
 | `stream` | `both` | `mainStream`, `subStream`, `externStream`, `both`, or `all` |
 | `channel_id` | `0` | Channel when connecting through a Reolink NVR (0-based) |
 | `permitted_users` | all users | Restrict this camera's mounts to specific `users` |
+| `record` | `true` | Include this camera in event recording (when `recording` is configured) |
 
 ## Using with Frigate
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,8 @@ services:
       - "8655:8655"   # web UI + API; remove if webui:false and API unused
     volumes:
       - ./config.json:/config/config.json:ro
+      # Event recording storage: uncomment and set "recording": { "path": "/recordings" }
+      # in config.json to capture detection events (clips + thumbnails) here.
+      # - ./recordings:/recordings
     # For RTSP over UDP transport, prefer host networking instead of port maps:
     # network_mode: host

--- a/src/Neolink.Server/Config/MiniToml.cs
+++ b/src/Neolink.Server/Config/MiniToml.cs
@@ -192,6 +192,10 @@ public static class MiniToml
             ? b
             : bool.TryParse(GetString(table, key), out var parsed) ? parsed : null;
 
+    /// <summary>A single [table] section, or null if absent.</summary>
+    public static Dictionary<string, object>? GetTable(Dictionary<string, object> table, string key) =>
+        table.TryGetValue(key, out var v) && v is Dictionary<string, object> d ? d : null;
+
     public static List<Dictionary<string, object>> GetTables(Dictionary<string, object> table, string key) =>
         table.TryGetValue(key, out var v) && v is List<Dictionary<string, object>> list
             ? list

--- a/src/Neolink.Server/Config/NeolinkConfig.cs
+++ b/src/Neolink.Server/Config/NeolinkConfig.cs
@@ -13,6 +13,8 @@ public sealed class NeolinkConfig
     public string? WebBind { get; set; }
     /// <summary>Serve the browser UI on the web port (in addition to the API).</summary>
     public bool WebUi { get; set; } = true;
+    /// <summary>Event recording (motion/AI detections + clips); null = disabled.</summary>
+    public RecordingConfig? Recording { get; set; }
     public List<UserConfig> Users { get; } = new();
     public List<CameraConfig> Cameras { get; } = new();
 
@@ -72,6 +74,9 @@ public sealed class NeolinkConfig
                 case "certificate":
                     WarnTls();
                     break;
+                case "recording":
+                    config.Recording = ParseJsonRecording(prop.Value);
+                    break;
                 case "users":
                     foreach (var u in prop.Value.EnumerateArray())
                         config.Users.Add(ParseJsonUser(u));
@@ -111,6 +116,7 @@ public sealed class NeolinkConfig
         string? name = null, username = null, password = null, address = null, uid = null, httpAddress = null;
         string stream = "both";
         byte channelId = 0;
+        bool record = true;
         List<string>? permitted = null;
 
         foreach (var prop in el.EnumerateObject())
@@ -125,6 +131,7 @@ public sealed class NeolinkConfig
                 case "uid": uid = prop.Value.GetString(); break;
                 case "stream": stream = prop.Value.GetString() ?? "both"; break;
                 case "channelid": channelId = prop.Value.GetByte(); break;
+                case "record": record = prop.Value.GetBoolean(); break;
                 case "permittedusers":
                     permitted = prop.Value.EnumerateArray().Select(x => x.GetString() ?? "").ToList();
                     break;
@@ -137,7 +144,30 @@ public sealed class NeolinkConfig
             }
         }
 
-        return BuildCamera(name, username, password, address, uid, stream, channelId, permitted, httpAddress);
+        return BuildCamera(name, username, password, address, uid, stream, channelId, permitted, httpAddress, record);
+    }
+
+    private static RecordingConfig ParseJsonRecording(JsonElement el)
+    {
+        string? path = null;
+        var rec = new RecordingConfig();
+        foreach (var prop in el.EnumerateObject())
+        {
+            switch (Key(prop.Name))
+            {
+                case "path": path = prop.Value.GetString(); break;
+                case "retentiondays": rec.RetentionDays = prop.Value.GetInt32(); break;
+                case "preseconds": rec.PreSeconds = prop.Value.GetInt32(); break;
+                case "postseconds": rec.PostSeconds = prop.Value.GetInt32(); break;
+                case "maxclipseconds": rec.MaxClipSeconds = prop.Value.GetInt32(); break;
+                case "stream": rec.Stream = prop.Value.GetString() ?? "auto"; break;
+                default:
+                    Log.Warn($"Config: ignoring unknown recording option '{prop.Name}'");
+                    break;
+            }
+        }
+        rec.Path = path ?? throw new FormatException("\"recording\" needs a \"path\" (the storage directory)");
+        return rec;
     }
 
     /// <summary>Normalizes JSON keys: case-insensitive, tolerates snake_case and kebab-case.</summary>
@@ -161,6 +191,20 @@ public sealed class NeolinkConfig
         if (MiniToml.GetString(root, "certificate") != null)
             WarnTls();
 
+        if (MiniToml.GetTable(root, "recording") is { } rec)
+        {
+            config.Recording = new RecordingConfig
+            {
+                Path = MiniToml.GetString(rec, "path")
+                    ?? throw new FormatException("[recording] needs a 'path' (the storage directory)"),
+                RetentionDays = (int)(MiniToml.GetInt(rec, "retention_days") ?? 7),
+                PreSeconds = (int)(MiniToml.GetInt(rec, "pre_seconds") ?? 5),
+                PostSeconds = (int)(MiniToml.GetInt(rec, "post_seconds") ?? 8),
+                MaxClipSeconds = (int)(MiniToml.GetInt(rec, "max_clip_seconds") ?? 120),
+                Stream = MiniToml.GetString(rec, "stream") ?? "auto",
+            };
+        }
+
         foreach (var u in MiniToml.GetTables(root, "users"))
         {
             var name = MiniToml.GetString(u, "name") ?? MiniToml.GetString(u, "username")
@@ -183,7 +227,8 @@ public sealed class NeolinkConfig
                 MiniToml.GetString(c, "stream") ?? "both",
                 (byte)(MiniToml.GetInt(c, "channel_id") ?? 0),
                 MiniToml.GetStringList(c, "permitted_users"),
-                MiniToml.GetString(c, "http_address")));
+                MiniToml.GetString(c, "http_address"),
+                MiniToml.GetBool(c, "record") ?? true));
         }
         return config;
     }
@@ -196,7 +241,7 @@ public sealed class NeolinkConfig
 
     private static CameraConfig BuildCamera(string? name, string? username, string? password,
         string? address, string? uid, string stream, byte channelId, List<string>? permitted,
-        string? httpAddress = null)
+        string? httpAddress = null, bool record = true)
     {
         if (name == null) throw new FormatException("camera entry missing \"name\"");
         if (username == null) throw new FormatException($"Camera \"{name}\" missing \"username\"");
@@ -219,6 +264,7 @@ public sealed class NeolinkConfig
             ChannelId = channelId,
             PermittedUsers = permitted,
             HttpAddress = string.IsNullOrWhiteSpace(httpAddress) ? null : httpAddress.Trim(),
+            Record = record,
         };
     }
 
@@ -257,6 +303,20 @@ public sealed class NeolinkConfig
             .Distinct().ToList();
         if (missing.Count > 0)
             throw new FormatException($"permitted_users reference undefined users: {string.Join(", ", missing)}");
+
+        if (Recording != null)
+        {
+            if (Recording.RetentionDays < 0)
+                throw new FormatException("recording.retention_days must be >= 0 (0 = keep forever)");
+            if (Recording.PreSeconds is < 0 or > 30)
+                throw new FormatException("recording.pre_seconds must be 0..30");
+            if (Recording.PostSeconds is < 1 or > 120)
+                throw new FormatException("recording.post_seconds must be 1..120");
+            if (Recording.MaxClipSeconds is < 10 or > 3600)
+                throw new FormatException("recording.max_clip_seconds must be 10..3600");
+            if (Recording.Stream is not ("auto" or "mainStream" or "subStream" or "externStream"))
+                throw new FormatException("recording.stream must be auto, mainStream, subStream or externStream");
+        }
     }
 
     private static (string host, int port) SplitHostPort(string address)
@@ -289,6 +349,23 @@ public sealed class UserConfig
     public required string Pass { get; init; }
 }
 
+/// <summary>Event recording settings ("recording" in the config).</summary>
+public sealed class RecordingConfig
+{
+    /// <summary>Storage directory for clips/thumbnails/event metadata (mount a volume here in Docker).</summary>
+    public string Path { get; set; } = "";
+    /// <summary>Days to keep events; 0 keeps them forever.</summary>
+    public int RetentionDays { get; set; } = 7;
+    /// <summary>Seconds of video kept from before the detection.</summary>
+    public int PreSeconds { get; set; } = 5;
+    /// <summary>Seconds of quiet after the last detection before an event closes.</summary>
+    public int PostSeconds { get; set; } = 8;
+    /// <summary>Hard cap on one event/clip; ongoing activity beyond it starts a new event.</summary>
+    public int MaxClipSeconds { get; set; } = 120;
+    /// <summary>Stream to record: "auto" (main if served, else first), or an explicit stream name.</summary>
+    public string Stream { get; set; } = "auto";
+}
+
 public sealed class CameraConfig
 {
     public required string Name { get; init; }
@@ -304,4 +381,6 @@ public sealed class CameraConfig
     /// the settings Baichuan has no verified write path for (stream encode profiles).
     /// </summary>
     public string? HttpAddress { get; init; }
+    /// <summary>Record detection events for this camera (when recording is configured).</summary>
+    public bool Record { get; init; } = true;
 }

--- a/src/Neolink.Server/Program.cs
+++ b/src/Neolink.Server/Program.cs
@@ -1,6 +1,7 @@
 using Neolink;
 using Neolink.Config;
 using Neolink.Protocol;
+using Neolink.Recording;
 using Neolink.Rtsp;
 using Neolink.Streaming;
 using Neolink.Web;
@@ -92,6 +93,25 @@ var server = new RtspServer(users);
 var tasks = new List<Task>();
 var webCameras = new List<WebCameraInfo>();
 
+// Event recording (motion/AI detections + clips), when a storage path is configured.
+EventStore? eventStore = null;
+if (config.Recording is { } recCfg)
+{
+    try
+    {
+        eventStore = new EventStore(recCfg.Path);
+        eventStore.Load();
+        Log.Info($"Recording events to {eventStore.Root} " +
+                 $"(retention: {(recCfg.RetentionDays > 0 ? $"{recCfg.RetentionDays} days" : "forever")})");
+        tasks.Add(Task.Run(() => eventStore.RunRetentionAsync(recCfg.RetentionDays, shutdown.Token)));
+    }
+    catch (Exception ex)
+    {
+        Log.Error($"Recording disabled: cannot use storage path '{recCfg.Path}': {ex.Message}");
+        eventStore = null;
+    }
+}
+
 foreach (var cam in config.Cameras)
 {
     var permitted = config.PermittedUsersFor(cam);
@@ -129,6 +149,26 @@ foreach (var cam in config.Cameras)
     ICameraControl control = new CameraControl(primaryService
         ?? throw new InvalidOperationException($"camera '{cam.Name}' has no streams"), httpApi);
     webCameras.Add(new WebCameraInfo(cam.Name, webStreams, control, permitted));
+
+    // Event recording: alarm pushes ride the primary connection; clips are cut from
+    // the configured stream's hub (auto = main when served, else the first stream).
+    if (eventStore != null && cam.Record)
+    {
+        var recordStream = config.Recording!.Stream == "auto"
+            ? webStreams.FirstOrDefault(s => s.Kind == "mainStream") ?? webStreams[0]
+            : webStreams.FirstOrDefault(s => s.Kind == config.Recording.Stream);
+        if (recordStream == null)
+        {
+            Log.Warn($"{cam.Name}: recording.stream '{config.Recording.Stream}' is not served " +
+                     $"by this camera (stream = \"{cam.Stream}\"); events disabled for it");
+        }
+        else
+        {
+            var recorder = new EventRecorder(cam.Name, recordStream.Hub, control, eventStore, config.Recording);
+            primaryService.MotionSink = recorder.OnMotion;
+            tasks.Add(Task.Run(() => recorder.RunAsync(shutdown.Token)));
+        }
+    }
 }
 
 // Web API (camera list + fMP4 live streams for browsers); guarded like the cameras.
@@ -139,7 +179,7 @@ if (config.WebPort > 0)
         try
         {
             await WebApi.RunAsync(config.WebBind ?? config.BindAddr, config.WebPort, config.WebUi,
-                webCameras, users, config.BindPort, shutdown.Token);
+                webCameras, users, config.BindPort, eventStore, shutdown.Token);
         }
         catch (OperationCanceledException) { }
         catch (Exception ex)

--- a/src/Neolink.Server/Protocol/BcCamera.cs
+++ b/src/Neolink.Server/Protocol/BcCamera.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Channels;
+using System.Xml.Linq;
 using Neolink.Bc;
 using Neolink.Bc.Xml;
 
@@ -232,6 +233,102 @@ public sealed class BcCamera : IBcCamera
         {
             // Some cameras never acknowledge accepted set commands.
             return null;
+        }
+    }
+
+    public async Task WatchMotionAsync(Action<MotionPush> onEvent, CancellationToken ct)
+    {
+        // Subscribe BEFORE opting in so no push can slip past between the two.
+        using var sub = _conn.Subscribe(BcConstants.MsgIdMotion);
+
+        // Opt in to alarm pushes. Some cameras ack the request, some stay silent
+        // and just start pushing — tolerate both.
+        await SendCommandAsync(BcConstants.MsgIdMotionRequest,
+            extension: new ExtensionXml { ChannelId = _channelId },
+            replyTimeout: TimeSpan.FromSeconds(5), tolerateNoReply: true, ct: ct).ConfigureAwait(false);
+
+        while (!ct.IsCancellationRequested)
+        {
+            BcMessage msg;
+            try
+            {
+                // Pushes are sporadic by nature: no read timeout. A dead connection
+                // is noticed by the video stream, which tears everything down.
+                msg = await sub.Messages.ReadAsync(ct).ConfigureAwait(false);
+            }
+            catch (System.Threading.Channels.ChannelClosedException)
+            {
+                return; // connection closed
+            }
+
+            var list = msg.Xml?.RawElement("AlarmEventList");
+            if (list == null) continue;
+            foreach (var ev in list.Elements("AlarmEvent"))
+            {
+                if (uint.TryParse(ev.Element("channelId")?.Value.Trim(), out var ch) && ch != _channelId)
+                    continue;
+                var status = ev.Element("status")?.Value.Trim() ?? "";
+                // AItype variants seen in the wild: repeated elements, comma lists,
+                // "none" placeholders, and differing capitalization.
+                var aiTypes = ev.Elements()
+                    .Where(e => e.Name.LocalName.Equals("AItype", StringComparison.OrdinalIgnoreCase))
+                    .SelectMany(e => e.Value.Split(new[] { ',', ';', ' ' }, StringSplitOptions.RemoveEmptyEntries))
+                    .Select(t => t.Trim().ToLowerInvariant())
+                    .Where(t => t is not ("" or "none"))
+                    .Distinct()
+                    .ToList();
+                onEvent(new MotionPush(status, aiTypes));
+            }
+        }
+    }
+
+    public async Task<byte[]?> SnapAsync(CancellationToken ct)
+    {
+        using var sub = _conn.Subscribe(BcConstants.MsgIdSnap);
+
+        var body = BcXmlBody.FromRaw(new XElement("Snap",
+            new XAttribute("version", BcXmlBody.XmlVersion),
+            new XElement("channelId", _channelId),
+            new XElement("logicChannel", _channelId),
+            new XElement("time", 0),
+            new XElement("fullFrame", 0),
+            new XElement("streamType", "subStream")));
+        var req = new BcMessage
+        {
+            Meta = new BcMeta
+            {
+                MsgId = BcConstants.MsgIdSnap,
+                ChannelId = _channelId,
+                MsgNum = NewMessageNum(),
+                StreamType = 0,
+                ResponseCode = 0,
+                Class = BcConstants.ClassModern,
+            },
+            Extension = new ExtensionXml { ChannelId = _channelId },
+            Xml = body,
+        };
+        await _conn.SendAsync(req, ct).ConfigureAwait(false);
+
+        // The JPEG may span several messages: the first reply carries a <Snap>
+        // with pictureSize, the image bytes arrive as binary payloads until
+        // that many bytes have been received.
+        int expected = -1;
+        using var jpeg = new MemoryStream();
+        var perMessageTimeout = TimeSpan.FromSeconds(8);
+        while (true)
+        {
+            var reply = await sub.ReceiveAsync(perMessageTimeout, ct).ConfigureAwait(false);
+            if (reply.Meta.ResponseCode != 200)
+                throw new CameraCommandException(BcConstants.MsgIdSnap, reply.Meta.ResponseCode);
+            if (reply.Xml?.RawElement("Snap") is { } snap
+                && int.TryParse(snap.Element("pictureSize")?.Value.Trim(), out var size) && size > 0)
+                expected = size;
+            if (reply.Binary is { Length: > 0 } bin)
+                jpeg.Write(bin, 0, bin.Length);
+            if (expected >= 0 && jpeg.Length >= expected)
+                return jpeg.ToArray();
+            if (expected < 0 && jpeg.Length > 0)
+                return jpeg.ToArray(); // no size advertised: single-message JPEG
         }
     }
 

--- a/src/Neolink.Server/Protocol/IBcCamera.cs
+++ b/src/Neolink.Server/Protocol/IBcCamera.cs
@@ -27,6 +27,16 @@ public interface IBcCamera : IAsyncDisposable
     Task PingAsync(CancellationToken ct);
 
     /// <summary>
+    /// Opts in to motion/AI alarm pushes (msg 31) and invokes <paramref name="onEvent"/>
+    /// for every push (msg 33) until cancelled or the connection drops. The camera sends
+    /// these on its own; there is no polling.
+    /// </summary>
+    Task WatchMotionAsync(Action<MotionPush> onEvent, CancellationToken ct);
+
+    /// <summary>Requests a JPEG snapshot from the camera (msg 109), or null if unsupported.</summary>
+    Task<byte[]?> SnapAsync(CancellationToken ct);
+
+    /// <summary>
     /// Sends one control message and awaits the camera's reply on the same message ID.
     /// Throws <see cref="CameraCommandException"/> when the camera answers with a
     /// non-200 response code. With <paramref name="tolerateNoReply"/> a missing reply
@@ -36,6 +46,17 @@ public interface IBcCamera : IAsyncDisposable
     /// </summary>
     Task<BcMessage?> SendCommandAsync(uint msgId, BcXmlBody? xml = null, ExtensionXml? extension = null,
         TimeSpan? replyTimeout = null, bool tolerateNoReply = false, CancellationToken ct = default);
+}
+
+/// <summary>
+/// One alarm push from the camera. Status is the raw detection state ("MD" while
+/// motion is seen, "none" when it stops); AiTypes carries the camera's own AI
+/// classification when it has one ("people", "vehicle", "dog_cat").
+/// </summary>
+public sealed record MotionPush(string Status, IReadOnlyList<string> AiTypes)
+{
+    /// <summary>True when this push signals active detection (as opposed to all-clear).</summary>
+    public bool Active => !string.Equals(Status, "none", StringComparison.OrdinalIgnoreCase) || AiTypes.Count > 0;
 }
 
 /// <summary>The camera answered a control command with a non-200 response code.</summary>

--- a/src/Neolink.Server/Recording/ClipWriter.cs
+++ b/src/Neolink.Server/Recording/ClipWriter.cs
@@ -1,0 +1,121 @@
+using Neolink.Media;
+using Neolink.Streaming;
+
+namespace Neolink.Recording;
+
+/// <summary>
+/// Writes hub video packets into a fragmented-MP4 file (playable by browsers and
+/// ffmpeg alike). Same pacing trick as the live web player: a camera buffer's true
+/// duration is only known when the NEXT buffer arrives (RTP delta), so one buffer
+/// is held back and its measured delta spread evenly across its frames.
+/// Video-only by design — detection clips don't need the audio track.
+/// </summary>
+public sealed class ClipWriter : IDisposable
+{
+    private const uint NominalFrame = 3000; // ~1/30s @ 90 kHz
+
+    private readonly FileStream _file;
+    private readonly VideoCodec _codec;
+
+    private uint _sequence = 1;
+    private ulong _decodeTime;
+    private bool _haveTs;
+    private uint _prevTs;
+    private long _lastIndex = -1;
+    private bool _waitKeyframe;
+    private List<(byte[] Sample, bool Keyframe)>? _pending;
+
+    private ClipWriter(FileStream file, VideoCodec codec)
+    {
+        _file = file;
+        _codec = codec;
+    }
+
+    /// <summary>Seconds of video written so far (upper bound; pending frames included at nominal rate).</summary>
+    public double DurationSeconds =>
+        (_decodeTime + (ulong)(_pending?.Count ?? 0) * NominalFrame) / (double)FMp4.Timescale;
+
+    /// <summary>Creates the file and writes the init segment; null when codec params are not known yet.</summary>
+    public static ClipWriter? TryCreate(string path, IStreamHub hub)
+    {
+        var codec = hub.Codec;
+        var sps = hub.Sps;
+        var pps = hub.Pps;
+        if (codec == null || sps == null || pps == null)
+            return null;
+
+        var file = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read, 64 * 1024);
+        try
+        {
+            file.Write(FMp4.BuildInit(codec.Value, sps, pps, hub.Vps, hub.Width, hub.Height));
+        }
+        catch
+        {
+            file.Dispose();
+            throw;
+        }
+        return new ClipWriter(file, codec.Value);
+    }
+
+    /// <summary>
+    /// Feeds the next video packet. Must be called with packets in hub order;
+    /// drops (index gaps) are handled by resuming at the next keyframe.
+    /// </summary>
+    public void Add(HubVideo v)
+    {
+        bool gap = _lastIndex >= 0 && v.Index != _lastIndex + 1;
+        _lastIndex = v.Index;
+        if (gap)
+        {
+            FlushPending((uint)(NominalFrame * (_pending?.Count ?? 1)));
+            _haveTs = false;
+            _waitKeyframe = true;
+        }
+        if (_waitKeyframe)
+        {
+            if (!v.Keyframe) return;
+            _waitKeyframe = false;
+        }
+
+        if (_haveTs && _pending != null)
+        {
+            uint delta = unchecked(v.RtpTs - _prevTs);
+            if (delta == 0 || delta > 30 * FMp4.Timescale)
+                delta = (uint)(NominalFrame * _pending.Count); // clock garbage: assume ~30fps
+            FlushPending(delta);
+        }
+        _prevTs = v.RtpTs;
+        _haveTs = true;
+
+        var aus = FMp4.SplitAccessUnits(_codec, v.AnnexB);
+        if (aus.Count > 0)
+            _pending = aus;
+    }
+
+    private void FlushPending(uint totalDuration)
+    {
+        if (_pending == null || _pending.Count == 0) { _pending = null; return; }
+        uint per = Math.Clamp(totalDuration / (uint)_pending.Count, 900u, 45_000u); // 10..500ms per frame
+        foreach (var (sample, key) in _pending)
+        {
+            _file.Write(FMp4.BuildFragment(_sequence++, _decodeTime, per, sample, key));
+            _decodeTime += per;
+        }
+        _pending = null;
+    }
+
+    /// <summary>Writes the held-back frames and closes the file.</summary>
+    public void Dispose()
+    {
+        try
+        {
+            FlushPending((uint)(NominalFrame * (_pending?.Count ?? 1)));
+            _file.Flush();
+        }
+        catch (IOException) { }
+        finally
+        {
+            _file.Dispose();
+        }
+    }
+}

--- a/src/Neolink.Server/Recording/EventRecorder.cs
+++ b/src/Neolink.Server/Recording/EventRecorder.cs
@@ -1,0 +1,294 @@
+using System.Threading.Channels;
+using Neolink.Config;
+using Neolink.Media;
+using Neolink.Protocol;
+using Neolink.Streaming;
+
+namespace Neolink.Recording;
+
+/// <summary>
+/// Turns a camera's alarm pushes into stored, labeled events with video clips.
+///
+/// Two long-lived tasks cooperate:
+///  - the packet pump subscribes to the stream hub and either maintains a keyframe-
+///    aligned pre-roll buffer (idle) or feeds the active clip writer (recording);
+///  - the event loop consumes motion pushes and drives the event lifecycle.
+///
+/// Grouping: one event spans a burst of activity. It opens on the first detection,
+/// keeps extending while the camera reports activity (labels accumulate — a person
+/// walking to their car becomes one "person + vehicle" event, not five), and closes
+/// after PostSeconds of quiet or at the MaxClipSeconds cap. A thumbnail is captured
+/// via the camera's own JPEG snapshot command, so no server-side decoding is needed.
+/// </summary>
+public sealed class EventRecorder
+{
+    private readonly string _camera;
+    private readonly IStreamHub _hub;
+    private readonly ICameraControl _control;
+    private readonly EventStore _store;
+    private readonly RecordingConfig _cfg;
+
+    private readonly Channel<MotionPush> _pushes = Channel.CreateUnbounded<MotionPush>(
+        new UnboundedChannelOptions { SingleReader = true });
+
+    // Pre-roll buffer and clip writer are handed between the pump and the event
+    // loop under one gate; both touch them briefly (local file I/O only).
+    private readonly object _mediaGate = new();
+    private readonly List<HubVideo> _preroll = new();
+    private ClipWriter? _writer;
+
+    public EventRecorder(string camera, IStreamHub hub, ICameraControl control,
+        EventStore store, RecordingConfig cfg)
+    {
+        _camera = camera;
+        _hub = hub;
+        _control = control;
+        _store = store;
+        _cfg = cfg;
+    }
+
+    public string Camera => _camera;
+
+    /// <summary>Called from the camera connection for every alarm push (any thread).</summary>
+    public void OnMotion(MotionPush push) => _pushes.Writer.TryWrite(push);
+
+    public async Task RunAsync(CancellationToken ct)
+    {
+        Log.Info($"{_camera}: event recording enabled ({_hub.Name}, pre={_cfg.PreSeconds}s, post={_cfg.PostSeconds}s)");
+        var pump = Task.Run(() => PumpPacketsAsync(ct), CancellationToken.None);
+        try
+        {
+            await EventLoopAsync(ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            lock (_mediaGate)
+            {
+                _writer?.Dispose();
+                _writer = null;
+            }
+            try { await pump.ConfigureAwait(false); } catch { }
+        }
+    }
+
+    // ------------------------------------------------------------------ packet pump
+
+    private async Task PumpPacketsAsync(CancellationToken ct)
+    {
+        var (id, reader) = _hub.Subscribe();
+        try
+        {
+            await foreach (var packet in reader.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                if (packet is not HubVideo v) continue;
+                lock (_mediaGate)
+                {
+                    if (_writer != null)
+                    {
+                        try
+                        {
+                            _writer.Add(v);
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Warn($"{_camera}: clip write failed: {ex.Message}");
+                            _writer.Dispose();
+                            _writer = null;
+                        }
+                    }
+                    else
+                    {
+                        _preroll.Add(v);
+                        TrimPreroll();
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+        finally
+        {
+            _hub.Unsubscribe(id);
+        }
+    }
+
+    /// <summary>
+    /// Keeps the pre-roll spanning at least PreSeconds while starting on a keyframe
+    /// (a clip must begin decodable): drop everything before the latest keyframe
+    /// that still preserves the wanted span.
+    /// </summary>
+    private void TrimPreroll()
+    {
+        uint want = (uint)_cfg.PreSeconds * FMp4.Timescale;
+        uint last = _preroll[^1].RtpTs;
+        int cut = -1;
+        for (int i = _preroll.Count - 1; i >= 0; i--)
+        {
+            if (!_preroll[i].Keyframe) continue;
+            if (unchecked(last - _preroll[i].RtpTs) >= want)
+            {
+                cut = i;
+                break;
+            }
+        }
+        if (cut > 0)
+            _preroll.RemoveRange(0, cut);
+        // Safety valve for streams with pathological keyframe intervals.
+        if (_preroll.Count > 4096)
+            _preroll.RemoveRange(0, _preroll.Count - 4096);
+    }
+
+    // ------------------------------------------------------------------ event lifecycle
+
+    private async Task EventLoopAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            MotionPush push;
+            try
+            {
+                push = await _pushes.Reader.ReadAsync(ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            if (!push.Active) continue; // stray all-clear with no open event
+
+            try
+            {
+                await RunEventAsync(push, ct).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Log.Error($"{_camera}: event handling failed: {Log.Flatten(ex)}");
+            }
+        }
+    }
+
+    private async Task RunEventAsync(MotionPush first, CancellationToken ct)
+    {
+        var rec = _store.Create(_camera,
+            DateTime.UtcNow - TimeSpan.FromSeconds(_cfg.PreSeconds), LabelsOf(first));
+        Log.Info($"{_camera}: ⚡ event started ({string.Join("+", rec.Labels)})");
+
+        StartClip(rec);
+        var thumbTask = CaptureThumbAsync(rec, ct);
+
+        var hardStop = DateTime.UtcNow.AddSeconds(_cfg.MaxClipSeconds);
+        var quietUntil = DateTime.UtcNow.AddSeconds(_cfg.PostSeconds);
+        bool active = true; // the camera currently reports detection
+
+        while (!ct.IsCancellationRequested)
+        {
+            var now = DateTime.UtcNow;
+            if (now >= hardStop) break;
+            var deadline = active ? hardStop : (quietUntil < hardStop ? quietUntil : hardStop);
+            if (!active && now >= deadline) break;
+
+            MotionPush push;
+            using var waitCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            waitCts.CancelAfter(deadline - now);
+            try
+            {
+                push = await _pushes.Reader.ReadAsync(waitCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            {
+                continue; // a deadline fired; loop re-evaluates
+            }
+
+            if (push.Active)
+            {
+                active = true;
+                var fresh = LabelsOf(push).Where(l => !rec.Labels.Contains(l)).ToList();
+                if (fresh.Count > 0)
+                {
+                    rec.Labels.AddRange(fresh);
+                    rec.EndUtc = DateTime.UtcNow;
+                    _store.Save(rec);
+                    Log.Info($"{_camera}: event escalated (+{string.Join("+", fresh)})");
+                }
+            }
+            else
+            {
+                active = false;
+                quietUntil = DateTime.UtcNow.AddSeconds(_cfg.PostSeconds);
+            }
+        }
+
+        lock (_mediaGate)
+        {
+            _writer?.Dispose();
+            _writer = null;
+        }
+        rec.EndUtc = DateTime.UtcNow;
+        rec.Ongoing = false;
+        _store.Save(rec);
+        try { await thumbTask.ConfigureAwait(false); } catch { }
+        Log.Info($"{_camera}: event ended ({string.Join("+", rec.Labels)}, " +
+                 $"{(rec.EndUtc - rec.StartUtc).TotalSeconds:0}s{(rec.HasClip ? ", clip saved" : "")})");
+    }
+
+    private void StartClip(EventRecord rec)
+    {
+        lock (_mediaGate)
+        {
+            try
+            {
+                _writer = ClipWriter.TryCreate(Path.Combine(_store.EventDir(rec), "clip.mp4"), _hub);
+                if (_writer == null)
+                {
+                    Log.Warn($"{_camera}: stream not ready; event stored without a clip");
+                    return;
+                }
+                foreach (var v in _preroll)
+                    _writer.Add(v);
+                _preroll.Clear();
+            }
+            catch (Exception ex)
+            {
+                Log.Warn($"{_camera}: cannot start clip: {ex.Message}");
+                _writer?.Dispose();
+                _writer = null;
+            }
+        }
+        if (_writer != null)
+        {
+            rec.HasClip = true;
+            _store.Save(rec);
+        }
+    }
+
+    /// <summary>Best-effort thumbnail via the camera's own JPEG snapshot command.</summary>
+    private async Task CaptureThumbAsync(EventRecord rec, CancellationToken ct)
+    {
+        try
+        {
+            var jpeg = await _control.SnapshotAsync(ct).ConfigureAwait(false);
+            if (jpeg is not { Length: > 100 } || jpeg[0] != 0xFF || jpeg[1] != 0xD8)
+                return; // not a JPEG (or camera doesn't support snapshots)
+            await File.WriteAllBytesAsync(Path.Combine(_store.EventDir(rec), "thumb.jpg"), jpeg, ct)
+                .ConfigureAwait(false);
+            rec.HasThumb = true;
+            _store.Save(rec);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Log.Debug($"{_camera}: event snapshot failed: {Log.Flatten(ex)}");
+        }
+    }
+
+    /// <summary>Camera AI classifications → normalized event labels.</summary>
+    internal static List<string> LabelsOf(MotionPush push)
+    {
+        var labels = push.AiTypes.Select(t => t switch
+        {
+            "people" or "person" or "face" => "person",
+            "vehicle" or "car" => "vehicle",
+            "dog_cat" or "animal" or "pet" => "animal",
+            "package" => "package",
+            _ => t,
+        }).Distinct().ToList();
+        return labels.Count > 0 ? labels : new List<string> { "motion" };
+    }
+}

--- a/src/Neolink.Server/Recording/EventStore.cs
+++ b/src/Neolink.Server/Recording/EventStore.cs
@@ -1,0 +1,215 @@
+using System.Text.Json;
+
+namespace Neolink.Recording;
+
+/// <summary>One detection event: what was seen, when, and what was captured.</summary>
+public sealed class EventRecord
+{
+    public required string Id { get; init; }
+    public required string Camera { get; init; }
+    public DateTime StartUtc { get; set; }
+    public DateTime EndUtc { get; set; }
+    /// <summary>Normalized labels: "person", "vehicle", "animal", "motion".</summary>
+    public List<string> Labels { get; set; } = new();
+    /// <summary>Set once the user has looked at the event (dismissed from the review bar).</summary>
+    public bool Reviewed { get; set; }
+    /// <summary>Still being extended by ongoing detections.</summary>
+    public bool Ongoing { get; set; }
+    public bool HasClip { get; set; }
+    public bool HasThumb { get; set; }
+}
+
+/// <summary>
+/// File-based event storage — deliberately no database, keeping the zero-dependency
+/// rule. Layout: {root}/{camera}/{yyyy-MM-dd}/{HHmmss}-{suffix}/ holding event.json,
+/// clip.mp4 and thumb.jpg. The day directory is the retention unit: expiring events
+/// means deleting old day directories. An in-memory index (loaded by scanning at
+/// startup) serves queries; JSON files are the source of truth across restarts.
+/// </summary>
+public sealed class EventStore
+{
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
+
+    private readonly string _root;
+    private readonly object _gate = new();
+    private readonly Dictionary<string, (EventRecord Record, string Dir)> _byId = new();
+
+    public EventStore(string root)
+    {
+        _root = Path.GetFullPath(root);
+        Directory.CreateDirectory(_root);
+    }
+
+    public string Root => _root;
+
+    /// <summary>Scans the storage directory and rebuilds the in-memory index.</summary>
+    public void Load()
+    {
+        int loaded = 0;
+        foreach (var file in Directory.EnumerateFiles(_root, "event.json", SearchOption.AllDirectories))
+        {
+            try
+            {
+                var rec = JsonSerializer.Deserialize<EventRecord>(File.ReadAllText(file), JsonOpts);
+                if (rec == null) continue;
+                rec.Ongoing = false; // whatever was ongoing did not survive the restart
+                lock (_gate) { _byId[rec.Id] = (rec, Path.GetDirectoryName(file)!); }
+                loaded++;
+            }
+            catch (Exception ex)
+            {
+                Log.Warn($"Events: skipping unreadable {file}: {ex.Message}");
+            }
+        }
+        if (loaded > 0)
+            Log.Info($"Events: indexed {loaded} stored event(s) under {_root}");
+    }
+
+    /// <summary>Creates a new event and its directory, and persists the initial record.</summary>
+    public EventRecord Create(string camera, DateTime startUtc, IEnumerable<string> labels)
+    {
+        var local = startUtc.ToLocalTime();
+        var suffix = Convert.ToHexString(Guid.NewGuid().ToByteArray()[..2]).ToLowerInvariant();
+        var folder = $"{local:HHmmss}-{suffix}";
+        var id = $"{camera}~{local:yyyy-MM-dd}~{folder}";
+        var dir = Path.Combine(_root, SafeName(camera), $"{local:yyyy-MM-dd}", folder);
+        Directory.CreateDirectory(dir);
+
+        var rec = new EventRecord
+        {
+            Id = id,
+            Camera = camera,
+            StartUtc = startUtc,
+            EndUtc = startUtc,
+            Labels = labels.Distinct().ToList(),
+            Ongoing = true,
+        };
+        lock (_gate) { _byId[id] = (rec, dir); }
+        Save(rec);
+        return rec;
+    }
+
+    /// <summary>Persists the record (atomic replace so a crash can't corrupt it).</summary>
+    public void Save(EventRecord rec)
+    {
+        string dir;
+        lock (_gate)
+        {
+            if (!_byId.TryGetValue(rec.Id, out var entry)) return; // expired mid-write
+            dir = entry.Dir;
+        }
+        try
+        {
+            var tmp = Path.Combine(dir, "event.json.tmp");
+            File.WriteAllText(tmp, JsonSerializer.Serialize(rec, JsonOpts));
+            File.Move(tmp, Path.Combine(dir, "event.json"), overwrite: true);
+        }
+        catch (IOException ex)
+        {
+            Log.Warn($"Events: cannot persist {rec.Id}: {ex.Message}");
+        }
+    }
+
+    public string EventDir(EventRecord rec)
+    {
+        lock (_gate) { return _byId[rec.Id].Dir; }
+    }
+
+    public EventRecord? Find(string id)
+    {
+        lock (_gate) { return _byId.TryGetValue(id, out var e) ? e.Record : null; }
+    }
+
+    /// <summary>Absolute path of a stored artifact ("clip.mp4"/"thumb.jpg"), or null.</summary>
+    public string? ArtifactPath(string id, string fileName)
+    {
+        string? dir;
+        lock (_gate) { dir = _byId.TryGetValue(id, out var e) ? e.Dir : null; }
+        if (dir == null) return null;
+        var path = Path.Combine(dir, fileName);
+        return File.Exists(path) ? path : null;
+    }
+
+    public bool SetReviewed(string id, bool reviewed)
+    {
+        EventRecord? rec;
+        lock (_gate) { rec = _byId.TryGetValue(id, out var e) ? e.Record : null; }
+        if (rec == null) return false;
+        rec.Reviewed = reviewed;
+        Save(rec);
+        return true;
+    }
+
+    /// <summary>Newest-first event listing with optional filters.</summary>
+    public List<EventRecord> List(string? camera = null, bool? reviewed = null, int limit = 200)
+    {
+        lock (_gate)
+        {
+            return _byId.Values.Select(e => e.Record)
+                .Where(r => camera == null || string.Equals(r.Camera, camera, StringComparison.OrdinalIgnoreCase))
+                .Where(r => reviewed == null || r.Reviewed == reviewed)
+                .OrderByDescending(r => r.StartUtc)
+                .Take(Math.Clamp(limit, 1, 1000))
+                .ToList();
+        }
+    }
+
+    /// <summary>Deletes day directories older than the retention window.</summary>
+    public void Cleanup(int retentionDays)
+    {
+        if (retentionDays <= 0) return;
+        var cutoff = DateTime.Now.Date.AddDays(-retentionDays);
+        int removed = 0;
+
+        foreach (var cameraDir in Directory.EnumerateDirectories(_root))
+        {
+            foreach (var dayDir in Directory.EnumerateDirectories(cameraDir))
+            {
+                if (!DateTime.TryParseExact(Path.GetFileName(dayDir), "yyyy-MM-dd",
+                        null, System.Globalization.DateTimeStyles.None, out var day)
+                    || day >= cutoff)
+                    continue;
+                try
+                {
+                    Directory.Delete(dayDir, recursive: true);
+                    removed++;
+                }
+                catch (IOException ex)
+                {
+                    Log.Warn($"Events: cannot delete expired {dayDir}: {ex.Message}");
+                    continue;
+                }
+                lock (_gate)
+                {
+                    foreach (var id in _byId.Where(kv => kv.Value.Dir.StartsWith(dayDir, StringComparison.OrdinalIgnoreCase))
+                                 .Select(kv => kv.Key).ToList())
+                        _byId.Remove(id);
+                }
+            }
+        }
+        if (removed > 0)
+            Log.Info($"Events: retention removed {removed} expired day folder(s) (older than {retentionDays}d)");
+    }
+
+    /// <summary>Runs retention cleanup once at start and then hourly.</summary>
+    public async Task RunRetentionAsync(int retentionDays, CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try { Cleanup(retentionDays); }
+            catch (Exception ex) { Log.Warn($"Events: retention pass failed: {Log.Flatten(ex)}"); }
+            try { await Task.Delay(TimeSpan.FromHours(1), ct).ConfigureAwait(false); }
+            catch (OperationCanceledException) { return; }
+        }
+    }
+
+    private static string SafeName(string name)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        return new string(name.Select(c => invalid.Contains(c) ? '_' : c).ToArray());
+    }
+}

--- a/src/Neolink.Server/SelfTest.cs
+++ b/src/Neolink.Server/SelfTest.cs
@@ -240,6 +240,114 @@ public static class SelfTest
             Assert((packets[^1][1] & 0x80) != 0, "marker on last packet");
         });
 
+        Test("event label mapping", () =>
+        {
+            var labels = Recording.EventRecorder.LabelsOf(new MotionPush("MD",
+                new[] { "people", "dog_cat", "people" }));
+            AssertEq(string.Join(",", labels.OrderBy(x => x)), "animal,person");
+            AssertEq(string.Join(",", Recording.EventRecorder.LabelsOf(new MotionPush("MD", Array.Empty<string>()))),
+                "motion");
+            Assert(new MotionPush("MD", Array.Empty<string>()).Active, "MD is active");
+            Assert(!new MotionPush("none", Array.Empty<string>()).Active, "none is all-clear");
+            Assert(new MotionPush("none", new[] { "people" }).Active, "AI type implies activity");
+        });
+
+        Test("event store roundtrip + retention", () =>
+        {
+            var dir = Path.Combine(Path.GetTempPath(), $"neolink-selftest-{Guid.NewGuid():N}");
+            try
+            {
+                var store = new Recording.EventStore(dir);
+                var rec = store.Create("cam1", DateTime.UtcNow, new[] { "person" });
+                rec.EndUtc = rec.StartUtc.AddSeconds(30);
+                rec.Ongoing = false;
+                store.Save(rec);
+
+                // A fresh store must find it again by scanning the files.
+                var store2 = new Recording.EventStore(dir);
+                store2.Load();
+                var listed = store2.List();
+                AssertEq(listed.Count, 1);
+                AssertEq(listed[0].Id, rec.Id);
+                Assert(!listed[0].Reviewed, "starts unreviewed");
+                Assert(store2.SetReviewed(rec.Id, true), "review known id");
+                Assert(store2.List(reviewed: false).Count == 0, "reviewed filter");
+
+                // An event folder older than the retention window gets deleted.
+                var oldDir = Path.Combine(dir, "cam1", "2000-01-01", "120000-dead");
+                Directory.CreateDirectory(oldDir);
+                File.WriteAllText(Path.Combine(oldDir, "event.json"), "{}");
+                store2.Cleanup(retentionDays: 7);
+                Assert(!Directory.Exists(oldDir), "expired day folder removed");
+                Assert(store2.List().Count == 1, "recent event survives retention");
+            }
+            finally
+            {
+                try { Directory.Delete(dir, recursive: true); } catch { }
+            }
+        });
+
+        Test("clip writer produces a playable fmp4 structure", () =>
+        {
+            var dir = Path.Combine(Path.GetTempPath(), $"neolink-selftest-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(dir);
+            try
+            {
+                // Feed a synthetic H.264 stream through a hub so the writer can
+                // pick up codec parameters, then write a few frames.
+                var hub = new Streaming.StreamHub("selftest");
+                byte[] Nal(byte type, int len)
+                {
+                    // Non-zero body: NAL splitting trims trailing zeros and must not
+                    // find stray start codes. 0x80 in byte 1 = first_mb_in_slice bit.
+                    var nal = new byte[len];
+                    Array.Fill(nal, (byte)0xAA);
+                    nal[0] = type;
+                    nal[1] = 0x80;
+                    return nal;
+                }
+                byte[] Au(params byte[][] nals)
+                {
+                    var ms = new MemoryStream();
+                    foreach (var n in nals)
+                    {
+                        ms.Write(new byte[] { 0, 0, 0, 1 });
+                        ms.Write(n);
+                    }
+                    return ms.ToArray();
+                }
+                var sps = new byte[] { 0x67, 0x42, 0xE0, 0x1F, 0xA0 };
+                var pps = new byte[] { 0x68, 0xCE, 0x38, 0x80 };
+                hub.PublishVideo(new VideoFrame(VideoCodec.H264, Keyframe: true, Microseconds: 0, UnixTime: null,
+                    Au(sps, pps, Nal(0x65, 40))));
+
+                var path = Path.Combine(dir, "clip.mp4");
+                using (var writer = Recording.ClipWriter.TryCreate(path, hub))
+                {
+                    Assert(writer != null, "writer created once params are known");
+                    long index = 0;
+                    uint ts = 1000;
+                    writer!.Add(new Streaming.HubVideo(index++, Au(Nal(0x65, 40)), true, ts));
+                    for (int i = 0; i < 5; i++)
+                        writer.Add(new Streaming.HubVideo(index++, Au(Nal(0x41, 25)), false, ts += 3000));
+                    Assert(writer.DurationSeconds > 0, "duration advances");
+                }
+
+                var bytes = File.ReadAllBytes(path);
+                Assert(bytes.Length > 200, "file has content");
+                AssertEq(Encoding.ASCII.GetString(bytes, 4, 4), "ftyp");
+                Assert(bytes.Length >= 16, "has boxes");
+                // moov must follow, and at least one moof/mdat pair must exist
+                var text = Encoding.ASCII.GetString(bytes);
+                Assert(text.Contains("moov"), "init segment present");
+                Assert(text.Contains("moof") && text.Contains("mdat"), "fragments present");
+            }
+            finally
+            {
+                try { Directory.Delete(dir, recursive: true); } catch { }
+            }
+        });
+
         if (rustRepoPath != null)
         {
             var bcSamples = Path.Combine(rustRepoPath, "crates", "core", "src", "bc", "samples");

--- a/src/Neolink.Server/Streaming/CameraControl.cs
+++ b/src/Neolink.Server/Streaming/CameraControl.cs
@@ -42,6 +42,9 @@ public interface ICameraControl
         uint? framerate, uint? bitrate, CancellationToken ct);
 
     Task<XElement?> GetBatteryInfoAsync(CancellationToken ct);
+
+    /// <summary>A JPEG snapshot from the camera, or null if unsupported.</summary>
+    Task<byte[]?> SnapshotAsync(CancellationToken ct);
     Task<XElement?> GetLedStateAsync(CancellationToken ct);
     Task SetLedStateAsync(string? state, string? lightState, CancellationToken ct);
     Task<XElement?> GetPirStateAsync(CancellationToken ct);
@@ -153,6 +156,9 @@ public sealed class CameraControl : ICameraControl
 
     public Task<XElement?> GetBatteryInfoAsync(CancellationToken ct) =>
         WithCameraAsync(camera => camera.GetBatteryInfoAsync(ct: ct), ct);
+
+    public Task<byte[]?> SnapshotAsync(CancellationToken ct) =>
+        WithCameraAsync(camera => camera.SnapAsync(ct), ct);
 
     public Task<XElement?> GetLedStateAsync(CancellationToken ct) =>
         WithCameraAsync(camera => camera.GetLedStateAsync(ct: ct), ct);

--- a/src/Neolink.Server/Streaming/CameraService.cs
+++ b/src/Neolink.Server/Streaming/CameraService.cs
@@ -43,6 +43,12 @@ public sealed class CameraService : ILiveCameraSource
     public string Name => _config.Name;
     public IBcCamera? LiveCamera => _live;
 
+    /// <summary>
+    /// When set (on the primary stream service), alarm pushes are requested on each
+    /// connection and forwarded here. Assigned once during startup wiring.
+    /// </summary>
+    public Action<MotionPush>? MotionSink { get; set; }
+
     private string Tag => $"{_config.Name} ({_kind})";
 
     public async Task RunAsync(CancellationToken ct)
@@ -131,6 +137,9 @@ public sealed class CameraService : ILiveCameraSource
         var reader = new MediaFrameReader(binary.Reader);
         long frames = 0;
         _live = camera;
+        Task? motionTask = MotionSink is { } sink
+            ? Task.Run(() => WatchMotionGuardedAsync(camera, sink, linked.Token), CancellationToken.None)
+            : null;
         try
         {
             while (!ct.IsCancellationRequested)
@@ -173,6 +182,32 @@ public sealed class CameraService : ILiveCameraSource
             _live = null;
             linked.Cancel();
             try { await videoTask.ConfigureAwait(false); } catch { }
+            if (motionTask != null)
+            {
+                try { await motionTask.ConfigureAwait(false); } catch { }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Alarm-push listener riding the same connection as the video stream. Failures
+    /// stay local: a camera without motion push must not disturb streaming.
+    /// </summary>
+    private async Task WatchMotionGuardedAsync(IBcCamera camera, Action<MotionPush> sink, CancellationToken ct)
+    {
+        try
+        {
+            await camera.WatchMotionAsync(sink, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex) when (ex is CameraCommandException or TimeoutException)
+        {
+            Log.Warn($"{Tag}: camera declined motion pushes ({ex.Message}); no events this session");
+        }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException)
+        {
+            // Connection died; the video loop notices and reconnects everything.
+            Log.Debug($"{Tag}: motion watch ended: {ex.Message}");
         }
     }
 }

--- a/src/Neolink.Server/Web/WebApi.cs
+++ b/src/Neolink.Server/Web/WebApi.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Neolink.Media;
 using Neolink.Protocol;
+using Neolink.Recording;
 using Neolink.Streaming;
 
 namespace Neolink.Web;
@@ -26,6 +27,8 @@ public sealed record WebCameraInfo(string Name, List<WebStreamInfo> Streams, ICa
 ///   GET /api/cameras/{name}/streaminfo      — encode profiles (resolution/fps/bitrate tables)
 ///   POST/PUT .../settings/stream            — change an encode profile (needs http_address)
 ///   GET/POST .../led /pir; POST .../ptz /reboot; GET .../battery — camera control
+///   GET /api/events[?camera=&amp;reviewed=&amp;limit=] — recorded detection events (when enabled)
+///   GET /api/events/{id}/clip /thumb        — event artifacts; POST .../review to (un)dismiss
 ///   /                                       — web UI (when enabled in the config)
 /// Mutating endpoints require HTTP Basic auth when users are configured (same
 /// credentials and per-camera permissions as RTSP).
@@ -37,10 +40,11 @@ public static class WebApi
     private sealed record PtzRequest(string? Command, float? Speed);
     private sealed record StreamSettingsRequest(string? Stream, uint? Width, uint? Height,
         uint? Framerate, uint? Bitrate);
+    private sealed record ReviewRequest(bool? Reviewed);
 
     public static async Task RunAsync(string bindAddr, int port, bool webUi,
         IReadOnlyList<WebCameraInfo> cameras, IReadOnlyDictionary<string, string> users,
-        int rtspPort, CancellationToken ct)
+        int rtspPort, EventStore? events, CancellationToken ct)
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
         {
@@ -288,6 +292,68 @@ public static class WebApi
                 await control.RebootAsync(reqCt);
                 return Results.Json(new { ok = true });
             }));
+
+        // ------------------------------------------------------------ recorded events
+
+        if (events != null)
+        {
+            object Shape(EventRecord r) => new
+            {
+                id = r.Id,
+                camera = r.Camera,
+                start = r.StartUtc,
+                end = r.EndUtc,
+                labels = r.Labels,
+                reviewed = r.Reviewed,
+                ongoing = r.Ongoing,
+                hasClip = r.HasClip,
+                hasThumb = r.HasThumb,
+            };
+
+            app.MapGet("/api/events", (string? camera, bool? reviewed, int? limit) =>
+                Results.Json(events.List(camera, reviewed, limit ?? 200).Select(Shape)));
+
+            app.MapGet("/api/events/{id}/clip", (string id) =>
+            {
+                var path = events.ArtifactPath(id, "clip.mp4");
+                return path == null
+                    ? Results.Json(new { error = "no clip for this event" }, statusCode: 404)
+                    : Results.File(path, "video/mp4", enableRangeProcessing: true);
+            });
+
+            app.MapGet("/api/events/{id}/thumb", (string id) =>
+            {
+                var path = events.ArtifactPath(id, "thumb.jpg");
+                return path == null
+                    ? Results.Json(new { error = "no thumbnail for this event" }, statusCode: 404)
+                    : Results.File(path, "image/jpeg");
+            });
+
+            app.MapPost("/api/events/{id}/review", (string id, ReviewRequest req, HttpContext ctx) =>
+            {
+                var rec = events.Find(id);
+                if (rec == null)
+                    return Results.Json(new { error = "unknown event" }, statusCode: 404);
+                // Same rules as camera control: reviewing an event needs control rights
+                // on its camera. Events of removed cameras fall back to any valid user.
+                var cam = cameras.FirstOrDefault(c => string.Equals(c.Name, rec.Camera, StringComparison.OrdinalIgnoreCase));
+                if (cam != null)
+                {
+                    if (CheckAuth(ctx, cam) is { } denied) return denied;
+                }
+                else if (users.Count > 0)
+                {
+                    var creds = NetUtil.DecodeBasicAuth(ctx.Request.Headers.Authorization);
+                    if (creds == null || !users.TryGetValue(creds.Value.User, out var pw) || pw != creds.Value.Pass)
+                    {
+                        ctx.Response.Headers.WWWAuthenticate = "Basic realm=\"neolink\"";
+                        return Results.Json(new { error = "authentication required" }, statusCode: 401);
+                    }
+                }
+                events.SetReviewed(id, req.Reviewed ?? true);
+                return Results.Json(new { ok = true });
+            });
+        }
 
         app.Map("/api/stream", async ctx =>
         {

--- a/src/Neolink.Server/config.example.json
+++ b/src/Neolink.Server/config.example.json
@@ -14,6 +14,17 @@
   // Serve the browser UI on web_port. Set false for API-only / headless setups.
   "webui": true,
 
+  // Optional: record motion/AI detection events (clips + thumbnails) to disk.
+  // Remove this section to disable. In Docker, mount a volume at "path".
+  // "recording": {
+  //   "path": "/recordings",     // storage directory
+  //   "retention_days": 7,       // delete events older than this (0 = keep forever)
+  //   "pre_seconds": 5,          // video kept from before the detection
+  //   "post_seconds": 8,         // quiet time before an event closes
+  //   "max_clip_seconds": 120,   // hard cap per event/clip
+  //   "stream": "auto"           // which stream to record: auto|mainStream|subStream
+  // },
+
   // Optional: password-protect the RTSP server. Remove entries for open access.
   // Connect with e.g. rtsp://me:mepass@192.168.1.100:8654/driveway
   "users": [

--- a/src/Neolink.WebClient/Components/Pages/Home.razor
+++ b/src/Neolink.WebClient/Components/Pages/Home.razor
@@ -76,6 +76,44 @@
     </aside>
 
     <main class="stage">
+        @* Frigate-style review strip: unreviewed detection events, newest first.
+           Disappears entirely once everything is dismissed (or recording is off). *@
+        @if (_eventsSupported && _events.Any(e => !e.Reviewed))
+        {
+            <div class="events-bar">
+                <span class="events-bar-count" title="Unreviewed events">⚡ @_events.Count(e => !e.Reviewed)</span>
+                <div class="events-bar-scroll">
+                    @foreach (var ev in _events.Where(e => !e.Reviewed).Take(30))
+                    {
+                        <div class="event-card @(ev.Ongoing ? "live" : "")" @key="ev.Id"
+                             title="@ev.Title — click to play" @onclick="() => OpenEvent(ev)">
+                            <div class="event-thumb">
+                                @if (ev.HasThumb)
+                                {
+                                    <img src="@EventArtifactUrl(ev, "thumb")" loading="lazy" alt="" />
+                                }
+                                else
+                                {
+                                    <span class="event-thumb-icon">@ev.Icon</span>
+                                }
+                                @if (ev.Ongoing)
+                                {
+                                    <span class="event-live">● REC</span>
+                                }
+                            </div>
+                            <div class="event-meta">
+                                <span class="event-title">@ev.Icon @ev.Title</span>
+                                <span class="event-sub">@ev.Camera · @Ago(ev.Start)</span>
+                            </div>
+                            <button class="icon-btn event-dismiss" title="Dismiss (mark reviewed)"
+                                    @onclick="() => DismissAsync(ev)" @onclick:stopPropagation="true">✕</button>
+                        </div>
+                    }
+                </div>
+                <button class="chip events-clear" title="Dismiss all events" @onclick="DismissAllAsync">Clear all</button>
+            </div>
+        }
+
         <div class="toolbar">
             <button class="tool-btn menu-btn" title="Cameras" @onclick="() => _sidebarOpen = !_sidebarOpen">☰</button>
             <span class="tool-label">VIEW</span>
@@ -98,6 +136,13 @@
             {
                 <span class="tool-sep"></span>
                 <button class="tool-btn back" @onclick="RestoreFromBackup">⤡ Restore view</button>
+            }
+
+            @if (_eventsSupported)
+            {
+                <span class="tool-sep"></span>
+                <button class="tool-btn @(_showEventsPanel ? "active" : "")" title="Event history"
+                        @onclick="() => _showEventsPanel = !_showEventsPanel">🕘 <span class="tool-name">Events</span></button>
             }
         </div>
 
@@ -161,6 +206,97 @@
                      OnClose="() => _panelCamera = null" />
     }
 
+    @if (_showEventsPanel)
+    {
+        <div class="backdrop panel-backdrop" @onclick="() => _showEventsPanel = false"></div>
+        <aside class="campanel events-panel" role="dialog" aria-label="Event history">
+            <div class="campanel-head">
+                <span class="campanel-title">🕘 EVENTS</span>
+                <select class="event-filter" @bind="_eventCameraFilter" title="Filter by camera">
+                    <option value="">all cameras</option>
+                    @foreach (var c in _cameras)
+                    {
+                        <option value="@c.Name">@c.Name</option>
+                    }
+                </select>
+                <button class="chip @(_eventsUnreviewedOnly ? "" : "chip-off")" title="Only show unreviewed events"
+                        @onclick="() => _eventsUnreviewedOnly = !_eventsUnreviewedOnly">unreviewed</button>
+                <button class="icon-btn" title="Close" @onclick="() => _showEventsPanel = false">✕</button>
+            </div>
+
+            @if (!FilteredEvents.Any())
+            {
+                <div class="notice">
+                    @(_eventsUnreviewedOnly ? "Nothing awaiting review — all clear." : "No recorded events yet.")
+                </div>
+            }
+            @foreach (var day in FilteredEvents.GroupBy(e => e.Start.ToLocalTime().Date))
+            {
+                <div class="campanel-section">
+                    <div class="campanel-section-title">@DayLabel(day.Key) <span class="event-day-count">@day.Count()</span></div>
+                    @foreach (var ev in day)
+                    {
+                        <div class="event-row @(ev.Reviewed ? "reviewed" : "")" @key="ev.Id"
+                             title="Click to play" @onclick="() => OpenEvent(ev)">
+                            <span class="event-row-time">@ev.Start.ToLocalTime().ToString("HH:mm:ss")</span>
+                            <span class="event-row-icon">@ev.Icon</span>
+                            <div class="event-row-main">
+                                <span class="event-title">@ev.Title</span>
+                                <span class="event-sub">@ev.Camera · @DurationText(ev)</span>
+                            </div>
+                            @if (!ev.Reviewed)
+                            {
+                                <button class="icon-btn" title="Dismiss (mark reviewed)"
+                                        @onclick="() => DismissAsync(ev)" @onclick:stopPropagation="true">✕</button>
+                            }
+                        </div>
+                    }
+                </div>
+            }
+        </aside>
+    }
+
+    @if (_playEvent != null)
+    {
+        <div class="backdrop player-backdrop" @onclick="ClosePlayer"></div>
+        <div class="event-player" role="dialog" aria-label="Event playback">
+            <div class="event-player-head">
+                <div class="event-player-title">
+                    <span class="event-title">@_playEvent.Icon @_playEvent.Title</span>
+                    <span class="event-sub">
+                        @_playEvent.Camera · @_playEvent.Start.ToLocalTime().ToString("ddd d MMM HH:mm:ss") · @DurationText(_playEvent)
+                    </span>
+                </div>
+                <button class="icon-btn" title="Close" @onclick="ClosePlayer">✕</button>
+            </div>
+            @if (_playEvent.HasClip)
+            {
+                @* @key forces a fresh <video> when navigating between events *@
+                <video controls autoplay playsinline @key="_playEvent.Id"
+                       src="@EventArtifactUrl(_playEvent, "clip")"></video>
+            }
+            else
+            {
+                <div class="notice">No clip was recorded for this event@(_playEvent.Ongoing ? " yet — it is still being captured" : "").</div>
+            }
+            <div class="event-player-foot">
+                <button class="chip" disabled="@(NeighborEvent(1) == null)"
+                        @onclick="() => _playEvent = NeighborEvent(1)">← Older</button>
+                <button class="chip" disabled="@(NeighborEvent(-1) == null)"
+                        @onclick="() => _playEvent = NeighborEvent(-1)">Newer →</button>
+                <span class="tile-spacer"></span>
+                @if (!_playEvent.Reviewed)
+                {
+                    <button class="chip" @onclick="() => DismissAsync(_playEvent)">✓ Mark reviewed</button>
+                }
+                else
+                {
+                    <span class="event-sub">✓ reviewed</span>
+                }
+            </div>
+        </div>
+    }
+
 </div>
 
 @code {
@@ -192,6 +328,14 @@
     private readonly Dictionary<int, string> _attached = new();
     private PeriodicTimer? _pollTimer;
 
+    // Recorded events (populated when the server has recording enabled)
+    private readonly List<ApiEvent> _events = new();
+    private bool _eventsSupported;
+    private bool _showEventsPanel;
+    private string _eventCameraFilter = "";
+    private bool _eventsUnreviewedOnly;
+    private ApiEvent? _playEvent;
+
     protected override void OnInitialized() => EnsureSlots();
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -201,6 +345,7 @@
             await LoadPersistedAsync();
             _loaded = true;
             await RefreshCamerasAsync();
+            await RefreshEventsAsync();
             StateHasChanged();
             _ = PollLoopAsync();
             return;
@@ -307,6 +452,7 @@
             while (await _pollTimer.WaitForNextTickAsync())
             {
                 await RefreshCamerasAsync();
+                await RefreshEventsAsync();
                 StateHasChanged();
             }
         }
@@ -317,8 +463,121 @@
     private async Task OnServerChangedAsync()
     {
         await RefreshCamerasAsync();
+        await RefreshEventsAsync();
         await SaveAsync();
     }
+
+    // ------------------------------------------------------------ recorded events
+
+    private IEnumerable<ApiEvent> FilteredEvents => _events
+        .Where(e => _eventCameraFilter.Length == 0 || e.Camera == _eventCameraFilter)
+        .Where(e => !_eventsUnreviewedOnly || !e.Reviewed);
+
+    private string EventArtifactUrl(ApiEvent ev, string kind) =>
+        $"{_server.TrimEnd('/')}/api/events/{Uri.EscapeDataString(ev.Id)}/{kind}";
+
+    private async Task RefreshEventsAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_server)) return;
+        try
+        {
+            using var res = await Http.GetAsync($"{_server.TrimEnd('/')}/api/events?limit=300");
+            if (!res.IsSuccessStatusCode)
+            {
+                _eventsSupported = false; // recording disabled on the server: hide the UI
+                return;
+            }
+            var list = await res.Content.ReadFromJsonAsync<List<ApiEvent>>();
+            _eventsSupported = true;
+            _events.Clear();
+            if (list != null) _events.AddRange(list);
+            // Keep an open player in sync (the clip appears once an ongoing event closes).
+            if (_playEvent != null)
+                _playEvent = _events.FirstOrDefault(e => e.Id == _playEvent.Id) ?? _playEvent;
+        }
+        catch
+        {
+            _eventsSupported = false;
+        }
+    }
+
+    private void OpenEvent(ApiEvent ev) => _playEvent = ev;
+    private void ClosePlayer() => _playEvent = null;
+
+    /// <summary>The adjacent event in the newest-first list (+1 = older, -1 = newer).</summary>
+    private ApiEvent? NeighborEvent(int direction)
+    {
+        if (_playEvent == null) return null;
+        int i = _events.FindIndex(e => e.Id == _playEvent.Id);
+        int target = i + direction;
+        return i < 0 || target < 0 || target >= _events.Count ? null : _events[target];
+    }
+
+    private async Task DismissAsync(ApiEvent ev)
+    {
+        if (!await PostEventReviewAsync(ev, reviewed: true)) return;
+        int i = _events.FindIndex(e => e.Id == ev.Id);
+        if (i >= 0) _events[i] = _events[i] with { Reviewed = true };
+        if (_playEvent?.Id == ev.Id) _playEvent = _playEvent with { Reviewed = true };
+    }
+
+    private async Task DismissAllAsync()
+    {
+        foreach (var ev in _events.Where(e => !e.Reviewed).ToList())
+        {
+            if (!await PostEventReviewAsync(ev, reviewed: true)) return; // e.g. auth failed: stop
+            int i = _events.FindIndex(e => e.Id == ev.Id);
+            if (i >= 0) _events[i] = _events[i] with { Reviewed = true };
+        }
+    }
+
+    private async Task<bool> PostEventReviewAsync(ApiEvent ev, bool reviewed)
+    {
+        try
+        {
+            var req = new HttpRequestMessage(HttpMethod.Post,
+                $"{_server.TrimEnd('/')}/api/events/{Uri.EscapeDataString(ev.Id)}/review");
+            if (!string.IsNullOrEmpty(_user))
+            {
+                var token = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes($"{_user}:{_pass}"));
+                req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", token);
+            }
+            req.Content = JsonContent.Create(new { reviewed });
+            using var res = await Http.SendAsync(req);
+            if (res.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+            {
+                _error = "Not authorized — set your credentials under server settings (⚙).";
+                return false;
+            }
+            return res.IsSuccessStatusCode;
+        }
+        catch (Exception ex)
+        {
+            _error = $"Cannot reach {_server}: {ex.Message}";
+            return false;
+        }
+    }
+
+    private static string Ago(DateTime utc)
+    {
+        var span = DateTime.UtcNow - utc.ToUniversalTime();
+        if (span < TimeSpan.Zero) span = TimeSpan.Zero;
+        return span.TotalSeconds < 60 ? "just now"
+            : span.TotalMinutes < 60 ? $"{(int)span.TotalMinutes}m ago"
+            : span.TotalHours < 24 ? $"{(int)span.TotalHours}h ago"
+            : $"{(int)span.TotalDays}d ago";
+    }
+
+    private static string DayLabel(DateTime day) =>
+        day == DateTime.Now.Date ? "TODAY"
+        : day == DateTime.Now.Date.AddDays(-1) ? "YESTERDAY"
+        : day.ToString("dddd, d MMMM").ToUpperInvariant();
+
+    private static string DurationText(ApiEvent ev) =>
+        ev.Ongoing ? "recording…"
+        : ev.Duration.TotalSeconds < 1 ? "<1s"
+        : ev.Duration.TotalSeconds < 90 ? $"{(int)Math.Ceiling(ev.Duration.TotalSeconds)}s"
+        : $"{(int)Math.Round(ev.Duration.TotalMinutes)} min";
 
     // ------------------------------------------------------------ layout
 

--- a/src/Neolink.WebClient/Models.cs
+++ b/src/Neolink.WebClient/Models.cs
@@ -42,6 +42,43 @@ public sealed record ApiEncodeProfile(string Type, uint Width, uint Height,
 /// <summary>GET /api/cameras/{name}/streaminfo — the encode profiles of each stream.</summary>
 public sealed record ApiStreamProfiles(List<ApiEncodeProfile> Profiles);
 
+// ------------------------------------------------------------ recorded events
+
+/// <summary>GET /api/events — one recorded detection event.</summary>
+public sealed record ApiEvent(string Id, string Camera, DateTime Start, DateTime End,
+    List<string> Labels, bool Reviewed, bool Ongoing, bool HasClip, bool HasThumb)
+{
+    private static readonly (string Label, string Icon, string Name)[] Known =
+    {
+        ("person", "🧍", "Human"),
+        ("vehicle", "🚗", "Vehicle"),
+        ("animal", "🐾", "Animal"),
+        ("package", "📦", "Package"),
+        ("motion", "👁", "Motion"),
+    };
+
+    /// <summary>Leading icon: the most specific detection wins over plain motion.</summary>
+    public string Icon =>
+        Known.FirstOrDefault(k => Labels.Contains(k.Label)).Icon ?? "👁";
+
+    /// <summary>"Human detected", "Human + Vehicle detected", ...</summary>
+    public string Title
+    {
+        get
+        {
+            var names = Known.Where(k => Labels.Contains(k.Label)).Select(k => k.Name)
+                .Concat(Labels.Where(l => Known.All(k => k.Label != l)).Select(Cap))
+                .Distinct().ToList();
+            if (names.Count == 0) names.Add("Motion");
+            return string.Join(" + ", names) + " detected";
+        }
+    }
+
+    public TimeSpan Duration => End > Start ? End - Start : TimeSpan.Zero;
+
+    private static string Cap(string s) => s.Length == 0 ? s : char.ToUpperInvariant(s[0]) + s[1..];
+}
+
 /// <summary>One grid slot: which camera/stream is shown there (or empty).</summary>
 public sealed class ViewSlot
 {

--- a/src/Neolink.WebClient/wwwroot/css/app.css
+++ b/src/Neolink.WebClient/wwwroot/css/app.css
@@ -557,6 +557,213 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
     gap: 6px;
 }
 
+/* ------------------------------------------------------------ events (NVR) */
+
+/* Frigate-style review strip across the top of the stage */
+.events-bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    background: var(--panel);
+    border-bottom: 1px solid var(--line);
+    min-height: 64px;
+}
+
+.events-bar-count {
+    font-size: 12px;
+    color: var(--accent);
+    white-space: nowrap;
+    font-weight: 600;
+}
+
+.events-bar-scroll {
+    display: flex;
+    gap: 8px;
+    overflow-x: auto;
+    scrollbar-width: thin;
+    flex: 1;
+    padding: 2px 0;
+}
+
+.event-card {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--bg);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 4px 6px;
+    cursor: pointer;
+    flex: 0 0 auto;
+    max-width: 260px;
+}
+
+.event-card:hover { border-color: var(--accent); }
+.event-card.live { border-color: var(--err); }
+
+.event-thumb {
+    position: relative;
+    width: 84px;
+    height: 48px;
+    border-radius: 5px;
+    overflow: hidden;
+    background: #000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+}
+
+.event-thumb img { width: 100%; height: 100%; object-fit: cover; }
+.event-thumb-icon { font-size: 22px; opacity: 0.8; }
+
+.event-live {
+    position: absolute;
+    left: 4px;
+    top: 3px;
+    font-size: 9px;
+    font-weight: 700;
+    color: #fff;
+    background: var(--err);
+    border-radius: 3px;
+    padding: 0 4px;
+    animation: event-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes event-pulse { 50% { opacity: 0.45; } }
+
+.event-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.event-title {
+    font-size: 12px;
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.event-sub {
+    font-size: 11px;
+    color: var(--muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.event-dismiss { flex: 0 0 auto; }
+.events-clear { flex: 0 0 auto; }
+
+/* Event history panel (reuses the campanel chrome) */
+.events-panel .event-filter {
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    font-size: 12px;
+    padding: 3px 6px;
+    max-width: 130px;
+}
+
+.event-day-count {
+    color: var(--muted);
+    font-weight: 400;
+    margin-left: 6px;
+}
+
+.event-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 4px;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.event-row:hover { background: var(--bg); }
+.event-row.reviewed { opacity: 0.55; }
+
+.event-row-time {
+    font-size: 11px;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+    flex: 0 0 auto;
+}
+
+.event-row-icon { font-size: 16px; flex: 0 0 auto; }
+
+.event-row-main {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
+    flex: 1;
+}
+
+/* Playback modal */
+.player-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.7);
+    z-index: 62;
+}
+
+.event-player {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    width: min(920px, calc(100vw - 32px));
+    height: fit-content;
+    max-height: calc(100vh - 32px);
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    z-index: 63;
+    display: flex;
+    flex-direction: column;
+    padding: 12px;
+    gap: 10px;
+    box-shadow: 0 18px 60px rgba(0, 0, 0, 0.6);
+}
+
+.event-player-head {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+}
+
+.event-player-title {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    flex: 1;
+    min-width: 0;
+}
+
+.event-player-title .event-title { font-size: 15px; }
+
+.event-player video {
+    width: 100%;
+    max-height: calc(100vh - 180px);
+    background: #000;
+    border-radius: 8px;
+    outline: none;
+}
+
+.event-player-foot {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+/* ------------------------------------------------------------ stream chips */
+
 .stream-chip { cursor: default; }
 .stream-chip:hover { border-color: var(--line); color: var(--text); }
 


### PR DESCRIPTION
> **Stacked on #1** (stream settings via the Reolink HTTP API) — this PR targets that branch so the diff shows only the event-recording work. Retarget to `main` after #1 merges.

## What

Turns Neolink.NET into a lightweight NVR: the camera's own motion/AI detections (person, vehicle, animal) become stored, labeled events with video clips, thumbnails, a Frigate-style review strip, playback, and retention. No polling and no server-side ML — detections are pushed by the camera over the existing Baichuan connection, and classification happens on-camera.

### Server
- **Detection capture**: `BcCamera.WatchMotionAsync` opts in with msg 31 and parses msg 33 `AlarmEventList` pushes (status + `AItype`, lenient about firmware variants). `SnapAsync` fetches the camera's JPEG snapshot (msg 109, multi-part reassembly) for event thumbnails — zero server-side decoding. Both ride the primary stream connection; a camera that declines motion pushes logs a warning and streams on unaffected.
- **`Recording/EventRecorder`**: event lifecycle with grouping — one event spans a burst of activity, labels accumulate (a person walking to their car is one *person + vehicle* event), closes after `post_seconds` of quiet or the `max_clip_seconds` cap. A keyframe-aligned pre-roll buffer means clips include the seconds *before* the detection.
- **`Recording/ClipWriter`**: fragmented MP4 to disk (H.264/H.265 passthrough, video-only), reusing the existing muxer and the live web player's frame-pacing approach.
- **`Recording/EventStore`**: plain-file storage — `{path}/{camera}/{date}/{time}-{id}/{event.json, clip.mp4, thumb.jpg}` — with a scan-on-startup index, atomic JSON writes, and hourly retention that deletes day folders older than `retention_days`. Deliberately no database (zero-dependency rule); backups and external tooling stay trivial.
- **Config**: new `recording` section (`path`, `retention_days`, `pre_seconds`, `post_seconds`, `max_clip_seconds`, `stream`) in JSON and TOML, per-camera `"record": false` opt-out. `docker-compose.yml` shows the `./recordings:/recordings` volume.
- **API**: `GET /api/events` (camera/reviewed/limit filters), `GET /api/events/{id}/clip` (HTTP range support for seeking) and `/thumb`, `POST /api/events/{id}/review` behind the existing Basic-auth rules.

### Web UI
- **Review strip across the top** (Frigate-style): labeled thumbnail cards ("🧍 Human detected · driveway · 2m ago"), pulsing REC badge while an event is still recording, ✕ dismisses a card (mark reviewed), "Clear all" for bulk dismissal; the strip disappears once everything is reviewed and hides entirely when the server has recording disabled.
- **Playback modal**: clip player with older/newer navigation and mark-reviewed.
- **🕘 Events history panel**: grouped by day (Today / Yesterday / date) with camera and unreviewed-only filters.

## Reviewer notes
- **Tested**: 17/17 self-tests, including three new ones (label mapping, event-store roundtrip + retention, clip-writer fMP4 structure). Live smoke test: seeded events indexed at startup, expired day folder removed by retention, list/thumb/clip/review endpoints verified, review flag persisted to disk, web UI renders.
- **Not tested on hardware**: the exact msg 33 push format from a real camera. Parsing is deliberately lenient (raw XML, tolerant of `AItype` variants) and failures degrade to log warnings, never broken streaming. `--verbose` shows pushes as they arrive.
- Clips are video-only by design; the fMP4 muxer has a single video track. Audio in clips would be a follow-up.
- Event timestamps are stamped server-side on push arrival (sub-second accuracy; the pushes carry no usable timestamp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)