### PR TITLE
Timeline page, fixed-height events panel, auto-review on player close

### DIFF
--- a/src/Neolink.WebClient/Components/Pages/Home.razor
+++ b/src/Neolink.WebClient/Components/Pages/Home.razor
@@ -143,6 +143,7 @@
                 <span class="tool-sep"></span>
                 <button class="tool-btn @(_showEventsPanel ? "active" : "")" title="Event history"
                         @onclick="() => _showEventsPanel = !_showEventsPanel">🕘 <span class="tool-name">Events</span></button>
+                <a class="tool-btn" href="timeline" title="Scrub recorded footage across all cameras">📼 <span class="tool-name">Timeline</span></a>
             }
         </div>
 
@@ -332,7 +333,7 @@
 
     @if (_playEvent != null)
     {
-        <div class="backdrop player-backdrop" @onclick="ClosePlayer"></div>
+        <div class="backdrop player-backdrop" @onclick="ClosePlayerAsync"></div>
         <div class="event-player" role="dialog" aria-label="Event playback">
             <div class="event-player-head">
                 <div class="event-player-title">
@@ -341,7 +342,7 @@
                         @_playEvent.Camera · @_playEvent.Start.ToLocalTime().ToString("ddd d MMM HH:mm:ss") · @DurationText(_playEvent)
                     </span>
                 </div>
-                <button class="icon-btn" title="Close" @onclick="ClosePlayer">✕</button>
+                <button class="icon-btn" title="Close" @onclick="ClosePlayerAsync">✕</button>
             </div>
             @if (_playEvent.HasClip)
             {
@@ -355,17 +356,17 @@
             }
             <div class="event-player-foot">
                 <button class="chip" disabled="@(NeighborEvent(1) == null)"
-                        @onclick="() => _playEvent = NeighborEvent(1)">← Older</button>
+                        @onclick="() => NavigatePlayerAsync(1)">← Older</button>
                 <button class="chip" disabled="@(NeighborEvent(-1) == null)"
-                        @onclick="() => _playEvent = NeighborEvent(-1)">Newer →</button>
+                        @onclick="() => NavigatePlayerAsync(-1)">Newer →</button>
                 <span class="tile-spacer"></span>
-                @if (!_playEvent.Reviewed)
+                @if (_playEvent.Reviewed)
                 {
-                    <button class="chip" @onclick="() => DismissAsync(_playEvent)">✓ Mark reviewed</button>
+                    <span class="event-sub">✓ reviewed</span>
                 }
                 else
                 {
-                    <span class="event-sub">✓ reviewed</span>
+                    <span class="event-sub">will be marked reviewed on close</span>
                 }
             </div>
         </div>
@@ -584,7 +585,26 @@
     }
 
     private void OpenEvent(ApiEvent ev) => _playEvent = ev;
-    private void ClosePlayer() => _playEvent = null;
+
+    /// <summary>Closing the player counts as reviewing: the event leaves the top strip.</summary>
+    private async Task ClosePlayerAsync()
+    {
+        var ev = _playEvent;
+        _playEvent = null;
+        if (ev is { Reviewed: false })
+            await DismissAsync(ev);
+    }
+
+    /// <summary>Older/newer navigation: the event being left behind was watched too.</summary>
+    private async Task NavigatePlayerAsync(int direction)
+    {
+        var watched = _playEvent;
+        var next = NeighborEvent(direction);
+        if (next == null) return;
+        _playEvent = next;
+        if (watched is { Reviewed: false })
+            await DismissAsync(watched);
+    }
 
     /// <summary>The adjacent event in the newest-first list (+1 = older, -1 = newer).</summary>
     private ApiEvent? NeighborEvent(int direction)

--- a/src/Neolink.WebClient/Components/Pages/Timeline.razor
+++ b/src/Neolink.WebClient/Components/Pages/Timeline.razor
@@ -1,0 +1,400 @@
+@page "/timeline"
+@using System.Text.Json
+@inject HttpClient Http
+@inject IJSRuntime JS
+@implements IAsyncDisposable
+
+@* NVR-style timeline: pick a day, scrub the lanes, and every included camera
+   shows its continuous footage at that instant. Coverage is drawn per camera;
+   detection events overlay the lanes color-coded by type. *@
+
+<PageTitle>Neolink — Timeline</PageTitle>
+
+<div class="tl-page">
+    <div class="toolbar tl-toolbar">
+        <a class="tool-btn" href="" title="Back to live view">‹ Live</a>
+        <span class="tool-label">TIMELINE</span>
+        <button class="tool-btn" title="Previous day" @onclick="() => ChangeDayAsync(-1)">◀</button>
+        <span class="tl-date">@_date.ToString("ddd, d MMMM yyyy")</span>
+        <button class="tool-btn" title="Next day" disabled="@(_date >= DateTime.Today)"
+                @onclick="() => ChangeDayAsync(1)">▶</button>
+        <span class="tool-sep"></span>
+        <button class="tool-btn @(_playing ? "active" : "")" @onclick="TogglePlayAsync">
+            @(_playing ? "❚❚" : "▶") <span class="tool-name">@(_playing ? "Pause" : "Play")</span>
+        </button>
+        <span class="tl-clock">@TimeText(_t)</span>
+    </div>
+
+    @if (_error != null)
+    {
+        <div class="notice error">@_error</div>
+    }
+    else if (!_supported)
+    {
+        <div class="notice">
+            Recording is not enabled on this server — add a "recording" section to the config
+            and switch cameras to Continuous (24/7) to use the timeline.
+        </div>
+    }
+    else
+    {
+        <div class="tl-cams">
+            <span class="tool-label">CAMERAS</span>
+            @foreach (var cam in _cameras)
+            {
+                var name = cam.Name;
+                <button class="chip @(_excluded.Contains(name) ? "chip-off" : "")"
+                        title="@(_excluded.Contains(name) ? "Excluded — click to include" : "Included — click to exclude")"
+                        @onclick="() => ToggleCameraAsync(name)">@name</button>
+            }
+            <span class="event-sub">— scrub the lanes below; colored marks are events</span>
+        </div>
+
+        <div class="tl-board">
+            <div class="tl-names">
+                <div class="tl-name"></div>
+                @foreach (var cam in Included)
+                {
+                    <div class="tl-name" title="@cam.Name">@cam.Name</div>
+                }
+            </div>
+            <div class="tl-lanes" id="tl-scrub">
+                <div class="tl-ruler">
+                    @for (int h = 0; h <= 24; h += 3)
+                    {
+                        <span class="tl-tick" style="left:@Pct(h * 3600.0)">@($"{h:00}")</span>
+                    }
+                </div>
+                @foreach (var cam in Included)
+                {
+                    <div class="tl-lane">
+                        @if (_cov.TryGetValue(cam.Name, out var segs))
+                        {
+                            @foreach (var s in segs)
+                            {
+                                <div class="tl-cov" style="left:@Pct(s.Start); width:@Pct(s.Span)"></div>
+                            }
+                        }
+                        @if (_marks.TryGetValue(cam.Name, out var marks))
+                        {
+                            @foreach (var m in marks)
+                            {
+                                <div class="tl-ev" title="@m.Title"
+                                     style="left:@Pct(m.Start); width:@Pct(Math.Max(m.End - m.Start, 40)); background:@m.Color"></div>
+                            }
+                        }
+                    </div>
+                }
+                <div class="tl-cursor" style="left:@Pct(_t)">
+                    <span class="tl-cursor-time">@TimeText(_t)</span>
+                </div>
+            </div>
+        </div>
+
+        <div class="tl-grid">
+            @foreach (var cam in Included)
+            {
+                <div class="tl-tile" @key="cam.Name">
+                    <video id="@VideoId(cam.Name)" muted playsinline preload="auto"></video>
+                    @if (_noFootage.Contains(cam.Name))
+                    {
+                        <div class="tl-nofootage">no footage at @TimeText(_t)</div>
+                    }
+                    <div class="tl-tile-name">@cam.Name</div>
+                </div>
+            }
+            @if (!Included.Any())
+            {
+                <div class="notice">All cameras are excluded — include one above.</div>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    private const double DaySeconds = 24 * 3600;
+
+    private string _server = "";
+    private DateTime _date = DateTime.Today;
+    private double _t;
+    private bool _playing;
+    private bool _supported = true;
+    private string? _error;
+
+    private readonly List<ApiCamera> _cameras = new();
+    private HashSet<string> _excluded = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, List<Seg>> _cov = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, List<Mark>> _marks = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _noFootage = new(StringComparer.OrdinalIgnoreCase);
+
+    private DotNetObjectReference<Timeline>? _selfRef;
+    private PeriodicTimer? _clock;
+    private DateTime _lastTick;
+
+    /// <summary>One recording segment: seconds-of-day start, span and playback URL.</summary>
+    private sealed record Seg(double Start, double Span, string Url);
+    /// <summary>One event as a colored lane mark (seconds of day).</summary>
+    private sealed record Mark(double Start, double End, string Color, string Title);
+
+    private const string PrefsKey = "neolink.timeline";
+    private sealed class Prefs { public List<string> Excluded { get; set; } = new(); }
+
+    private IEnumerable<ApiCamera> Included => _cameras.Where(c => !_excluded.Contains(c.Name));
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender) return;
+
+        // Server + credentials are shared with the live view's persisted settings.
+        try
+        {
+            var json = await JS.InvokeAsync<string?>("neolink.lsGet", "neolink.view");
+            if (json != null)
+                _server = JsonSerializer.Deserialize<PersistedView>(json)?.Server ?? "";
+        }
+        catch { }
+        if (string.IsNullOrWhiteSpace(_server))
+            _server = await JS.InvokeAsync<string>("neolink.defaultServer");
+
+        try
+        {
+            var json = await JS.InvokeAsync<string?>("neolink.lsGet", PrefsKey);
+            if (json != null && JsonSerializer.Deserialize<Prefs>(json) is { } p)
+                _excluded = new HashSet<string>(p.Excluded, StringComparer.OrdinalIgnoreCase);
+        }
+        catch { }
+
+        await LoadCamerasAsync();
+        await LoadDayAsync();
+
+        _selfRef = DotNetObjectReference.Create(this);
+        await JS.InvokeVoidAsync("neolink.tlScrubInit", "tl-scrub", _selfRef);
+        _ = ClockLoopAsync();
+        StateHasChanged();
+    }
+
+    // ------------------------------------------------------------ data
+
+    private string Base => _server.TrimEnd('/');
+
+    private async Task LoadCamerasAsync()
+    {
+        try
+        {
+            var cams = await Http.GetFromJsonAsync<List<ApiCamera>>($"{Base}/api/cameras");
+            _cameras.Clear();
+            if (cams != null) _cameras.AddRange(cams);
+            _error = null;
+        }
+        catch (Exception ex)
+        {
+            _error = $"Cannot reach {_server}: {ex.Message}";
+        }
+    }
+
+    private async Task LoadDayAsync()
+    {
+        _cov.Clear();
+        _marks.Clear();
+        _playing = false;
+        var date = _date.ToString("yyyy-MM-dd");
+
+        // Coverage: the continuous segments of each camera for this day.
+        _supported = true;
+        foreach (var cam in _cameras)
+        {
+            try
+            {
+                var segs = await Http.GetFromJsonAsync<List<ApiSegment>>(
+                    $"{Base}/api/recordings/{Uri.EscapeDataString(cam.Name)}/{date}");
+                _cov[cam.Name] = BuildSegs(segs ?? new List<ApiSegment>(), cam.Name, date);
+            }
+            catch
+            {
+                _supported = false; // endpoint missing = recording disabled server-side
+                return;
+            }
+        }
+
+        // Events of the day, as colored lane marks.
+        try
+        {
+            var events = await Http.GetFromJsonAsync<List<ApiEvent>>($"{Base}/api/events?limit=1000");
+            foreach (var ev in events ?? new List<ApiEvent>())
+            {
+                var start = ev.Start.ToLocalTime();
+                if (start.Date != _date) continue;
+                double s = (start - _date).TotalSeconds;
+                double e = Math.Min(DaySeconds, s + Math.Max(ev.Duration.TotalSeconds, 1));
+                if (!_marks.TryGetValue(ev.Camera, out var list))
+                    _marks[ev.Camera] = list = new List<Mark>();
+                list.Add(new Mark(s, e, LabelColor(ev.Labels), $"{ev.Title} · {start:HH:mm:ss}"));
+            }
+        }
+        catch { /* events are decoration here; coverage already loaded */ }
+
+        // Land the cursor somewhere useful: near-now for today, else midday.
+        _t = _date == DateTime.Today
+            ? Math.Max(0, (DateTime.Now - _date).TotalSeconds - 30)
+            : DaySeconds / 2;
+        await SyncVideosAsync();
+    }
+
+    /// <summary>
+    /// Segment spans: a segment reaches to the next one when they are contiguous;
+    /// otherwise (a recording gap) the typical segment length is assumed.
+    /// </summary>
+    private List<Seg> BuildSegs(List<ApiSegment> files, string camera, string date)
+    {
+        var parsed = files
+            .Select(f => (f.File, Start: ParseStart(f.File)))
+            .Where(x => x.Start >= 0)
+            .OrderBy(x => x.Start)
+            .ToList();
+
+        var diffs = parsed.Zip(parsed.Skip(1), (a, b) => b.Start - a.Start)
+            .Where(d => d > 1).OrderBy(d => d).ToList();
+        double typical = diffs.Count > 0 ? Math.Clamp(diffs[diffs.Count / 2], 30, 1800) : 600;
+
+        var segs = new List<Seg>();
+        for (int i = 0; i < parsed.Count; i++)
+        {
+            double start = parsed[i].Start;
+            double span = typical;
+            if (i + 1 < parsed.Count)
+            {
+                double gap = parsed[i + 1].Start - start;
+                if (gap <= typical * 1.5) span = gap;
+            }
+            segs.Add(new Seg(start, span,
+                $"{Base}/api/recordings/{Uri.EscapeDataString(camera)}/{date}/{parsed[i].File}"));
+        }
+        return segs;
+    }
+
+    private static double ParseStart(string file) =>
+        file.Length >= 8
+        && int.TryParse(file.AsSpan(0, 2), out var h)
+        && int.TryParse(file.AsSpan(3, 2), out var m)
+        && int.TryParse(file.AsSpan(6, 2), out var s)
+            ? h * 3600 + m * 60 + s
+            : -1;
+
+    private static string LabelColor(List<string> labels) =>
+        labels.Contains("person") ? "#4f8cff"
+        : labels.Contains("vehicle") ? "#ffb020"
+        : labels.Contains("animal") ? "#3fd07f"
+        : labels.Contains("package") ? "#b06bff"
+        : "#8a93a5"; // motion / other
+
+    // ------------------------------------------------------------ playback
+
+    [JSInvokable]
+    public async Task OnTimelineScrub(double fraction, bool final)
+    {
+        await InvokeAsync(async () =>
+        {
+            _t = Math.Clamp(fraction, 0, 1) * DaySeconds;
+            await SyncVideosAsync();
+            StateHasChanged();
+        });
+    }
+
+    private async Task TogglePlayAsync()
+    {
+        _playing = !_playing;
+        _lastTick = DateTime.UtcNow;
+        await SyncVideosAsync();
+    }
+
+    private async Task ClockLoopAsync()
+    {
+        _clock = new PeriodicTimer(TimeSpan.FromMilliseconds(500));
+        _lastTick = DateTime.UtcNow;
+        try
+        {
+            while (await _clock.WaitForNextTickAsync())
+            {
+                var now = DateTime.UtcNow;
+                var elapsed = (now - _lastTick).TotalSeconds;
+                _lastTick = now;
+                if (!_playing) continue;
+                _t += elapsed;
+                if (_t >= DaySeconds - 1)
+                {
+                    _t = DaySeconds - 1;
+                    _playing = false;
+                }
+                await InvokeAsync(async () =>
+                {
+                    await SyncVideosAsync();
+                    StateHasChanged();
+                });
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (ObjectDisposedException) { }
+    }
+
+    /// <summary>Points every included camera's player at the footage under the cursor.</summary>
+    private async Task SyncVideosAsync()
+    {
+        foreach (var cam in Included)
+        {
+            var seg = _cov.TryGetValue(cam.Name, out var segs)
+                ? segs.FirstOrDefault(s => _t >= s.Start && _t < s.Start + s.Span)
+                : null;
+            if (seg == null)
+            {
+                _noFootage.Add(cam.Name);
+                await JS.InvokeVoidAsync("neolink.tlSync", VideoId(cam.Name), null!, 0d, false);
+            }
+            else
+            {
+                _noFootage.Remove(cam.Name);
+                await JS.InvokeVoidAsync("neolink.tlSync", VideoId(cam.Name), seg.Url, _t - seg.Start, _playing);
+            }
+        }
+    }
+
+    // ------------------------------------------------------------ actions
+
+    private async Task ChangeDayAsync(int days)
+    {
+        var next = _date.AddDays(days);
+        if (next > DateTime.Today) return;
+        _date = next;
+        await LoadDayAsync();
+    }
+
+    private async Task ToggleCameraAsync(string name)
+    {
+        if (!_excluded.Remove(name))
+            _excluded.Add(name);
+        await JS.InvokeVoidAsync("neolink.lsSet", PrefsKey,
+            JsonSerializer.Serialize(new Prefs { Excluded = _excluded.ToList() }));
+        // A camera coming back needs its coverage if the day was loaded before it existed.
+        if (!_excluded.Contains(name) && !_cov.ContainsKey(name))
+            await LoadDayAsync();
+        else
+            await SyncVideosAsync();
+    }
+
+    // ------------------------------------------------------------ helpers
+
+    private static string VideoId(string camera) => "tlv-" + Uri.EscapeDataString(camera);
+
+    private static string Pct(double seconds) =>
+        $"{seconds / DaySeconds * 100:0.###}%";
+
+    private static string TimeText(double t) =>
+        TimeSpan.FromSeconds(Math.Clamp(t, 0, DaySeconds - 1)).ToString(@"hh\:mm\:ss");
+
+    public async ValueTask DisposeAsync()
+    {
+        _clock?.Dispose();
+        try { await JS.InvokeVoidAsync("neolink.tlScrubDispose", "tl-scrub"); }
+        catch { /* circuit already gone */ }
+        _selfRef?.Dispose();
+    }
+}

--- a/src/Neolink.WebClient/wwwroot/css/app.css
+++ b/src/Neolink.WebClient/wwwroot/css/app.css
@@ -659,7 +659,21 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
 .event-dismiss { flex: 0 0 auto; }
 .events-clear { flex: 0 0 auto; }
 
-/* Event history panel (reuses the campanel chrome) */
+/* Event history panel (reuses the campanel chrome).
+   Fixed height: content changes (polling, expanding days, switching tabs) must
+   scroll inside the panel, never resize the popup itself. */
+.events-panel {
+    height: min(92vh, 960px);
+}
+
+.events-panel .campanel-head {
+    position: sticky;
+    top: -16px; /* campanel padding: pin flush to the panel edge */
+    background: var(--panel);
+    z-index: 2;
+    padding: 6px 0;
+}
+
 .events-panel .event-filter {
     background: var(--bg);
     color: var(--text);
@@ -757,10 +771,177 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
 
 .event-player video {
     width: 100%;
+    aspect-ratio: 16 / 9; /* stable modal size while media loads */
     max-height: calc(100vh - 180px);
     background: #000;
     border-radius: 8px;
     outline: none;
+}
+
+/* ------------------------------------------------------------ timeline page */
+
+.tl-page {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    background: var(--bg);
+    color: var(--text);
+    overflow: hidden;
+}
+
+.tl-toolbar { flex: 0 0 auto; }
+.tl-date { font-size: 13px; font-weight: 600; min-width: 150px; text-align: center; }
+
+.tl-clock {
+    margin-left: auto;
+    font-size: 15px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: var(--accent);
+}
+
+.tl-cams {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 8px 12px 0;
+    align-items: center;
+}
+
+.tl-board {
+    display: flex;
+    padding: 10px 12px;
+    gap: 0;
+    flex: 0 0 auto;
+}
+
+.tl-names { display: flex; flex-direction: column; width: 110px; flex: 0 0 auto; }
+
+.tl-name {
+    height: 26px;
+    display: flex;
+    align-items: center;
+    font-size: 12px;
+    color: var(--muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding-right: 8px;
+}
+
+.tl-lanes {
+    position: relative;
+    flex: 1;
+    cursor: crosshair;
+    touch-action: none; /* pointer-drag scrubbing on touch too */
+    user-select: none;
+}
+
+.tl-ruler { position: relative; height: 26px; }
+
+.tl-tick {
+    position: absolute;
+    top: 8px;
+    bottom: 0;
+    border-left: 1px solid var(--line);
+    font-size: 10px;
+    color: var(--muted);
+    padding-left: 3px;
+    pointer-events: none;
+}
+
+.tl-lane {
+    position: relative;
+    height: 26px;
+    background: color-mix(in srgb, var(--panel) 70%, transparent);
+    border-radius: 4px;
+    margin-bottom: 2px;
+    overflow: hidden;
+}
+
+.tl-cov {
+    position: absolute;
+    top: 7px;
+    height: 12px;
+    background: #35507e;
+    border-radius: 2px;
+    pointer-events: none;
+}
+
+.tl-ev {
+    position: absolute;
+    top: 4px;
+    height: 18px;
+    min-width: 3px;
+    border-radius: 2px;
+    opacity: 0.95;
+}
+
+.tl-cursor {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: var(--err);
+    pointer-events: none;
+    z-index: 3;
+}
+
+.tl-cursor-time {
+    position: absolute;
+    top: 0;
+    left: 4px;
+    font-size: 10px;
+    color: var(--err);
+    background: var(--bg);
+    padding: 0 3px;
+    border-radius: 3px;
+    white-space: nowrap;
+}
+
+.tl-grid {
+    flex: 1;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 8px;
+    padding: 4px 12px 12px;
+    overflow-y: auto;
+    align-content: start;
+}
+
+.tl-tile {
+    position: relative;
+    background: #000;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.tl-tile video {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    display: block;
+    background: #000;
+}
+
+.tl-tile-name {
+    position: absolute;
+    left: 8px;
+    bottom: 6px;
+    font-size: 12px;
+    background: rgba(0, 0, 0, 0.55);
+    padding: 2px 8px;
+    border-radius: 6px;
+}
+
+.tl-nofootage {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--muted);
+    font-size: 13px;
 }
 
 .event-player-foot {

--- a/src/Neolink.WebClient/wwwroot/js/neolink.js
+++ b/src/Neolink.WebClient/wwwroot/js/neolink.js
@@ -294,8 +294,74 @@
         });
     }
 
+    // ---------- timeline page (recorded footage scrubbing) ----------
+    const scrubs = {};
+
     window.neolink = {
         freeInit,
+
+        // Points a <video> at a recording segment and keeps it at the wanted
+        // offset. Tolerance while playing avoids constant reseeks (the video
+        // advances on its own); paused scrubbing snaps tightly.
+        tlSync(videoId, url, offset, playing) {
+            const v = document.getElementById(videoId);
+            if (!v) return;
+            v.muted = true;
+            if (!url) {
+                delete v.dataset.tlUrl;
+                if (v.getAttribute('src')) { v.removeAttribute('src'); try { v.load(); } catch { } }
+                return;
+            }
+            if (v.dataset.tlUrl !== url) {
+                v.dataset.tlUrl = url;
+                v.src = url;
+                try { v.load(); } catch { }
+                v.currentTime = offset;
+            } else {
+                const tolerance = playing ? 1.5 : 0.35;
+                if (Math.abs(v.currentTime - offset) > tolerance) v.currentTime = offset;
+            }
+            if (playing) { if (v.paused) v.play().catch(() => { }); }
+            else if (!v.paused) v.pause();
+        },
+
+        // Pointer-drag scrubbing on the timeline lanes: reports the horizontal
+        // fraction (0..1) to Blazor, throttled so dragging doesn't flood SignalR.
+        tlScrubInit(elemId, dotnetRef) {
+            this.tlScrubDispose(elemId);
+            const el = document.getElementById(elemId);
+            if (!el) return;
+            let lastSent = 0;
+            const send = (e, final) => {
+                const now = performance.now();
+                if (!final && now - lastSent < 70) return;
+                lastSent = now;
+                const r = el.getBoundingClientRect();
+                const f = Math.min(1, Math.max(0, (e.clientX - r.left) / r.width));
+                dotnetRef.invokeMethodAsync('OnTimelineScrub', f, final);
+            };
+            const down = (e) => {
+                if (e.button !== 0 && e.pointerType === 'mouse') return;
+                e.preventDefault();
+                try { el.setPointerCapture(e.pointerId); } catch { }
+                send(e, false);
+                const move = (ev) => send(ev, false);
+                const up = (ev) => {
+                    el.removeEventListener('pointermove', move);
+                    el.removeEventListener('pointerup', up);
+                    send(ev, true);
+                };
+                el.addEventListener('pointermove', move);
+                el.addEventListener('pointerup', up);
+            };
+            el.addEventListener('pointerdown', down);
+            scrubs[elemId] = { el, down };
+        },
+        tlScrubDispose(elemId) {
+            const s = scrubs[elemId];
+            if (s) { s.el.removeEventListener('pointerdown', s.down); delete scrubs[elemId]; }
+        },
+
         attach(videoId, wsUrl) {
             this.detach(videoId);
             const video = document.getElementById(videoId);


### PR DESCRIPTION
Follow-up to #4 — UI layer only, no server changes.

## Timeline page (`/timeline`, 📼 toolbar button)
NVR-style synchronized playback over the continuous recordings:
- **Per-camera coverage lanes** under an hour ruler (00–24); footage blocks are built from segment file timestamps, so recording gaps show as gaps.
- **Scrubbing**: pointer-drag across the lanes moves a red time cursor and seeks *every included camera* to that instant (segment lookup + in-file offset). Scrub traffic is throttled JS→SignalR; the videos are driven by a small JS helper (`tlSync`) rather than Blazor re-renders.
- **Play/pause**: a master clock advances the cursor; players roll together with drift correction (reseek only past 1.5 s) and hand off automatically across segment file boundaries.
- **Include/exclude cameras** via chips, persisted in localStorage.
- **Events overlay the lanes color-coded by type**: 🔵 person, 🟠 vehicle, 🟢 animal, 🟣 package, gray motion; hover shows label + time, scrubbing onto a mark plays that moment.

## Fixes / UX
- **Events panel no longer resizes randomly**: the popup had content-driven height (10 s polls, expanding days, tab switches). Now fixed at `min(92vh, 960px)` with internal scrolling and a sticky header. The playback modal video also gets a fixed 16:9 aspect ratio so it doesn't jump while a clip loads.
- **Auto-review on close**: playing an event counts as reviewing it — closing the popup (✕ or backdrop) or navigating older/newer marks the watched event reviewed, clearing it from the top strip. Replaces the manual "Mark reviewed" button.

## Reviewer notes
- Verified in a live browser session (preview tooling): scrub to 21:32 loaded the correct segment at exactly 120 s offset, "no footage" overlays toggle correctly, panel height stays constant, auto-review persisted `reviewed: true` to disk and cleared the strip. Console clean.
- Segment durations are inferred (next segment start when contiguous, else the typical length) — good enough for a scrubber without probing MP4s server-side.
- Needs a real-hardware pass to confirm actual footage decodes while scrubbing (test data was stub files, so mechanics are verified, pixels are not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)