### PR TITLE
Continuous 24/7 recording, per-camera switches, event-type filter; fix near-empty clips

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,13 +236,23 @@ the original Rust neolink are also accepted.
 | `users` | *(none)* | RTSP Basic-auth users: `{ "name", "pass" }`. Omit for open access |
 | `recording` | *(none)* | Event recording (see below). Omit to disable |
 
-### Event recording (`"recording": { ... }`)
+### Recording (`"recording": { ... }`)
 
-Captures the camera's own motion/AI detections (person, vehicle, animal — pushed
-over the Baichuan connection, no polling and no server-side ML) as labeled events
-with video clips and thumbnails. New events appear in a review strip at the top of
-the web UI; click to play, ✕ to dismiss. The 🕘 Events button opens the full
-history grouped by day.
+Two recording modes, both switchable **per camera at runtime** from the web UI
+(camera ⚙ → RECORDING) — the switches persist in `settings.json` inside the
+storage directory, so they survive restarts and live on the same Docker volume
+as the footage:
+
+- **Detection events**: the camera's own motion/AI detections (person, vehicle,
+  animal — pushed over the Baichuan connection, no polling and no server-side ML)
+  become labeled events with video clips and thumbnails. New events appear in a
+  review strip at the top of the web UI; click to play, ✕ to dismiss. The 🕘
+  Events button opens the full history grouped by day. Per camera you can also
+  pick **which detection types to record** (🧍 person, 🚗 vehicle, 🐾 animal,
+  📦 package, 👁 motion) — detections of disabled types are discarded entirely.
+- **Continuous (24/7)**: classic NVR-style recording into rolling
+  `segment_minutes`-long MP4 files, browsable under 🕘 → Recordings (grouped by
+  day, click to play). Off by default; enable per camera in the UI.
 
 | Option | Default | Description |
 |---|---|---|
@@ -252,12 +262,15 @@ history grouped by day.
 | `post_seconds` | `8` | Quiet time after the last detection before the event closes |
 | `max_clip_seconds` | `120` | Hard cap per event; continued activity starts a new event |
 | `stream` | `auto` | Stream to record: `auto` (main if served), `mainStream`, `subStream` |
+| `segment_minutes` | `10` | Continuous recording: length of one segment file |
+| `continuous_retention_days` | = `retention_days` | Days to keep continuous footage (`0` = forever) |
 
-Clips are fragmented MP4 (H.264/H.265 passthrough, video-only) playable in the
-browser and by ffmpeg/VLC. Storage layout is plain files —
-`recordings/<camera>/<date>/<time>-<id>/{event.json, clip.mp4, thumb.jpg}` — so
-backups and external tooling are trivial. Set `"record": false` on a camera to
-exclude it.
+Everything is fragmented MP4 (H.264/H.265 passthrough, video-only) playable in
+the browser and by ffmpeg/VLC. Storage layout is plain files —
+`recordings/<camera>/<date>/<time>-<id>/{event.json, clip.mp4, thumb.jpg}` for
+events, `recordings/<camera>/continuous/<date>/<HH-mm-ss>.mp4` for 24/7 footage —
+so backups and external tooling are trivial. Set `"record": false` on a camera
+to start with events off (the UI switch can re-enable it).
 
 ### Per camera
 
@@ -270,7 +283,7 @@ exclude it.
 | `stream` | `both` | `mainStream`, `subStream`, `externStream`, `both`, or `all` |
 | `channel_id` | `0` | Channel when connecting through a Reolink NVR (0-based) |
 | `permitted_users` | all users | Restrict this camera's mounts to specific `users` |
-| `record` | `true` | Include this camera in event recording (when `recording` is configured) |
+| `record` | `true` | Initial default for this camera's "Detection events" switch (changeable in the web UI) |
 
 ## Using with Frigate
 

--- a/src/Neolink.Server/Config/NeolinkConfig.cs
+++ b/src/Neolink.Server/Config/NeolinkConfig.cs
@@ -161,6 +161,8 @@ public sealed class NeolinkConfig
                 case "postseconds": rec.PostSeconds = prop.Value.GetInt32(); break;
                 case "maxclipseconds": rec.MaxClipSeconds = prop.Value.GetInt32(); break;
                 case "stream": rec.Stream = prop.Value.GetString() ?? "auto"; break;
+                case "segmentminutes": rec.SegmentMinutes = prop.Value.GetInt32(); break;
+                case "continuousretentiondays": rec.ContinuousRetentionDays = prop.Value.GetInt32(); break;
                 default:
                     Log.Warn($"Config: ignoring unknown recording option '{prop.Name}'");
                     break;
@@ -202,6 +204,8 @@ public sealed class NeolinkConfig
                 PostSeconds = (int)(MiniToml.GetInt(rec, "post_seconds") ?? 8),
                 MaxClipSeconds = (int)(MiniToml.GetInt(rec, "max_clip_seconds") ?? 120),
                 Stream = MiniToml.GetString(rec, "stream") ?? "auto",
+                SegmentMinutes = (int)(MiniToml.GetInt(rec, "segment_minutes") ?? 10),
+                ContinuousRetentionDays = (int?)MiniToml.GetInt(rec, "continuous_retention_days"),
             };
         }
 
@@ -316,6 +320,10 @@ public sealed class NeolinkConfig
                 throw new FormatException("recording.max_clip_seconds must be 10..3600");
             if (Recording.Stream is not ("auto" or "mainStream" or "subStream" or "externStream"))
                 throw new FormatException("recording.stream must be auto, mainStream, subStream or externStream");
+            if (Recording.SegmentMinutes is < 1 or > 120)
+                throw new FormatException("recording.segment_minutes must be 1..120");
+            if (Recording.ContinuousRetentionDays is < 0)
+                throw new FormatException("recording.continuous_retention_days must be >= 0 (0 = keep forever)");
         }
     }
 
@@ -364,6 +372,12 @@ public sealed class RecordingConfig
     public int MaxClipSeconds { get; set; } = 120;
     /// <summary>Stream to record: "auto" (main if served, else first), or an explicit stream name.</summary>
     public string Stream { get; set; } = "auto";
+    /// <summary>Length of one continuous-recording segment file, in minutes.</summary>
+    public int SegmentMinutes { get; set; } = 10;
+    /// <summary>Days to keep continuous footage; null = same as RetentionDays.</summary>
+    public int? ContinuousRetentionDays { get; set; }
+
+    public int EffectiveContinuousRetentionDays => ContinuousRetentionDays ?? RetentionDays;
 }
 
 public sealed class CameraConfig

--- a/src/Neolink.Server/Program.cs
+++ b/src/Neolink.Server/Program.cs
@@ -93,17 +93,21 @@ var server = new RtspServer(users);
 var tasks = new List<Task>();
 var webCameras = new List<WebCameraInfo>();
 
-// Event recording (motion/AI detections + clips), when a storage path is configured.
+// Recording (detection events + continuous), when a storage path is configured.
 EventStore? eventStore = null;
+RecordingSettings? recordingSettings = null;
 if (config.Recording is { } recCfg)
 {
     try
     {
         eventStore = new EventStore(recCfg.Path);
         eventStore.Load();
-        Log.Info($"Recording events to {eventStore.Root} " +
-                 $"(retention: {(recCfg.RetentionDays > 0 ? $"{recCfg.RetentionDays} days" : "forever")})");
-        tasks.Add(Task.Run(() => eventStore.RunRetentionAsync(recCfg.RetentionDays, shutdown.Token)));
+        recordingSettings = new RecordingSettings(eventStore.Root);
+        Log.Info($"Recording to {eventStore.Root} " +
+                 $"(events: {(recCfg.RetentionDays > 0 ? $"{recCfg.RetentionDays} days" : "forever")}, " +
+                 $"continuous: {(recCfg.EffectiveContinuousRetentionDays > 0 ? $"{recCfg.EffectiveContinuousRetentionDays} days" : "forever")})");
+        tasks.Add(Task.Run(() => eventStore.RunRetentionAsync(
+            recCfg.RetentionDays, recCfg.EffectiveContinuousRetentionDays, shutdown.Token)));
     }
     catch (Exception ex)
     {
@@ -150,9 +154,12 @@ foreach (var cam in config.Cameras)
         ?? throw new InvalidOperationException($"camera '{cam.Name}' has no streams"), httpApi);
     webCameras.Add(new WebCameraInfo(cam.Name, webStreams, control, permitted));
 
-    // Event recording: alarm pushes ride the primary connection; clips are cut from
-    // the configured stream's hub (auto = main when served, else the first stream).
-    if (eventStore != null && cam.Record)
+    // Recording: alarm pushes ride the primary connection; event clips and
+    // continuous segments are cut from the configured stream's hub (auto = main
+    // when served, else the first stream). The per-camera on/off switches live in
+    // RecordingSettings and are flipped from the web UI at runtime; the config's
+    // "record" flag only seeds the initial events default.
+    if (eventStore != null && recordingSettings != null)
     {
         var recordStream = config.Recording!.Stream == "auto"
             ? webStreams.FirstOrDefault(s => s.Kind == "mainStream") ?? webStreams[0]
@@ -160,13 +167,19 @@ foreach (var cam in config.Cameras)
         if (recordStream == null)
         {
             Log.Warn($"{cam.Name}: recording.stream '{config.Recording.Stream}' is not served " +
-                     $"by this camera (stream = \"{cam.Stream}\"); events disabled for it");
+                     $"by this camera (stream = \"{cam.Stream}\"); recording disabled for it");
         }
         else
         {
-            var recorder = new EventRecorder(cam.Name, recordStream.Hub, control, eventStore, config.Recording);
+            recordingSettings.Seed(cam.Name, eventsDefault: cam.Record);
+            var recorder = new EventRecorder(cam.Name, recordStream.Hub, control, eventStore,
+                config.Recording, recordingSettings);
             primaryService.MotionSink = recorder.OnMotion;
             tasks.Add(Task.Run(() => recorder.RunAsync(shutdown.Token)));
+
+            var continuous = new ContinuousRecorder(cam.Name, recordStream.Hub, eventStore,
+                recordingSettings, config.Recording);
+            tasks.Add(Task.Run(() => continuous.RunAsync(shutdown.Token)));
         }
     }
 }
@@ -179,7 +192,7 @@ if (config.WebPort > 0)
         try
         {
             await WebApi.RunAsync(config.WebBind ?? config.BindAddr, config.WebPort, config.WebUi,
-                webCameras, users, config.BindPort, eventStore, shutdown.Token);
+                webCameras, users, config.BindPort, eventStore, recordingSettings, shutdown.Token);
         }
         catch (OperationCanceledException) { }
         catch (Exception ex)

--- a/src/Neolink.Server/Recording/ClipWriter.cs
+++ b/src/Neolink.Server/Recording/ClipWriter.cs
@@ -21,8 +21,7 @@ public sealed class ClipWriter : IDisposable
     private ulong _decodeTime;
     private bool _haveTs;
     private uint _prevTs;
-    private long _lastIndex = -1;
-    private bool _waitKeyframe;
+    private bool _waitKeyframe = true; // clips must start decodable
     private List<(byte[] Sample, bool Keyframe)>? _pending;
 
     private ClipWriter(FileStream file, VideoCodec codec)
@@ -58,13 +57,15 @@ public sealed class ClipWriter : IDisposable
     }
 
     /// <summary>
-    /// Feeds the next video packet. Must be called with packets in hub order;
-    /// drops (index gaps) are handled by resuming at the next keyframe.
+    /// Feeds the next video packet, in hub order. <paramref name="gap"/> signals that
+    /// packets were dropped since the previous one — the caller must derive it from
+    /// the hub index of EVERY packet (audio included): hub indices are global, so a
+    /// video-only view sees non-consecutive indices whenever audio is interleaved,
+    /// and treating those as drops would silently discard all P-frames.
+    /// After a real drop, writing resumes at the next keyframe.
     /// </summary>
-    public void Add(HubVideo v)
+    public void Add(HubVideo v, bool gap = false)
     {
-        bool gap = _lastIndex >= 0 && v.Index != _lastIndex + 1;
-        _lastIndex = v.Index;
         if (gap)
         {
             FlushPending((uint)(NominalFrame * (_pending?.Count ?? 1)));

--- a/src/Neolink.Server/Recording/ContinuousRecorder.cs
+++ b/src/Neolink.Server/Recording/ContinuousRecorder.cs
@@ -1,0 +1,118 @@
+using Neolink.Config;
+using Neolink.Streaming;
+
+namespace Neolink.Recording;
+
+/// <summary>
+/// 24/7 recording to rolling fMP4 segment files, like a classic NVR:
+/// {root}/{camera}/continuous/{yyyy-MM-dd}/{HH-mm-ss}.mp4.
+///
+/// Toggleable at runtime (web UI → RecordingSettings): the hub subscription stays
+/// open either way, packets are simply discarded while the switch is off, so a
+/// toggle takes effect on the next frame. Segments roll at the first keyframe
+/// after SegmentMinutes, keeping every file independently playable. Day folders
+/// are pruned by the same retention task that expires events.
+/// </summary>
+public sealed class ContinuousRecorder
+{
+    /// <summary>After a write failure (disk full, volume gone) don't retry instantly.</summary>
+    private static readonly TimeSpan WriteErrorBackoff = TimeSpan.FromSeconds(30);
+
+    private readonly string _camera;
+    private readonly IStreamHub _hub;
+    private readonly EventStore _store;
+    private readonly RecordingSettings _settings;
+    private readonly double _segmentSeconds;
+
+    public ContinuousRecorder(string camera, IStreamHub hub, EventStore store,
+        RecordingSettings settings, RecordingConfig cfg)
+    {
+        _camera = camera;
+        _hub = hub;
+        _store = store;
+        _settings = settings;
+        _segmentSeconds = cfg.SegmentMinutes * 60.0;
+    }
+
+    public async Task RunAsync(CancellationToken ct)
+    {
+        var (id, reader) = _hub.Subscribe();
+        ClipWriter? writer = null;
+        bool wasOn = false;
+        long lastIndex = -1;
+        var retryAfter = DateTime.MinValue;
+
+        try
+        {
+            await foreach (var packet in reader.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                // Hub indices are global across video and audio — see EventRecorder.
+                bool gap = lastIndex >= 0 && packet.Index != lastIndex + 1;
+                lastIndex = packet.Index;
+                if (packet is not HubVideo v) continue;
+
+                bool on = _settings.Get(_camera).Continuous;
+                if (!on)
+                {
+                    if (writer != null)
+                    {
+                        writer.Dispose();
+                        writer = null;
+                        Log.Info($"{_camera}: continuous recording stopped");
+                    }
+                    wasOn = false;
+                    continue;
+                }
+                if (!wasOn)
+                {
+                    Log.Info($"{_camera}: continuous recording started " +
+                             $"({_segmentSeconds / 60:0}-minute segments)");
+                    wasOn = true;
+                }
+
+                // Roll to a new file at the first keyframe past the segment length.
+                if (writer != null && v.Keyframe && writer.DurationSeconds >= _segmentSeconds)
+                {
+                    writer.Dispose();
+                    writer = null;
+                }
+
+                if (writer == null)
+                {
+                    // Every segment starts on a keyframe so it plays standalone.
+                    if (!v.Keyframe || DateTime.UtcNow < retryAfter) continue;
+                    try
+                    {
+                        writer = ClipWriter.TryCreate(_store.NewSegmentPath(_camera, DateTime.Now), _hub);
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Warn($"{_camera}: cannot start recording segment: {ex.Message}");
+                        retryAfter = DateTime.UtcNow + WriteErrorBackoff;
+                        continue;
+                    }
+                    if (writer == null) continue; // codec parameters not known yet
+                    gap = false; // fresh file: this keyframe is a clean start
+                }
+
+                try
+                {
+                    writer.Add(v, gap);
+                }
+                catch (Exception ex)
+                {
+                    Log.Warn($"{_camera}: segment write failed: {ex.Message}");
+                    writer.Dispose();
+                    writer = null;
+                    retryAfter = DateTime.UtcNow + WriteErrorBackoff;
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+        finally
+        {
+            writer?.Dispose();
+            _hub.Unsubscribe(id);
+        }
+    }
+}

--- a/src/Neolink.Server/Recording/EventRecorder.cs
+++ b/src/Neolink.Server/Recording/EventRecorder.cs
@@ -27,24 +27,28 @@ public sealed class EventRecorder
     private readonly ICameraControl _control;
     private readonly EventStore _store;
     private readonly RecordingConfig _cfg;
+    private readonly RecordingSettings _settings;
 
     private readonly Channel<MotionPush> _pushes = Channel.CreateUnbounded<MotionPush>(
         new UnboundedChannelOptions { SingleReader = true });
 
     // Pre-roll buffer and clip writer are handed between the pump and the event
     // loop under one gate; both touch them briefly (local file I/O only).
+    // Each buffered packet carries its drop flag so a clip started later still
+    // knows where the stream was discontinuous.
     private readonly object _mediaGate = new();
-    private readonly List<HubVideo> _preroll = new();
+    private readonly List<(HubVideo Video, bool Gap)> _preroll = new();
     private ClipWriter? _writer;
 
     public EventRecorder(string camera, IStreamHub hub, ICameraControl control,
-        EventStore store, RecordingConfig cfg)
+        EventStore store, RecordingConfig cfg, RecordingSettings settings)
     {
         _camera = camera;
         _hub = hub;
         _control = control;
         _store = store;
         _cfg = cfg;
+        _settings = settings;
     }
 
     public string Camera => _camera;
@@ -78,8 +82,16 @@ public sealed class EventRecorder
         var (id, reader) = _hub.Subscribe();
         try
         {
+            // The hub index is global across video AND audio packets, so it must be
+            // tracked for every packet — a video-only view sees non-consecutive
+            // indices whenever audio is interleaved, and treating those as drops
+            // would discard all P-frames (0-second clips).
+            long lastIndex = -1;
             await foreach (var packet in reader.ReadAllAsync(ct).ConfigureAwait(false))
             {
+                bool gap = lastIndex >= 0 && packet.Index != lastIndex + 1;
+                lastIndex = packet.Index;
+
                 if (packet is not HubVideo v) continue;
                 lock (_mediaGate)
                 {
@@ -87,7 +99,7 @@ public sealed class EventRecorder
                     {
                         try
                         {
-                            _writer.Add(v);
+                            _writer.Add(v, gap);
                         }
                         catch (Exception ex)
                         {
@@ -98,7 +110,7 @@ public sealed class EventRecorder
                     }
                     else
                     {
-                        _preroll.Add(v);
+                        _preroll.Add((v, gap));
                         TrimPreroll();
                     }
                 }
@@ -119,12 +131,12 @@ public sealed class EventRecorder
     private void TrimPreroll()
     {
         uint want = (uint)_cfg.PreSeconds * FMp4.Timescale;
-        uint last = _preroll[^1].RtpTs;
+        uint last = _preroll[^1].Video.RtpTs;
         int cut = -1;
         for (int i = _preroll.Count - 1; i >= 0; i--)
         {
-            if (!_preroll[i].Keyframe) continue;
-            if (unchecked(last - _preroll[i].RtpTs) >= want)
+            if (!_preroll[i].Video.Keyframe) continue;
+            if (unchecked(last - _preroll[i].Video.RtpTs) >= want)
             {
                 cut = i;
                 break;
@@ -154,9 +166,16 @@ public sealed class EventRecorder
             }
             if (!push.Active) continue; // stray all-clear with no open event
 
+            // Runtime switches (web UI): events off, or every label of this push
+            // filtered out by the camera's event-type selection → discard silently.
+            var settings = _settings.Get(_camera);
+            if (!settings.Events) continue;
+            var labels = LabelsOf(push).Where(settings.AllowsLabel).ToList();
+            if (labels.Count == 0) continue;
+
             try
             {
-                await RunEventAsync(push, ct).ConfigureAwait(false);
+                await RunEventAsync(labels, ct).ConfigureAwait(false);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
@@ -165,10 +184,10 @@ public sealed class EventRecorder
         }
     }
 
-    private async Task RunEventAsync(MotionPush first, CancellationToken ct)
+    private async Task RunEventAsync(List<string> initialLabels, CancellationToken ct)
     {
         var rec = _store.Create(_camera,
-            DateTime.UtcNow - TimeSpan.FromSeconds(_cfg.PreSeconds), LabelsOf(first));
+            DateTime.UtcNow - TimeSpan.FromSeconds(_cfg.PreSeconds), initialLabels);
         Log.Info($"{_camera}: ⚡ event started ({string.Join("+", rec.Labels)})");
 
         StartClip(rec);
@@ -199,8 +218,12 @@ public sealed class EventRecorder
 
             if (push.Active)
             {
+                // Filtered-out detection types don't extend the event either —
+                // as far as recording is concerned, they never happened.
+                var allowed = LabelsOf(push).Where(_settings.Get(_camera).AllowsLabel).ToList();
+                if (allowed.Count == 0) continue;
                 active = true;
-                var fresh = LabelsOf(push).Where(l => !rec.Labels.Contains(l)).ToList();
+                var fresh = allowed.Where(l => !rec.Labels.Contains(l)).ToList();
                 if (fresh.Count > 0)
                 {
                     rec.Labels.AddRange(fresh);
@@ -241,8 +264,8 @@ public sealed class EventRecorder
                     Log.Warn($"{_camera}: stream not ready; event stored without a clip");
                     return;
                 }
-                foreach (var v in _preroll)
-                    _writer.Add(v);
+                foreach (var (v, gap) in _preroll)
+                    _writer.Add(v, gap);
                 _preroll.Clear();
             }
             catch (Exception ex)

--- a/src/Neolink.Server/Recording/EventStore.cs
+++ b/src/Neolink.Server/Recording/EventStore.cs
@@ -158,31 +158,101 @@ public sealed class EventStore
         }
     }
 
-    /// <summary>Deletes day directories older than the retention window.</summary>
-    public void Cleanup(int retentionDays)
-    {
-        if (retentionDays <= 0) return;
-        var cutoff = DateTime.Now.Date.AddDays(-retentionDays);
-        int removed = 0;
+    // ------------------------------------------------------------------ continuous recordings
 
+    /// <summary>Path for a new continuous-recording segment starting now (creates the day dir).</summary>
+    public string NewSegmentPath(string camera, DateTime local)
+    {
+        var dir = Path.Combine(_root, SafeName(camera), "continuous", $"{local:yyyy-MM-dd}");
+        Directory.CreateDirectory(dir);
+        return Path.Combine(dir, $"{local:HH-mm-ss}.mp4");
+    }
+
+    /// <summary>Days with continuous footage for a camera, newest first ("yyyy-MM-dd").</summary>
+    public List<string> ListContinuousDays(string camera)
+    {
+        var dir = Path.Combine(_root, SafeName(camera), "continuous");
+        if (!Directory.Exists(dir)) return new List<string>();
+        return Directory.EnumerateDirectories(dir)
+            .Select(d => Path.GetFileName(d)!)
+            .Where(IsDayName)
+            .OrderByDescending(d => d)
+            .ToList();
+    }
+
+    /// <summary>Segment files of one day, oldest first: (file name, size in bytes).</summary>
+    public List<(string File, long Size)> ListSegments(string camera, string date)
+    {
+        if (!IsDayName(date)) return new List<(string, long)>();
+        var dir = Path.Combine(_root, SafeName(camera), "continuous", date);
+        if (!Directory.Exists(dir)) return new List<(string, long)>();
+        return Directory.EnumerateFiles(dir, "*.mp4")
+            .Select(f => new FileInfo(f))
+            .Where(f => IsSegmentName(f.Name))
+            .OrderBy(f => f.Name)
+            .Select(f => (f.Name, f.Length))
+            .ToList();
+    }
+
+    /// <summary>Absolute path of one segment; strict name validation (no traversal).</summary>
+    public string? SegmentPath(string camera, string date, string file)
+    {
+        if (!IsDayName(date) || !IsSegmentName(file)) return null;
+        var path = Path.Combine(_root, SafeName(camera), "continuous", date, file);
+        return File.Exists(path) ? path : null;
+    }
+
+    private static bool IsDayName(string s) =>
+        s.Length == 10 && DateTime.TryParseExact(s, "yyyy-MM-dd",
+            null, System.Globalization.DateTimeStyles.None, out _);
+
+    private static bool IsSegmentName(string s) =>
+        s.Length == 12 && s.EndsWith(".mp4", StringComparison.OrdinalIgnoreCase)
+        && s[..8].Replace("-", "").All(char.IsAsciiDigit) && s[2] == '-' && s[5] == '-';
+
+    // ------------------------------------------------------------------ retention
+
+    /// <summary>Deletes event and continuous day directories older than their retention windows.</summary>
+    public void Cleanup(int retentionDays, int continuousRetentionDays)
+    {
+        int events = 0, segments = 0;
         foreach (var cameraDir in Directory.EnumerateDirectories(_root))
         {
-            foreach (var dayDir in Directory.EnumerateDirectories(cameraDir))
+            if (retentionDays > 0)
+                events += CleanupDayDirs(cameraDir, DateTime.Now.Date.AddDays(-retentionDays), dropIndex: true);
+
+            var contDir = Path.Combine(cameraDir, "continuous");
+            if (continuousRetentionDays > 0 && Directory.Exists(contDir))
+                segments += CleanupDayDirs(contDir, DateTime.Now.Date.AddDays(-continuousRetentionDays), dropIndex: false);
+        }
+        if (events > 0)
+            Log.Info($"Events: retention removed {events} expired day folder(s) (older than {retentionDays}d)");
+        if (segments > 0)
+            Log.Info($"Recordings: retention removed {segments} expired day folder(s) (older than {continuousRetentionDays}d)");
+    }
+
+    private int CleanupDayDirs(string parent, DateTime cutoff, bool dropIndex)
+    {
+        int removed = 0;
+        foreach (var dayDir in Directory.EnumerateDirectories(parent))
+        {
+            // Non-date entries (e.g. the "continuous" folder itself) are skipped here.
+            if (!DateTime.TryParseExact(Path.GetFileName(dayDir), "yyyy-MM-dd",
+                    null, System.Globalization.DateTimeStyles.None, out var day)
+                || day >= cutoff)
+                continue;
+            try
             {
-                if (!DateTime.TryParseExact(Path.GetFileName(dayDir), "yyyy-MM-dd",
-                        null, System.Globalization.DateTimeStyles.None, out var day)
-                    || day >= cutoff)
-                    continue;
-                try
-                {
-                    Directory.Delete(dayDir, recursive: true);
-                    removed++;
-                }
-                catch (IOException ex)
-                {
-                    Log.Warn($"Events: cannot delete expired {dayDir}: {ex.Message}");
-                    continue;
-                }
+                Directory.Delete(dayDir, recursive: true);
+                removed++;
+            }
+            catch (IOException ex)
+            {
+                Log.Warn($"Retention: cannot delete expired {dayDir}: {ex.Message}");
+                continue;
+            }
+            if (dropIndex)
+            {
                 lock (_gate)
                 {
                     foreach (var id in _byId.Where(kv => kv.Value.Dir.StartsWith(dayDir, StringComparison.OrdinalIgnoreCase))
@@ -191,16 +261,15 @@ public sealed class EventStore
                 }
             }
         }
-        if (removed > 0)
-            Log.Info($"Events: retention removed {removed} expired day folder(s) (older than {retentionDays}d)");
+        return removed;
     }
 
     /// <summary>Runs retention cleanup once at start and then hourly.</summary>
-    public async Task RunRetentionAsync(int retentionDays, CancellationToken ct)
+    public async Task RunRetentionAsync(int retentionDays, int continuousRetentionDays, CancellationToken ct)
     {
         while (!ct.IsCancellationRequested)
         {
-            try { Cleanup(retentionDays); }
+            try { Cleanup(retentionDays, continuousRetentionDays); }
             catch (Exception ex) { Log.Warn($"Events: retention pass failed: {Log.Flatten(ex)}"); }
             try { await Task.Delay(TimeSpan.FromHours(1), ct).ConfigureAwait(false); }
             catch (OperationCanceledException) { return; }

--- a/src/Neolink.Server/Recording/RecordingSettings.cs
+++ b/src/Neolink.Server/Recording/RecordingSettings.cs
@@ -1,0 +1,111 @@
+using System.Text.Json;
+
+namespace Neolink.Recording;
+
+/// <summary>
+/// One camera's runtime recording switches. Immutable — readers always see a
+/// consistent snapshot.
+/// </summary>
+public sealed record CameraRecordingSettings(bool Events, bool Continuous, List<string>? EventTypes)
+{
+    /// <summary>Known detection labels (what the UI offers as event-type filters).</summary>
+    public static readonly string[] KnownLabels = { "person", "vehicle", "animal", "package", "motion" };
+
+    /// <summary>A null EventTypes list means every detection type is recorded.</summary>
+    public bool AllowsLabel(string label) => EventTypes == null || EventTypes.Contains(label);
+}
+
+/// <summary>
+/// Per-camera recording switches changeable at runtime from the web UI, persisted
+/// as settings.json in the storage root — so they live on the same (Docker) volume
+/// as the footage and survive restarts. The config file only provides each
+/// camera's initial defaults; once a user flips a switch, this file wins.
+/// </summary>
+public sealed class RecordingSettings
+{
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
+
+    private readonly string _file;
+    private readonly object _gate = new();
+    private Dictionary<string, CameraRecordingSettings> _cameras = new(StringComparer.OrdinalIgnoreCase);
+
+    public RecordingSettings(string root)
+    {
+        _file = Path.Combine(root, "settings.json");
+        try
+        {
+            if (File.Exists(_file))
+            {
+                var loaded = JsonSerializer.Deserialize<Dictionary<string, CameraRecordingSettings>>(
+                    File.ReadAllText(_file), JsonOpts);
+                if (loaded != null)
+                    _cameras = new Dictionary<string, CameraRecordingSettings>(loaded, StringComparer.OrdinalIgnoreCase);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Warn($"Recording settings unreadable ({ex.Message}); starting from config defaults");
+        }
+    }
+
+    /// <summary>Registers a camera's config defaults without touching stored user choices.</summary>
+    public void Seed(string camera, bool eventsDefault)
+    {
+        lock (_gate)
+        {
+            if (!_cameras.ContainsKey(camera))
+                _cameras[camera] = new CameraRecordingSettings(eventsDefault, Continuous: false, EventTypes: null);
+        }
+    }
+
+    public CameraRecordingSettings Get(string camera)
+    {
+        lock (_gate)
+        {
+            return _cameras.TryGetValue(camera, out var s)
+                ? s
+                : new CameraRecordingSettings(Events: true, Continuous: false, EventTypes: null);
+        }
+    }
+
+    /// <summary>
+    /// Applies a partial update (null = leave unchanged; for the type filter,
+    /// <paramref name="setEventTypes"/> distinguishes "set" from "unchanged")
+    /// and persists the result.
+    /// </summary>
+    public CameraRecordingSettings Update(string camera, bool? events, bool? continuous,
+        List<string>? eventTypes, bool setEventTypes)
+    {
+        lock (_gate)
+        {
+            var cur = _cameras.TryGetValue(camera, out var s)
+                ? s
+                : new CameraRecordingSettings(Events: true, Continuous: false, EventTypes: null);
+            var next = new CameraRecordingSettings(
+                events ?? cur.Events,
+                continuous ?? cur.Continuous,
+                setEventTypes ? eventTypes : cur.EventTypes);
+            _cameras[camera] = next;
+            SaveLocked();
+            return next;
+        }
+    }
+
+    private void SaveLocked()
+    {
+        try
+        {
+            var tmp = _file + ".tmp";
+            File.WriteAllText(tmp, JsonSerializer.Serialize(_cameras, JsonOpts));
+            File.Move(tmp, _file, overwrite: true);
+        }
+        catch (IOException ex)
+        {
+            Log.Warn($"Cannot persist recording settings: {ex.Message}");
+        }
+    }
+}

--- a/src/Neolink.Server/SelfTest.cs
+++ b/src/Neolink.Server/SelfTest.cs
@@ -273,13 +273,51 @@ public static class SelfTest
                 Assert(store2.SetReviewed(rec.Id, true), "review known id");
                 Assert(store2.List(reviewed: false).Count == 0, "reviewed filter");
 
-                // An event folder older than the retention window gets deleted.
+                // Folders older than the retention window get deleted — events and
+                // continuous footage each against their own window.
                 var oldDir = Path.Combine(dir, "cam1", "2000-01-01", "120000-dead");
                 Directory.CreateDirectory(oldDir);
                 File.WriteAllText(Path.Combine(oldDir, "event.json"), "{}");
-                store2.Cleanup(retentionDays: 7);
-                Assert(!Directory.Exists(oldDir), "expired day folder removed");
+                var oldSeg = Path.Combine(dir, "cam1", "continuous", "2000-01-01");
+                Directory.CreateDirectory(oldSeg);
+                var newSeg = store2.NewSegmentPath("cam1", DateTime.Now);
+                File.WriteAllText(newSeg, "x");
+                store2.Cleanup(retentionDays: 7, continuousRetentionDays: 7);
+                Assert(!Directory.Exists(oldDir), "expired event day folder removed");
+                Assert(!Directory.Exists(oldSeg), "expired continuous day folder removed");
+                Assert(File.Exists(newSeg), "recent segment survives retention");
                 Assert(store2.List().Count == 1, "recent event survives retention");
+                Assert(store2.ListContinuousDays("cam1").Count == 1, "recent day listed");
+            }
+            finally
+            {
+                try { Directory.Delete(dir, recursive: true); } catch { }
+            }
+        });
+
+        Test("recording settings roundtrip + type filter", () =>
+        {
+            var dir = Path.Combine(Path.GetTempPath(), $"neolink-selftest-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(dir);
+            try
+            {
+                var settings = new Recording.RecordingSettings(dir);
+                settings.Seed("cam1", eventsDefault: false);
+                Assert(!settings.Get("cam1").Events, "seeded default respected");
+                Assert(settings.Get("cam1").AllowsLabel("person"), "null filter allows everything");
+
+                settings.Update("cam1", events: true, continuous: true,
+                    new List<string> { "person" }, setEventTypes: true);
+                var s = settings.Get("cam1");
+                Assert(s.Events && s.Continuous, "switches updated");
+                Assert(s.AllowsLabel("person") && !s.AllowsLabel("vehicle"), "type filter applied");
+
+                // Seeding again must NOT clobber the user's choices; neither may a reload.
+                settings.Seed("cam1", eventsDefault: false);
+                Assert(settings.Get("cam1").Events, "seed does not overwrite user choice");
+                var reloaded = new Recording.RecordingSettings(dir);
+                Assert(reloaded.Get("cam1").Continuous, "settings persisted across restart");
+                Assert(!reloaded.Get("cam1").AllowsLabel("vehicle"), "filter persisted");
             }
             finally
             {
@@ -325,12 +363,23 @@ public static class SelfTest
                 using (var writer = Recording.ClipWriter.TryCreate(path, hub))
                 {
                     Assert(writer != null, "writer created once params are known");
+                    // Hub indices jump by 2, as they do when audio packets are
+                    // interleaved. That is NOT a drop: the writer must keep every
+                    // frame (regression: index-based gap detection dropped all
+                    // P-frames, producing near-zero-length clips).
                     long index = 0;
                     uint ts = 1000;
-                    writer!.Add(new Streaming.HubVideo(index++, Au(Nal(0x65, 40)), true, ts));
+                    writer!.Add(new Streaming.HubVideo(index, Au(Nal(0x65, 40)), true, ts));
                     for (int i = 0; i < 5; i++)
-                        writer.Add(new Streaming.HubVideo(index++, Au(Nal(0x41, 25)), false, ts += 3000));
-                    Assert(writer.DurationSeconds > 0, "duration advances");
+                    {
+                        index += 2;
+                        writer.Add(new Streaming.HubVideo(index, Au(Nal(0x41, 25)), false, ts += 3000));
+                    }
+                    Assert(writer.DurationSeconds > 0.15, "all frames survive audio interleave");
+
+                    // A real drop (gap flag) resumes at the next keyframe.
+                    writer.Add(new Streaming.HubVideo(index + 50, Au(Nal(0x41, 25)), false, ts += 3000), gap: true);
+                    writer.Add(new Streaming.HubVideo(index + 51, Au(Nal(0x65, 40)), true, ts += 3000));
                 }
 
                 var bytes = File.ReadAllBytes(path);

--- a/src/Neolink.Server/Web/WebApi.cs
+++ b/src/Neolink.Server/Web/WebApi.cs
@@ -29,6 +29,8 @@ public sealed record WebCameraInfo(string Name, List<WebStreamInfo> Streams, ICa
 ///   GET/POST .../led /pir; POST .../ptz /reboot; GET .../battery — camera control
 ///   GET /api/events[?camera=&amp;reviewed=&amp;limit=] — recorded detection events (when enabled)
 ///   GET /api/events/{id}/clip /thumb        — event artifacts; POST .../review to (un)dismiss
+///   GET/POST /api/cameras/{name}/recording  — per-camera recording switches + event-type filter
+///   GET /api/recordings/{camera}[/{date}[/{file}]] — browse/play continuous footage
 ///   /                                       — web UI (when enabled in the config)
 /// Mutating endpoints require HTTP Basic auth when users are configured (same
 /// credentials and per-camera permissions as RTSP).
@@ -41,10 +43,11 @@ public static class WebApi
     private sealed record StreamSettingsRequest(string? Stream, uint? Width, uint? Height,
         uint? Framerate, uint? Bitrate);
     private sealed record ReviewRequest(bool? Reviewed);
+    private sealed record RecordingSettingsRequest(bool? Events, bool? Continuous, List<string>? EventTypes);
 
     public static async Task RunAsync(string bindAddr, int port, bool webUi,
         IReadOnlyList<WebCameraInfo> cameras, IReadOnlyDictionary<string, string> users,
-        int rtspPort, EventStore? events, CancellationToken ct)
+        int rtspPort, EventStore? events, RecordingSettings? recordingSettings, CancellationToken ct)
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
         {
@@ -352,6 +355,73 @@ public static class WebApi
                 }
                 events.SetReviewed(id, req.Reviewed ?? true);
                 return Results.Json(new { ok = true });
+            });
+        }
+
+        // ------------------------------------------------------------ recording switches + footage
+
+        if (events != null && recordingSettings != null)
+        {
+            object ShapeSettings(CameraRecordingSettings s) => new
+            {
+                events = s.Events,
+                continuous = s.Continuous,
+                eventTypes = s.EventTypes,
+                knownTypes = CameraRecordingSettings.KnownLabels,
+            };
+
+            app.MapGet("/api/cameras/{name}/recording", (string name, HttpContext ctx) =>
+            {
+                var cam = cameras.FirstOrDefault(c => string.Equals(c.Name, name, StringComparison.OrdinalIgnoreCase));
+                return cam == null
+                    ? Results.Json(new { error = $"unknown camera '{name}'" }, statusCode: 404)
+                    : Results.Json(ShapeSettings(recordingSettings.Get(cam.Name)));
+            });
+
+            app.MapPost("/api/cameras/{name}/recording", (string name, RecordingSettingsRequest req, HttpContext ctx) =>
+            {
+                var cam = cameras.FirstOrDefault(c => string.Equals(c.Name, name, StringComparison.OrdinalIgnoreCase));
+                if (cam == null)
+                    return Results.Json(new { error = $"unknown camera '{name}'" }, statusCode: 404);
+                if (CheckAuth(ctx, cam) is { } denied)
+                    return denied;
+
+                List<string>? types = null;
+                if (req.EventTypes != null)
+                {
+                    types = req.EventTypes.Select(t => t.Trim().ToLowerInvariant())
+                        .Where(t => t.Length > 0).Distinct().ToList();
+                }
+                var updated = recordingSettings.Update(cam.Name, req.Events, req.Continuous,
+                    types, setEventTypes: req.EventTypes != null);
+                return Results.Json(ShapeSettings(updated));
+            });
+
+            app.MapGet("/api/recordings/{camera}", (string camera) =>
+            {
+                var cam = cameras.FirstOrDefault(c => string.Equals(c.Name, camera, StringComparison.OrdinalIgnoreCase));
+                return cam == null
+                    ? Results.Json(new { error = $"unknown camera '{camera}'" }, statusCode: 404)
+                    : Results.Json(events.ListContinuousDays(cam.Name));
+            });
+
+            app.MapGet("/api/recordings/{camera}/{date}", (string camera, string date) =>
+            {
+                var cam = cameras.FirstOrDefault(c => string.Equals(c.Name, camera, StringComparison.OrdinalIgnoreCase));
+                if (cam == null)
+                    return Results.Json(new { error = $"unknown camera '{camera}'" }, statusCode: 404);
+                var segments = events.ListSegments(cam.Name, date)
+                    .Select(s => new { file = s.File, size = s.Size });
+                return Results.Json(segments);
+            });
+
+            app.MapGet("/api/recordings/{camera}/{date}/{file}", (string camera, string date, string file) =>
+            {
+                var cam = cameras.FirstOrDefault(c => string.Equals(c.Name, camera, StringComparison.OrdinalIgnoreCase));
+                var path = cam == null ? null : events.SegmentPath(cam.Name, date, file);
+                return path == null
+                    ? Results.Json(new { error = "no such recording" }, statusCode: 404)
+                    : Results.File(path, "video/mp4", enableRangeProcessing: true);
             });
         }
 

--- a/src/Neolink.Server/config.example.json
+++ b/src/Neolink.Server/config.example.json
@@ -14,15 +14,18 @@
   // Serve the browser UI on web_port. Set false for API-only / headless setups.
   "webui": true,
 
-  // Optional: record motion/AI detection events (clips + thumbnails) to disk.
+  // Optional: recording to disk — motion/AI detection events (clips + thumbnails)
+  // and, when switched on per camera in the web UI, continuous 24/7 footage.
   // Remove this section to disable. In Docker, mount a volume at "path".
   // "recording": {
-  //   "path": "/recordings",     // storage directory
-  //   "retention_days": 7,       // delete events older than this (0 = keep forever)
-  //   "pre_seconds": 5,          // video kept from before the detection
-  //   "post_seconds": 8,         // quiet time before an event closes
-  //   "max_clip_seconds": 120,   // hard cap per event/clip
-  //   "stream": "auto"           // which stream to record: auto|mainStream|subStream
+  //   "path": "/recordings",           // storage directory
+  //   "retention_days": 7,             // delete events older than this (0 = keep forever)
+  //   "pre_seconds": 5,                // video kept from before the detection
+  //   "post_seconds": 8,               // quiet time before an event closes
+  //   "max_clip_seconds": 120,         // hard cap per event/clip
+  //   "stream": "auto",                // which stream to record: auto|mainStream|subStream
+  //   "segment_minutes": 10,           // continuous recording: length of one file
+  //   "continuous_retention_days": 7   // continuous footage retention (default = retention_days)
   // },
 
   // Optional: password-protect the RTSP server. Remove entries for open access.

--- a/src/Neolink.WebClient/Components/CameraPanel.razor
+++ b/src/Neolink.WebClient/Components/CameraPanel.razor
@@ -169,6 +169,46 @@
             </div>
         }
 
+        @if (_recording != null)
+        {
+            <div class="campanel-section">
+                <div class="campanel-section-title">RECORDING</div>
+                <div class="control-row">
+                    <span>Detection events</span>
+                    <button class="chip @(_recording.Events ? "" : "chip-off")"
+                            @onclick="() => SetRecordingAsync(events: !_recording.Events)">
+                        @(_recording.Events ? "on" : "off")
+                    </button>
+                </div>
+                <div class="control-row">
+                    <span>Continuous (24/7)</span>
+                    <button class="chip @(_recording.Continuous ? "" : "chip-off")"
+                            @onclick="() => SetRecordingAsync(continuous: !_recording.Continuous)">
+                        @(_recording.Continuous ? "on" : "off")
+                    </button>
+                </div>
+                @if (_recording.Events)
+                {
+                    <div class="control-row rec-types-row">
+                        <span>Event types</span>
+                        <div class="stream-options">
+                            @foreach (var t in _recording.KnownTypes ?? new List<string>())
+                            {
+                                <button class="chip @(_recording.TypeEnabled(t) ? "" : "chip-off")"
+                                        title="@(_recording.TypeEnabled(t) ? "Recording" : "Discarded")"
+                                        @onclick="() => ToggleEventTypeAsync(t)">
+                                    @TypeIcon(t) @t
+                                </button>
+                            }
+                        </div>
+                    </div>
+                    <div class="notice small">
+                        Detections of disabled types are discarded — they neither start nor extend events.
+                    </div>
+                }
+            </div>
+        }
+
         <div class="campanel-section">
             <div class="campanel-section-title">MAINTENANCE</div>
             <div class="control-row">
@@ -202,6 +242,7 @@
     [Parameter] public EventCallback OnClose { get; set; }
 
     private ApiCapabilities? _caps;
+    private ApiRecordingSettings? _recording;
     private List<ApiEncodeProfile>? _profiles;
     private JsonElement? _battery;
     private JsonElement? _led;
@@ -228,6 +269,7 @@
         _loading = true;
         _error = _status = null;
         _caps = null;
+        _recording = null;
         _profiles = null;
         _battery = _led = _pir = null;
         _confirmReboot = false;
@@ -238,6 +280,7 @@
         _caps = await GetAsync<ApiCapabilities>("capabilities");
         if (_caps is { Online: true })
         {
+            _recording = await GetAsync<ApiRecordingSettings>("recording"); // null when the server records nothing
             _profiles = (await GetAsync<ApiStreamProfiles>("streaminfo"))?.Profiles;
             if (_caps.Features?.Battery == true) _battery = await GetAsync<JsonElement?>("battery");
             if (_caps.Features?.Led == true) _led = await GetAsync<JsonElement?>("led");
@@ -296,6 +339,32 @@
     {
         if (await PostAsync("pir", new { enabled = !PirEnabled }))
             _pir = await GetAsync<JsonElement?>("pir");
+    }
+
+    private static string TypeIcon(string label) => label switch
+    {
+        "person" => "🧍",
+        "vehicle" => "🚗",
+        "animal" => "🐾",
+        "package" => "📦",
+        "motion" => "👁",
+        _ => "•",
+    };
+
+    private async Task SetRecordingAsync(bool? events = null, bool? continuous = null, List<string>? eventTypes = null)
+    {
+        object body = new { events, continuous, eventTypes };
+        if (await PostAsync("recording", body))
+            _recording = await GetAsync<ApiRecordingSettings>("recording");
+    }
+
+    private Task ToggleEventTypeAsync(string label)
+    {
+        if (_recording == null) return Task.CompletedTask;
+        // null filter = all types; materialize it before toggling one off.
+        var types = (_recording.EventTypes ?? _recording.KnownTypes ?? new List<string>()).ToList();
+        if (!types.Remove(label)) types.Add(label);
+        return SetRecordingAsync(eventTypes: types);
     }
 
     private async Task RebootAsync()

--- a/src/Neolink.WebClient/Components/Pages/Home.razor
+++ b/src/Neolink.WebClient/Components/Pages/Home.razor
@@ -211,49 +211,123 @@
         <div class="backdrop panel-backdrop" @onclick="() => _showEventsPanel = false"></div>
         <aside class="campanel events-panel" role="dialog" aria-label="Event history">
             <div class="campanel-head">
-                <span class="campanel-title">🕘 EVENTS</span>
-                <select class="event-filter" @bind="_eventCameraFilter" title="Filter by camera">
-                    <option value="">all cameras</option>
-                    @foreach (var c in _cameras)
-                    {
-                        <option value="@c.Name">@c.Name</option>
-                    }
-                </select>
-                <button class="chip @(_eventsUnreviewedOnly ? "" : "chip-off")" title="Only show unreviewed events"
-                        @onclick="() => _eventsUnreviewedOnly = !_eventsUnreviewedOnly">unreviewed</button>
+                <button class="chip @(_panelTab == "events" ? "" : "chip-off")"
+                        @onclick='() => _panelTab = "events"'>🕘 Events</button>
+                <button class="chip @(_panelTab == "recordings" ? "" : "chip-off")"
+                        @onclick="OpenRecordingsTabAsync">🎞 Recordings</button>
+                <span class="tile-spacer"></span>
+                @if (_panelTab == "events")
+                {
+                    <select class="event-filter" @bind="_eventCameraFilter" title="Filter by camera">
+                        <option value="">all cameras</option>
+                        @foreach (var c in _cameras)
+                        {
+                            <option value="@c.Name">@c.Name</option>
+                        }
+                    </select>
+                    <button class="chip @(_eventsUnreviewedOnly ? "" : "chip-off")" title="Only show unreviewed events"
+                            @onclick="() => _eventsUnreviewedOnly = !_eventsUnreviewedOnly">unreviewed</button>
+                }
+                else
+                {
+                    <select class="event-filter" value="@_recCamera" title="Camera"
+                            @onchange="e => SelectRecordingCameraAsync((string?)e.Value)">
+                        @foreach (var c in _cameras)
+                        {
+                            <option value="@c.Name">@c.Name</option>
+                        }
+                    </select>
+                }
                 <button class="icon-btn" title="Close" @onclick="() => _showEventsPanel = false">✕</button>
             </div>
 
-            @if (!FilteredEvents.Any())
+            @if (_panelTab == "events")
             {
-                <div class="notice">
-                    @(_eventsUnreviewedOnly ? "Nothing awaiting review — all clear." : "No recorded events yet.")
-                </div>
-            }
-            @foreach (var day in FilteredEvents.GroupBy(e => e.Start.ToLocalTime().Date))
-            {
-                <div class="campanel-section">
-                    <div class="campanel-section-title">@DayLabel(day.Key) <span class="event-day-count">@day.Count()</span></div>
-                    @foreach (var ev in day)
-                    {
-                        <div class="event-row @(ev.Reviewed ? "reviewed" : "")" @key="ev.Id"
-                             title="Click to play" @onclick="() => OpenEvent(ev)">
-                            <span class="event-row-time">@ev.Start.ToLocalTime().ToString("HH:mm:ss")</span>
-                            <span class="event-row-icon">@ev.Icon</span>
-                            <div class="event-row-main">
-                                <span class="event-title">@ev.Title</span>
-                                <span class="event-sub">@ev.Camera · @DurationText(ev)</span>
+                @if (!FilteredEvents.Any())
+                {
+                    <div class="notice">
+                        @(_eventsUnreviewedOnly ? "Nothing awaiting review — all clear." : "No recorded events yet.")
+                    </div>
+                }
+                @foreach (var day in FilteredEvents.GroupBy(e => e.Start.ToLocalTime().Date))
+                {
+                    <div class="campanel-section">
+                        <div class="campanel-section-title">@DayLabel(day.Key) <span class="event-day-count">@day.Count()</span></div>
+                        @foreach (var ev in day)
+                        {
+                            <div class="event-row @(ev.Reviewed ? "reviewed" : "")" @key="ev.Id"
+                                 title="Click to play" @onclick="() => OpenEvent(ev)">
+                                <span class="event-row-time">@ev.Start.ToLocalTime().ToString("HH:mm:ss")</span>
+                                <span class="event-row-icon">@ev.Icon</span>
+                                <div class="event-row-main">
+                                    <span class="event-title">@ev.Title</span>
+                                    <span class="event-sub">@ev.Camera · @DurationText(ev)</span>
+                                </div>
+                                @if (!ev.Reviewed)
+                                {
+                                    <button class="icon-btn" title="Dismiss (mark reviewed)"
+                                            @onclick="() => DismissAsync(ev)" @onclick:stopPropagation="true">✕</button>
+                                }
                             </div>
-                            @if (!ev.Reviewed)
-                            {
-                                <button class="icon-btn" title="Dismiss (mark reviewed)"
-                                        @onclick="() => DismissAsync(ev)" @onclick:stopPropagation="true">✕</button>
-                            }
+                        }
+                    </div>
+                }
+            }
+            else
+            {
+                @* Continuous (24/7) footage browser: days → segment files. *@
+                @if (_recDays.Count == 0)
+                {
+                    <div class="notice">
+                        No continuous footage for @(_recCamera.Length > 0 ? _recCamera : "this camera") yet.
+                        Enable “Continuous (24/7)” in the camera's settings (⚙) to record around the clock.
+                    </div>
+                }
+                @foreach (var day in _recDays)
+                {
+                    <div class="campanel-section">
+                        <div class="campanel-section-title rec-day" title="Show/hide this day"
+                             @onclick="() => ToggleRecordingDayAsync(day)">
+                            @(_recExpanded.Contains(day) ? "▾" : "▸") @RecDayLabel(day)
                         </div>
-                    }
-                </div>
+                        @if (_recExpanded.Contains(day) && _recSegments.TryGetValue(day, out var segments))
+                        {
+                            @if (segments.Count == 0)
+                            {
+                                <div class="notice small">No segments.</div>
+                            }
+                            @foreach (var seg in segments)
+                            {
+                                <div class="event-row" @key="seg.File" title="Click to play"
+                                     @onclick="() => _playSegment = (_recCamera, day, seg)">
+                                    <span class="event-row-icon">🎞</span>
+                                    <div class="event-row-main">
+                                        <span class="event-title">@seg.TimeLabel</span>
+                                        <span class="event-sub">@seg.SizeLabel</span>
+                                    </div>
+                                </div>
+                            }
+                        }
+                    </div>
+                }
             }
         </aside>
+    }
+
+    @if (_playSegment is { } ps)
+    {
+        <div class="backdrop player-backdrop" @onclick="() => _playSegment = null"></div>
+        <div class="event-player" role="dialog" aria-label="Recording playback">
+            <div class="event-player-head">
+                <div class="event-player-title">
+                    <span class="event-title">🎞 Continuous recording</span>
+                    <span class="event-sub">@ps.Camera · @RecDayLabel(ps.Date) @ps.Segment.TimeLabel · @ps.Segment.SizeLabel</span>
+                </div>
+                <button class="icon-btn" title="Close" @onclick="() => _playSegment = null">✕</button>
+            </div>
+            <video controls autoplay playsinline @key="@($"{ps.Camera}/{ps.Date}/{ps.Segment.File}")"
+                   src="@SegmentUrl(ps.Camera, ps.Date, ps.Segment.File)"></video>
+        </div>
     }
 
     @if (_playEvent != null)
@@ -335,6 +409,14 @@
     private string _eventCameraFilter = "";
     private bool _eventsUnreviewedOnly;
     private ApiEvent? _playEvent;
+
+    // Continuous (24/7) footage browser
+    private string _panelTab = "events";
+    private string _recCamera = "";
+    private List<string> _recDays = new();
+    private readonly Dictionary<string, List<ApiSegment>> _recSegments = new();
+    private readonly HashSet<string> _recExpanded = new();
+    private (string Camera, string Date, ApiSegment Segment)? _playSegment;
 
     protected override void OnInitialized() => EnsureSlots();
 
@@ -578,6 +660,72 @@
         : ev.Duration.TotalSeconds < 1 ? "<1s"
         : ev.Duration.TotalSeconds < 90 ? $"{(int)Math.Ceiling(ev.Duration.TotalSeconds)}s"
         : $"{(int)Math.Round(ev.Duration.TotalMinutes)} min";
+
+    // ------------------------------------------------------------ continuous footage
+
+    private string SegmentUrl(string camera, string date, string file) =>
+        $"{_server.TrimEnd('/')}/api/recordings/{Uri.EscapeDataString(camera)}/{date}/{file}";
+
+    private static string RecDayLabel(string day) =>
+        DateTime.TryParseExact(day, "yyyy-MM-dd", null, System.Globalization.DateTimeStyles.None, out var d)
+            ? DayLabel(d.Date)
+            : day;
+
+    private Task OpenRecordingsTabAsync()
+    {
+        _panelTab = "recordings";
+        if (_recCamera.Length == 0)
+            _recCamera = _eventCameraFilter.Length > 0 ? _eventCameraFilter : _cameras.FirstOrDefault()?.Name ?? "";
+        return LoadRecordingDaysAsync();
+    }
+
+    private Task SelectRecordingCameraAsync(string? camera)
+    {
+        _recCamera = camera ?? "";
+        return LoadRecordingDaysAsync();
+    }
+
+    private async Task LoadRecordingDaysAsync()
+    {
+        _recDays.Clear();
+        _recSegments.Clear();
+        _recExpanded.Clear();
+        if (_recCamera.Length == 0 || string.IsNullOrWhiteSpace(_server)) return;
+        try
+        {
+            var days = await Http.GetFromJsonAsync<List<string>>(
+                $"{_server.TrimEnd('/')}/api/recordings/{Uri.EscapeDataString(_recCamera)}");
+            if (days != null) _recDays = days;
+        }
+        catch (Exception ex)
+        {
+            _error = $"Cannot reach {_server}: {ex.Message}";
+            return;
+        }
+        // Most recent day opens by itself; older days load on click.
+        if (_recDays.Count > 0)
+            await ToggleRecordingDayAsync(_recDays[0]);
+    }
+
+    private async Task ToggleRecordingDayAsync(string day)
+    {
+        if (!_recExpanded.Add(day))
+        {
+            _recExpanded.Remove(day);
+            return;
+        }
+        if (_recSegments.ContainsKey(day)) return;
+        try
+        {
+            var segments = await Http.GetFromJsonAsync<List<ApiSegment>>(
+                $"{_server.TrimEnd('/')}/api/recordings/{Uri.EscapeDataString(_recCamera)}/{day}");
+            _recSegments[day] = segments ?? new List<ApiSegment>();
+        }
+        catch
+        {
+            _recSegments[day] = new List<ApiSegment>();
+        }
+    }
 
     // ------------------------------------------------------------ layout
 

--- a/src/Neolink.WebClient/Models.cs
+++ b/src/Neolink.WebClient/Models.cs
@@ -42,6 +42,24 @@ public sealed record ApiEncodeProfile(string Type, uint Width, uint Height,
 /// <summary>GET /api/cameras/{name}/streaminfo — the encode profiles of each stream.</summary>
 public sealed record ApiStreamProfiles(List<ApiEncodeProfile> Profiles);
 
+/// <summary>GET/POST /api/cameras/{name}/recording — runtime recording switches.</summary>
+public sealed record ApiRecordingSettings(bool Events, bool Continuous,
+    List<string>? EventTypes, List<string>? KnownTypes)
+{
+    /// <summary>null EventTypes = every detection type is recorded.</summary>
+    public bool TypeEnabled(string label) => EventTypes == null || EventTypes.Contains(label);
+}
+
+/// <summary>GET /api/recordings/{camera}/{date} — one continuous-recording segment.</summary>
+public sealed record ApiSegment(string File, long Size)
+{
+    /// <summary>"HH-mm-ss.mp4" → "HH:mm:ss".</summary>
+    public string TimeLabel => File.Length >= 8 ? File[..8].Replace('-', ':') : File;
+    public string SizeLabel => Size >= 1024 * 1024
+        ? $"{Size / (1024.0 * 1024):0} MB"
+        : $"{Size / 1024.0:0} KB";
+}
+
 // ------------------------------------------------------------ recorded events
 
 /// <summary>GET /api/events — one recorded detection event.</summary>

--- a/src/Neolink.WebClient/wwwroot/css/app.css
+++ b/src/Neolink.WebClient/wwwroot/css/app.css
@@ -705,6 +705,13 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
     flex: 1;
 }
 
+/* Continuous-footage browser + per-camera recording switches */
+.rec-day { cursor: pointer; user-select: none; }
+.rec-day:hover { color: var(--accent); }
+
+.rec-types-row { align-items: flex-start; }
+.rec-types-row .stream-options { justify-content: flex-end; }
+
 /* Playback modal */
 .player-backdrop {
     display: block;


### PR DESCRIPTION
Follow-up to #2. One bug fix from real-hardware testing plus the continuous-recording feature set.

## Bug fix: event clips were 0–1 s long
On cameras with audio, every event clip came out nearly empty. Root cause: the stream hub's packet index is global across video **and** audio, but the recorder's pump skipped audio packets without tracking their indices — so with interleaved audio every video frame looked like a drop, and the clip writer discarded all P-frames while waiting for keyframes. (The live WebSocket player documents this exact trap; the recorder had re-introduced it.) Drops are now detected across *all* packets in the pump and passed to `ClipWriter` as an explicit flag; the pre-roll buffer carries the flag too. A regression self-test feeds video with jumping hub indices and fails against the old code.

## Continuous (24/7) recording
`ContinuousRecorder` writes rolling fMP4 segments — `{camera}/continuous/{date}/{HH-mm-ss}.mp4` — like a classic NVR. Segments roll at the first keyframe past `segment_minutes` (default 10) so every file plays standalone; disk-write failures back off 30 s. New config: `segment_minutes`, `continuous_retention_days` (defaults to `retention_days`); the hourly retention task prunes event and continuous day folders independently.

## Per-camera runtime switches (web UI)
Camera panel (⚙) gains a **RECORDING** section: “Detection events” and “Continuous (24/7)” on/off chips. State is persisted by `RecordingSettings` to `settings.json` in the storage root — same Docker volume as the footage, survives restarts. The config `record` flag now only seeds the initial default; a user's UI choice is never overwritten (covered by a self-test).

## Per-camera event-type filter
Type chips (🧍 person, 🚗 vehicle, 🐾 animal, 📦 package, 👁 motion) select which detections are recorded. Disabled types are discarded entirely — they neither start nor extend events. Note: disabling *motion* gives “AI-only” recording, and clips then hug the AI detection window since generic motion no longer keeps events alive.

## API + UI
- `GET/POST /api/cameras/{name}/recording` (writes behind the existing Basic-auth rules; input normalized).
- `GET /api/recordings/{camera}[/{date}[/{file}]]` — browse and play continuous footage; range requests for seeking, strict segment-name validation (traversal probe returns 404, verified).
- Events panel gains **Events | Recordings** tabs; footage listed by day (most recent auto-expanded), segments play in the modal player.

## Reviewer notes
- 18/18 self-tests. Live smoke test covered: settings roundtrip + persistence, partial updates, day/segment listing and MP4 serving, traversal rejection, retention pruning both trees.
- Needs a real-camera check: clip lengths after the fix (expect ~pre + activity + post), and a continuous segment rolling over after `segment_minutes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)