### PR TITLE
Playable clip files, opt-in timeline cameras, settings.json in config dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ docker image inspect ghcr.io/borexola/neolink.net:latest --format '{{.Os}}/{{.Ar
 ### 2. Create a config
 
 ```bash
-curl -o config.json https://raw.githubusercontent.com/borexola/neolink.net/main/src/Neolink.Server/config.example.json
+mkdir -p config
+curl -o config/config.json https://raw.githubusercontent.com/borexola/neolink.net/main/src/Neolink.Server/config.example.json
 ```
 
 Edit it: camera names, IP addresses, and credentials (same login as the Reolink app).
@@ -108,9 +109,11 @@ Edit it: camera names, IP addresses, and credentials (same login as the Reolink 
 ### 3. Run
 
 ```bash
+# /config is a directory mount: config.json lives in it, and runtime settings
+# from the web UI (settings.json) are persisted next to it.
 docker run -d --name neolink --restart unless-stopped \
     -p 8654:8654 -p 8655:8655 \
-    -v "$PWD/config.json:/config/config.json:ro" \
+    -v "$PWD/config:/config" \
     ghcr.io/borexola/neolink.net:latest
 ```
 
@@ -125,7 +128,7 @@ docker logs -f neolink     # prints the ready-to-use RTSP and web UI URLs
 
 ### Or with compose
 
-Save this as `docker-compose.yml` next to your `config.json`
+Save this as `docker-compose.yml` next to your `config/` directory
 (or `curl -O https://raw.githubusercontent.com/borexola/neolink.net/main/docker-compose.yml`):
 
 ```yaml
@@ -138,7 +141,7 @@ services:
       - "8654:8654"   # RTSP (TCP-interleaved works for ffmpeg/Frigate/VLC)
       - "8655:8655"   # web UI + API; remove if webui:false and API unused
     volumes:
-      - ./config.json:/config/config.json:ro
+      - ./config:/config   # holds config.json + web-UI settings.json
     # For RTSP over UDP transport, use host networking instead of port maps:
     # network_mode: host
 ```
@@ -166,7 +169,7 @@ docker compose pull && docker compose up -d
 git clone https://github.com/borexola/neolink.net.git && cd neolink.net
 docker build -t neolink.net .
 docker run -d --name neolink -p 8654:8654 -p 8655:8655 \
-    -v "$PWD/config.json:/config/config.json:ro" neolink.net
+    -v "$PWD/config:/config" neolink.net
 ```
 
 Then:
@@ -239,9 +242,8 @@ the original Rust neolink are also accepted.
 ### Recording (`"recording": { ... }`)
 
 Two recording modes, both switchable **per camera at runtime** from the web UI
-(camera ⚙ → RECORDING) — the switches persist in `settings.json` inside the
-storage directory, so they survive restarts and live on the same Docker volume
-as the footage:
+(camera ⚙ → RECORDING) — the switches persist in `settings.json` next to your
+config file (in Docker: the `/config` mount), so they survive restarts:
 
 - **Detection events**: the camera's own motion/AI detections (person, vehicle,
   animal — pushed over the Baichuan connection, no polling and no server-side ML)
@@ -250,6 +252,10 @@ as the footage:
   Events button opens the full history grouped by day. Per camera you can also
   pick **which detection types to record** (🧍 person, 🚗 vehicle, 🐾 animal,
   📦 package, 👁 motion) — detections of disabled types are discarded entirely.
+  ⚠ The camera does the detecting: person/vehicle/animal labels only arrive when
+  the matching Smart Detection is enabled **in the Reolink app** (camera →
+  Settings → Detection). The chips are a Neolink-side filter on what arrives;
+  the camera's own settings are never changed.
 - **Continuous (24/7)**: classic NVR-style recording into rolling
   `segment_minutes`-long MP4 files, browsable under 🕘 → Recordings (grouped by
   day, click to play). Off by default; enable per camera in the UI.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,9 @@ services:
       - "8654:8654"   # RTSP (TCP-interleaved works for ffmpeg/Frigate/VLC)
       - "8655:8655"   # web UI + API; remove if webui:false and API unused
     volumes:
-      - ./config.json:/config/config.json:ro
+      # Config directory (not a single file): config.json lives here, and the web
+      # UI's runtime settings (settings.json) are persisted next to it.
+      - ./config:/config
       # Event recording storage: uncomment and set "recording": { "path": "/recordings" }
       # in config.json to capture detection events (clips + thumbnails) here.
       # - ./recordings:/recordings

--- a/src/Neolink.Server/Program.cs
+++ b/src/Neolink.Server/Program.cs
@@ -102,7 +102,10 @@ if (config.Recording is { } recCfg)
     {
         eventStore = new EventStore(recCfg.Path);
         eventStore.Load();
-        recordingSettings = new RecordingSettings(eventStore.Root);
+        // Runtime switches live next to the config file; the recordings root is
+        // checked once to migrate the old location.
+        recordingSettings = new RecordingSettings(
+            Path.GetDirectoryName(Path.GetFullPath(configPath))!, legacyDir: eventStore.Root);
         Log.Info($"Recording to {eventStore.Root} " +
                  $"(events: {(recCfg.RetentionDays > 0 ? $"{recCfg.RetentionDays} days" : "forever")}, " +
                  $"continuous: {(recCfg.EffectiveContinuousRetentionDays > 0 ? $"{recCfg.EffectiveContinuousRetentionDays} days" : "forever")})");

--- a/src/Neolink.Server/Recording/ClipWriter.cs
+++ b/src/Neolink.Server/Recording/ClipWriter.cs
@@ -1,3 +1,5 @@
+using System.Buffers.Binary;
+using System.Text;
 using Neolink.Media;
 using Neolink.Streaming;
 
@@ -9,6 +11,13 @@ namespace Neolink.Recording;
 /// duration is only known when the NEXT buffer arrives (RTP delta), so one buffer
 /// is held back and its measured delta spread evenly across its frames.
 /// Video-only by design — detection clips don't need the audio track.
+///
+/// The live-style init segment declares duration 0 (fine for MSE, where fragments
+/// stream in). A FILE with duration 0 freezes browsers on the first frame — the
+/// element believes the clip is zero-length. So the real duration is patched into
+/// mvhd/tkhd/mdhd when the clip closes, and an mfra random-access index (keyframe
+/// time → moof offset) is appended so external players (VLC, ffmpeg) can open and
+/// seek the file like any ordinary MP4.
 /// </summary>
 public sealed class ClipWriter : IDisposable
 {
@@ -16,6 +25,9 @@ public sealed class ClipWriter : IDisposable
 
     private readonly FileStream _file;
     private readonly VideoCodec _codec;
+    private readonly int _mvhdOffset;
+    private readonly int _tkhdOffset;
+    private readonly int _mdhdOffset;
 
     private uint _sequence = 1;
     private ulong _decodeTime;
@@ -23,11 +35,16 @@ public sealed class ClipWriter : IDisposable
     private uint _prevTs;
     private bool _waitKeyframe = true; // clips must start decodable
     private List<(byte[] Sample, bool Keyframe)>? _pending;
+    private readonly List<(ulong Time, long Offset)> _syncPoints = new();
 
-    private ClipWriter(FileStream file, VideoCodec codec)
+    private ClipWriter(FileStream file, VideoCodec codec, byte[] init)
     {
         _file = file;
         _codec = codec;
+        var boxes = FindHeaderBoxes(init);
+        _mvhdOffset = boxes.GetValueOrDefault("mvhd", -1);
+        _tkhdOffset = boxes.GetValueOrDefault("tkhd", -1);
+        _mdhdOffset = boxes.GetValueOrDefault("mdhd", -1);
     }
 
     /// <summary>Seconds of video written so far (upper bound; pending frames included at nominal rate).</summary>
@@ -43,17 +60,18 @@ public sealed class ClipWriter : IDisposable
         if (codec == null || sps == null || pps == null)
             return null;
 
-        var file = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read, 64 * 1024);
+        var file = new FileStream(path, FileMode.Create, FileAccess.ReadWrite, FileShare.Read, 64 * 1024);
         try
         {
-            file.Write(FMp4.BuildInit(codec.Value, sps, pps, hub.Vps, hub.Width, hub.Height));
+            var init = FMp4.BuildInit(codec.Value, sps, pps, hub.Vps, hub.Width, hub.Height);
+            file.Write(init);
+            return new ClipWriter(file, codec.Value, init);
         }
         catch
         {
             file.Dispose();
             throw;
         }
-        return new ClipWriter(file, codec.Value);
     }
 
     /// <summary>
@@ -99,24 +117,113 @@ public sealed class ClipWriter : IDisposable
         uint per = Math.Clamp(totalDuration / (uint)_pending.Count, 900u, 45_000u); // 10..500ms per frame
         foreach (var (sample, key) in _pending)
         {
+            if (key)
+                _syncPoints.Add((_decodeTime, _file.Position)); // moof starts here
             _file.Write(FMp4.BuildFragment(_sequence++, _decodeTime, per, sample, key));
             _decodeTime += per;
         }
         _pending = null;
     }
 
-    /// <summary>Writes the held-back frames and closes the file.</summary>
+    /// <summary>Writes the held-back frames, patches the duration and closes the file.</summary>
     public void Dispose()
     {
         try
         {
             FlushPending((uint)(NominalFrame * (_pending?.Count ?? 1)));
+            WriteMfra();
+            PatchDurations();
             _file.Flush();
         }
         catch (IOException) { }
         finally
         {
             _file.Dispose();
+        }
+    }
+
+    /// <summary>Backfills the total duration into the init-segment headers.</summary>
+    private void PatchDurations()
+    {
+        if (_decodeTime == 0) return;
+        // mvhd/tkhd run on the movie timescale (1000 = ms), mdhd on the media
+        // timescale (90 kHz). All are version-0 boxes, i.e. 32-bit durations.
+        uint ms = (uint)Math.Min(uint.MaxValue, _decodeTime * 1000 / FMp4.Timescale);
+        uint ticks = (uint)Math.Min(uint.MaxValue, _decodeTime);
+        if (_mvhdOffset >= 0) WriteU32At(_mvhdOffset + 24, ms);
+        if (_tkhdOffset >= 0) WriteU32At(_tkhdOffset + 28, ms);
+        if (_mdhdOffset >= 0) WriteU32At(_mdhdOffset + 24, ticks);
+        _file.Seek(0, SeekOrigin.End);
+    }
+
+    /// <summary>
+    /// Appends the mfra box: one tfra entry per keyframe (media time → moof file
+    /// offset) plus the mfro trailer players use to find the index from the file end.
+    /// </summary>
+    private void WriteMfra()
+    {
+        if (_syncPoints.Count == 0) return;
+        int tfraSize = 24 + _syncPoints.Count * 19;
+        int mfraSize = 8 + tfraSize + 16;
+        var buf = new byte[mfraSize];
+        var s = buf.AsSpan();
+
+        BinaryPrimitives.WriteUInt32BigEndian(s, (uint)mfraSize);
+        "mfra"u8.CopyTo(s[4..]);
+
+        var t = s[8..];
+        BinaryPrimitives.WriteUInt32BigEndian(t, (uint)tfraSize);
+        "tfra"u8.CopyTo(t[4..]);
+        BinaryPrimitives.WriteUInt32BigEndian(t[8..], 0x01000000); // version 1 (64-bit fields)
+        BinaryPrimitives.WriteUInt32BigEndian(t[12..], 1);         // track_ID
+        BinaryPrimitives.WriteUInt32BigEndian(t[16..], 0);         // 1-byte traf/trun/sample numbers
+        BinaryPrimitives.WriteUInt32BigEndian(t[20..], (uint)_syncPoints.Count);
+        int p = 24;
+        foreach (var (time, offset) in _syncPoints)
+        {
+            BinaryPrimitives.WriteUInt64BigEndian(t[p..], time);
+            BinaryPrimitives.WriteUInt64BigEndian(t[(p + 8)..], (ulong)offset);
+            t[p + 16] = 1; // traf 1
+            t[p + 17] = 1; // trun 1
+            t[p + 18] = 1; // sample 1
+            p += 19;
+        }
+
+        var m = s[(8 + tfraSize)..];
+        BinaryPrimitives.WriteUInt32BigEndian(m, 16);
+        "mfro"u8.CopyTo(m[4..]);
+        BinaryPrimitives.WriteUInt32BigEndian(m[8..], 0);           // version/flags
+        BinaryPrimitives.WriteUInt32BigEndian(m[12..], (uint)mfraSize);
+
+        _file.Write(buf);
+    }
+
+    private void WriteU32At(long offset, uint value)
+    {
+        var buf = new byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(buf, value);
+        _file.Seek(offset, SeekOrigin.Begin);
+        _file.Write(buf);
+    }
+
+    /// <summary>Absolute offsets of the duration-carrying boxes inside the init segment.</summary>
+    private static Dictionary<string, int> FindHeaderBoxes(byte[] init)
+    {
+        var found = new Dictionary<string, int>();
+        Walk(0, init.Length);
+        return found;
+
+        void Walk(int pos, int end)
+        {
+            while (pos + 8 <= end)
+            {
+                uint size = BinaryPrimitives.ReadUInt32BigEndian(init.AsSpan(pos));
+                if (size < 8 || pos + size > (uint)end) return;
+                var type = Encoding.ASCII.GetString(init, pos + 4, 4);
+                if (type is "mvhd" or "tkhd" or "mdhd") found[type] = pos;
+                if (type is "moov" or "trak" or "mdia") Walk(pos + 8, pos + (int)size);
+                pos += (int)size;
+            }
         }
     }
 }

--- a/src/Neolink.Server/Recording/RecordingSettings.cs
+++ b/src/Neolink.Server/Recording/RecordingSettings.cs
@@ -17,9 +17,9 @@ public sealed record CameraRecordingSettings(bool Events, bool Continuous, List<
 
 /// <summary>
 /// Per-camera recording switches changeable at runtime from the web UI, persisted
-/// as settings.json in the storage root — so they live on the same (Docker) volume
-/// as the footage and survive restarts. The config file only provides each
-/// camera's initial defaults; once a user flips a switch, this file wins.
+/// as settings.json NEXT TO THE CONFIG FILE (in Docker: the /config mount), so
+/// static config and runtime settings live together. The config file only provides
+/// each camera's initial defaults; once a user flips a switch, this file wins.
 /// </summary>
 public sealed class RecordingSettings
 {
@@ -33,17 +33,27 @@ public sealed class RecordingSettings
     private readonly object _gate = new();
     private Dictionary<string, CameraRecordingSettings> _cameras = new(StringComparer.OrdinalIgnoreCase);
 
-    public RecordingSettings(string root)
+    public RecordingSettings(string configDir, string? legacyDir = null)
     {
-        _file = Path.Combine(root, "settings.json");
+        _file = Path.Combine(configDir, "settings.json");
         try
         {
-            if (File.Exists(_file))
+            // Older versions kept settings.json in the recordings root; migrate once.
+            var source = _file;
+            if (!File.Exists(source) && legacyDir != null
+                && File.Exists(Path.Combine(legacyDir, "settings.json")))
+            {
+                source = Path.Combine(legacyDir, "settings.json");
+                Log.Info($"Recording settings: migrating {source} -> {_file}");
+            }
+            if (File.Exists(source))
             {
                 var loaded = JsonSerializer.Deserialize<Dictionary<string, CameraRecordingSettings>>(
-                    File.ReadAllText(_file), JsonOpts);
+                    File.ReadAllText(source), JsonOpts);
                 if (loaded != null)
                     _cameras = new Dictionary<string, CameraRecordingSettings>(loaded, StringComparer.OrdinalIgnoreCase);
+                if (!ReferenceEquals(source, _file) && source != _file)
+                    lock (_gate) { SaveLocked(); }
             }
         }
         catch (Exception ex)

--- a/src/Neolink.Server/SelfTest.cs
+++ b/src/Neolink.Server/SelfTest.cs
@@ -318,6 +318,14 @@ public static class SelfTest
                 var reloaded = new Recording.RecordingSettings(dir);
                 Assert(reloaded.Get("cam1").Continuous, "settings persisted across restart");
                 Assert(!reloaded.Get("cam1").AllowsLabel("vehicle"), "filter persisted");
+
+                // Migration: settings.json used to live in the recordings root; a fresh
+                // config dir must pick it up from there and re-home it.
+                var newDir = Path.Combine(dir, "new-config-dir");
+                Directory.CreateDirectory(newDir);
+                var migrated = new Recording.RecordingSettings(newDir, legacyDir: dir);
+                Assert(migrated.Get("cam1").Continuous, "legacy settings migrated");
+                Assert(File.Exists(Path.Combine(newDir, "settings.json")), "settings re-homed to config dir");
             }
             finally
             {
@@ -390,6 +398,25 @@ public static class SelfTest
                 var text = Encoding.ASCII.GetString(bytes);
                 Assert(text.Contains("moov"), "init segment present");
                 Assert(text.Contains("moof") && text.Contains("mdat"), "fragments present");
+
+                // The closed file must carry a real duration: browsers trust mvhd,
+                // and duration 0 freezes the <video> on the first frame.
+                static uint DurationAfterTag(byte[] data, string tag, int offsetFromTag)
+                {
+                    int i = Encoding.ASCII.GetString(data).IndexOf(tag, StringComparison.Ordinal);
+                    Assert(i > 0, $"{tag} box present");
+                    return System.Buffers.Binary.BinaryPrimitives.ReadUInt32BigEndian(
+                        data.AsSpan(i + offsetFromTag));
+                }
+                Assert(DurationAfterTag(bytes, "mvhd", 20) > 0, "mvhd duration patched (ms)");
+                Assert(DurationAfterTag(bytes, "tkhd", 24) > 0, "tkhd duration patched (ms)");
+                Assert(DurationAfterTag(bytes, "mdhd", 20) > 0, "mdhd duration patched (90kHz)");
+
+                // The seek index players use: mfra at the end, mfro trailer pointing at it.
+                uint mfraSize = System.Buffers.Binary.BinaryPrimitives.ReadUInt32BigEndian(bytes.AsSpan(bytes.Length - 4));
+                Assert(mfraSize > 24 && mfraSize < bytes.Length, "mfro trailer carries mfra size");
+                AssertEq(Encoding.ASCII.GetString(bytes, bytes.Length - (int)mfraSize + 4, 4), "mfra");
+                Assert(text.Contains("tfra"), "tfra keyframe index present");
             }
             finally
             {

--- a/src/Neolink.WebClient/Components/CameraPanel.razor
+++ b/src/Neolink.WebClient/Components/CameraPanel.razor
@@ -203,7 +203,11 @@
                         </div>
                     </div>
                     <div class="notice small">
-                        Detections of disabled types are discarded — they neither start nor extend events.
+                        ⚠ Person/vehicle/animal labels only arrive when the matching Smart Detection is
+                        enabled <b>in the Reolink app</b> (camera → Settings → Detection) — the camera does
+                        the detecting and must be set up to send this data. The chips above are a Neolink-side
+                        filter on what arrives: disabled types are discarded and the camera's own settings
+                        are never changed.
                     </div>
                 }
             </div>

--- a/src/Neolink.WebClient/Components/Pages/Timeline.razor
+++ b/src/Neolink.WebClient/Components/Pages/Timeline.razor
@@ -43,13 +43,19 @@
             @foreach (var cam in _cameras)
             {
                 var name = cam.Name;
-                <button class="chip @(_excluded.Contains(name) ? "chip-off" : "")"
-                        title="@(_excluded.Contains(name) ? "Excluded — click to include" : "Included — click to exclude")"
+                <button class="chip @(_included.Contains(name) ? "" : "chip-off")"
+                        title="@(_included.Contains(name) ? "Loaded — click to remove" : "Click to load this camera's footage")"
                         @onclick="() => ToggleCameraAsync(name)">@name</button>
             }
-            <span class="event-sub">— scrub the lanes below; colored marks are events</span>
+            <span class="event-sub">— pick the cameras to scrub; nothing loads until selected</span>
         </div>
 
+        @if (!Included.Any())
+        {
+            <div class="notice">Select cameras above to load their footage — colored marks on the lanes are events.</div>
+        }
+        else
+        {
         <div class="tl-board">
             <div class="tl-names">
                 <div class="tl-name"></div>
@@ -91,7 +97,8 @@
             </div>
         </div>
 
-        <div class="tl-grid">
+        @* Tile size adapts to the selection: fewer cameras = bigger tiles. *@
+        <div class="tl-grid" style="grid-template-columns: repeat(@TileColumns(), 1fr);">
             @foreach (var cam in Included)
             {
                 <div class="tl-tile" @key="cam.Name">
@@ -103,11 +110,8 @@
                     <div class="tl-tile-name">@cam.Name</div>
                 </div>
             }
-            @if (!Included.Any())
-            {
-                <div class="notice">All cameras are excluded — include one above.</div>
-            }
         </div>
+        }
     }
 </div>
 
@@ -122,7 +126,7 @@
     private string? _error;
 
     private readonly List<ApiCamera> _cameras = new();
-    private HashSet<string> _excluded = new(StringComparer.OrdinalIgnoreCase);
+    private HashSet<string> _included = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, List<Seg>> _cov = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, List<Mark>> _marks = new(StringComparer.OrdinalIgnoreCase);
     private readonly HashSet<string> _noFootage = new(StringComparer.OrdinalIgnoreCase);
@@ -130,6 +134,8 @@
     private DotNetObjectReference<Timeline>? _selfRef;
     private PeriodicTimer? _clock;
     private DateTime _lastTick;
+    private bool _scrubInit;
+    private bool _booted;
 
     /// <summary>One recording segment: seconds-of-day start, span and playback URL.</summary>
     private sealed record Seg(double Start, double Span, string Url);
@@ -137,40 +143,58 @@
     private sealed record Mark(double Start, double End, string Color, string Title);
 
     private const string PrefsKey = "neolink.timeline";
-    private sealed class Prefs { public List<string> Excluded { get; set; } = new(); }
+    private sealed class Prefs { public List<string> Included { get; set; } = new(); }
 
-    private IEnumerable<ApiCamera> Included => _cameras.Where(c => !_excluded.Contains(c.Name));
+    /// <summary>Only explicitly selected cameras load footage — scrubbing all cams at once is expensive.</summary>
+    private IEnumerable<ApiCamera> Included => _cameras.Where(c => _included.Contains(c.Name));
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (!firstRender) return;
-
-        // Server + credentials are shared with the live view's persisted settings.
-        try
+        if (firstRender)
         {
-            var json = await JS.InvokeAsync<string?>("neolink.lsGet", "neolink.view");
-            if (json != null)
-                _server = JsonSerializer.Deserialize<PersistedView>(json)?.Server ?? "";
-        }
-        catch { }
-        if (string.IsNullOrWhiteSpace(_server))
-            _server = await JS.InvokeAsync<string>("neolink.defaultServer");
+            // Server + credentials are shared with the live view's persisted settings.
+            try
+            {
+                var json = await JS.InvokeAsync<string?>("neolink.lsGet", "neolink.view");
+                if (json != null)
+                    _server = JsonSerializer.Deserialize<PersistedView>(json)?.Server ?? "";
+            }
+            catch { }
+            if (string.IsNullOrWhiteSpace(_server))
+                _server = await JS.InvokeAsync<string>("neolink.defaultServer");
 
-        try
+            try
+            {
+                var json = await JS.InvokeAsync<string?>("neolink.lsGet", PrefsKey);
+                if (json != null && JsonSerializer.Deserialize<Prefs>(json) is { } p)
+                    _included = new HashSet<string>(p.Included, StringComparer.OrdinalIgnoreCase);
+            }
+            catch { }
+
+            await LoadCamerasAsync();
+            _included.RemoveWhere(name => _cameras.All(c => !string.Equals(c.Name, name, StringComparison.OrdinalIgnoreCase)));
+            await LoadDayAsync();
+
+            _selfRef = DotNetObjectReference.Create(this);
+            _ = ClockLoopAsync();
+            _booted = true;
+            StateHasChanged();
+            return;
+        }
+
+        // The lane strip only exists while cameras are selected; (re)hook the
+        // scrub handler whenever it (re)appears.
+        if (!_booted || _selfRef == null) return;
+        if (Included.Any() && !_scrubInit)
         {
-            var json = await JS.InvokeAsync<string?>("neolink.lsGet", PrefsKey);
-            if (json != null && JsonSerializer.Deserialize<Prefs>(json) is { } p)
-                _excluded = new HashSet<string>(p.Excluded, StringComparer.OrdinalIgnoreCase);
+            _scrubInit = true;
+            await JS.InvokeVoidAsync("neolink.tlScrubInit", "tl-scrub", _selfRef);
         }
-        catch { }
-
-        await LoadCamerasAsync();
-        await LoadDayAsync();
-
-        _selfRef = DotNetObjectReference.Create(this);
-        await JS.InvokeVoidAsync("neolink.tlScrubInit", "tl-scrub", _selfRef);
-        _ = ClockLoopAsync();
-        StateHasChanged();
+        else if (!Included.Any() && _scrubInit)
+        {
+            _scrubInit = false;
+            await JS.InvokeVoidAsync("neolink.tlScrubDispose", "tl-scrub");
+        }
     }
 
     // ------------------------------------------------------------ data
@@ -197,30 +221,20 @@
         _cov.Clear();
         _marks.Clear();
         _playing = false;
-        var date = _date.ToString("yyyy-MM-dd");
 
-        // Coverage: the continuous segments of each camera for this day.
-        _supported = true;
-        foreach (var cam in _cameras)
-        {
-            try
-            {
-                var segs = await Http.GetFromJsonAsync<List<ApiSegment>>(
-                    $"{Base}/api/recordings/{Uri.EscapeDataString(cam.Name)}/{date}");
-                _cov[cam.Name] = BuildSegs(segs ?? new List<ApiSegment>(), cam.Name, date);
-            }
-            catch
-            {
-                _supported = false; // endpoint missing = recording disabled server-side
-                return;
-            }
-        }
-
-        // Events of the day, as colored lane marks.
+        // Recording support is probed via the events endpoint (same feature gate),
+        // and the reply doubles as the day's colored lane marks.
         try
         {
-            var events = await Http.GetFromJsonAsync<List<ApiEvent>>($"{Base}/api/events?limit=1000");
-            foreach (var ev in events ?? new List<ApiEvent>())
+            using var res = await Http.GetAsync($"{Base}/api/events?limit=1000");
+            if (!res.IsSuccessStatusCode)
+            {
+                _supported = false;
+                return;
+            }
+            _supported = true;
+            var events = await res.Content.ReadFromJsonAsync<List<ApiEvent>>() ?? new List<ApiEvent>();
+            foreach (var ev in events)
             {
                 var start = ev.Start.ToLocalTime();
                 if (start.Date != _date) continue;
@@ -231,13 +245,36 @@
                 list.Add(new Mark(s, e, LabelColor(ev.Labels), $"{ev.Title} · {start:HH:mm:ss}"));
             }
         }
-        catch { /* events are decoration here; coverage already loaded */ }
+        catch
+        {
+            _supported = false;
+            return;
+        }
+
+        // Coverage only for the cameras the user selected — this is the expensive part.
+        foreach (var cam in Included)
+            await LoadCoverageAsync(cam.Name);
 
         // Land the cursor somewhere useful: near-now for today, else midday.
         _t = _date == DateTime.Today
             ? Math.Max(0, (DateTime.Now - _date).TotalSeconds - 30)
             : DaySeconds / 2;
         await SyncVideosAsync();
+    }
+
+    private async Task LoadCoverageAsync(string camera)
+    {
+        var date = _date.ToString("yyyy-MM-dd");
+        try
+        {
+            var segs = await Http.GetFromJsonAsync<List<ApiSegment>>(
+                $"{Base}/api/recordings/{Uri.EscapeDataString(camera)}/{date}");
+            _cov[camera] = BuildSegs(segs ?? new List<ApiSegment>(), camera, date);
+        }
+        catch
+        {
+            _cov[camera] = new List<Seg>();
+        }
     }
 
     /// <summary>
@@ -369,20 +406,30 @@
 
     private async Task ToggleCameraAsync(string name)
     {
-        if (!_excluded.Remove(name))
-            _excluded.Add(name);
-        await JS.InvokeVoidAsync("neolink.lsSet", PrefsKey,
-            JsonSerializer.Serialize(new Prefs { Excluded = _excluded.ToList() }));
-        // A camera coming back needs its coverage if the day was loaded before it existed.
-        if (!_excluded.Contains(name) && !_cov.ContainsKey(name))
-            await LoadDayAsync();
+        if (_included.Remove(name))
+        {
+            _cov.Remove(name); // free it; reselecting fetches fresh coverage
+        }
         else
-            await SyncVideosAsync();
+        {
+            _included.Add(name);
+            await LoadCoverageAsync(name); // lazy: only now does this camera cost anything
+        }
+        await JS.InvokeVoidAsync("neolink.lsSet", PrefsKey,
+            JsonSerializer.Serialize(new Prefs { Included = _included.ToList() }));
+        await SyncVideosAsync();
     }
 
     // ------------------------------------------------------------ helpers
 
     private static string VideoId(string camera) => "tlv-" + Uri.EscapeDataString(camera);
+
+    /// <summary>Square-ish grid: 1 cam fills the stage, 2 side by side, 3-4 in a 2x2, ...</summary>
+    private int TileColumns()
+    {
+        int n = Included.Count();
+        return n <= 1 ? 1 : (int)Math.Ceiling(Math.Sqrt(n));
+    }
 
     private static string Pct(double seconds) =>
         $"{seconds / DaySeconds * 100:0.###}%";

--- a/src/Neolink.WebClient/wwwroot/css/app.css
+++ b/src/Neolink.WebClient/wwwroot/css/app.css
@@ -901,8 +901,7 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
 
 .tl-grid {
     flex: 1;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    display: grid; /* columns are set inline: fewer cameras = bigger tiles */
     gap: 8px;
     padding: 4px 12px 12px;
     overflow-y: auto;


### PR DESCRIPTION
Follow-up to #5 — fixes from real-hardware testing plus scope/UX corrections.

## Fix: clips froze in browsers / continuous files wouldn't open in VLC
Same root cause for both: the recorded fMP4 files reused the live/MSE init segment, which declares **duration 0** — players trust `mvhd` and treat the file as zero-length (browsers freeze on frame one, VLC refuses to open). `ClipWriter` now:
- patches the real duration into `mvhd`/`tkhd`/`mdhd` when a file closes, and
- appends an **`mfra`/`mfro` keyframe index** (time → moof offset) so VLC/ffmpeg open and *seek* the files like ordinary MP4s.

Applies to both event clips and continuous segments. Files recorded before the fix keep the zero duration (`ffmpeg -i old.mp4 -c copy fixed.mp4` repairs them); the segment currently being written is finalized when it rolls.

## Timeline: cameras are opt-in
Loading every camera's footage by default was too expensive. The page now starts idle — coverage is fetched per camera at the moment it's selected (freed on deselect), selection persists in localStorage, and the scrub handler re-hooks itself since the lane strip appears late. Tile grid stays dynamic (fewer cameras = bigger tiles).

## Event-type chips: camera-side control reverted
The `GetAiCfg`/`SetAiCfg` experiment was rolled back before ever landing (E1-class cameras have no HTTP API, so it was misleading for exactly the cameras this project targets). The chips are a Neolink-side filter again, now with an explicit panel/README note: **person/vehicle/animal labels only arrive when Smart Detection is enabled in the Reolink app** — the camera does the detecting, Neolink filters what arrives and never changes camera settings.

## settings.json → config directory
Runtime recording switches now persist next to `config.json` instead of inside the recordings root, with one-time auto-migration from the old location. Docker examples now mount a config *directory* (`./config:/config`) rather than a single read-only file, so runtime settings survive container recreation.

## Reviewer notes
- 18/18 self-tests, with new assertions for the patched durations, the `mfra`/`mfro` structure, and the settings migration. Timeline opt-in flow verified in a live browser session (idle by default → select camera → lanes/tiles appear → scrub works → per-day coverage loads).
- Needs a real-hardware check: let a fresh continuous segment roll, then open it in VLC and replay a new event clip in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)