### PR TITLE
Temporarily disable continuous (24/7) recording; event recording stays

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,11 @@ the original Rust neolink are also accepted.
 
 ### Recording (`"recording": { ... }`)
 
+> ⚠ **Continuous (24/7) recording is temporarily disabled** while its
+> file/playback issues are ironed out — the per-camera switch, the timeline and
+> the recordings browser are hidden until it returns. **Detection events are
+> unaffected** and record normally.
+
 Two recording modes, both switchable **per camera at runtime** from the web UI
 (camera ⚙ → RECORDING) — the switches persist in `settings.json` next to your
 config file (in Docker: the `/config` mount), so they survive restarts:

--- a/src/Neolink.Server/Config/NeolinkConfig.cs
+++ b/src/Neolink.Server/Config/NeolinkConfig.cs
@@ -360,6 +360,15 @@ public sealed class UserConfig
 /// <summary>Event recording settings ("recording" in the config).</summary>
 public sealed class RecordingConfig
 {
+    /// <summary>
+    /// Kill switch for continuous (24/7) recording, temporarily off while its
+    /// file/playback issues are ironed out. Event recording is unaffected.
+    /// When false: no ContinuousRecorder runs, the /api/recordings endpoints are
+    /// absent, the per-camera switch is hidden, and the timeline page explains
+    /// itself. Flip to true to bring the feature back.
+    /// </summary>
+    public static bool ContinuousEnabled => false;
+
     /// <summary>Storage directory for clips/thumbnails/event metadata (mount a volume here in Docker).</summary>
     public string Path { get; set; } = "";
     /// <summary>Days to keep events; 0 keeps them forever.</summary>

--- a/src/Neolink.Server/Program.cs
+++ b/src/Neolink.Server/Program.cs
@@ -180,9 +180,14 @@ foreach (var cam in config.Cameras)
             primaryService.MotionSink = recorder.OnMotion;
             tasks.Add(Task.Run(() => recorder.RunAsync(shutdown.Token)));
 
-            var continuous = new ContinuousRecorder(cam.Name, recordStream.Hub, eventStore,
-                recordingSettings, config.Recording);
-            tasks.Add(Task.Run(() => continuous.RunAsync(shutdown.Token)));
+            // Continuous (24/7) recording is temporarily disabled — see
+            // RecordingConfig.ContinuousEnabled.
+            if (RecordingConfig.ContinuousEnabled)
+            {
+                var continuous = new ContinuousRecorder(cam.Name, recordStream.Hub, eventStore,
+                    recordingSettings, config.Recording);
+                tasks.Add(Task.Run(() => continuous.RunAsync(shutdown.Token)));
+            }
         }
     }
 }

--- a/src/Neolink.Server/Web/WebApi.cs
+++ b/src/Neolink.Server/Web/WebApi.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Neolink.Config;
 using Neolink.Media;
 using Neolink.Protocol;
 using Neolink.Recording;
@@ -80,6 +81,13 @@ public static class WebApi
         });
 
         app.UseWebSockets(new WebSocketOptions { KeepAliveInterval = TimeSpan.FromSeconds(20) });
+
+        // Feature discovery, so clients can hide UI for what this server won't do.
+        app.MapGet("/api/features", () => Results.Json(new
+        {
+            events = events != null,
+            continuous = events != null && RecordingConfig.ContinuousEnabled,
+        }));
 
         app.MapGet("/api/cameras", () =>
         {
@@ -365,7 +373,8 @@ public static class WebApi
             object ShapeSettings(CameraRecordingSettings s) => new
             {
                 events = s.Events,
-                continuous = s.Continuous,
+                continuous = RecordingConfig.ContinuousEnabled && s.Continuous,
+                continuousAvailable = RecordingConfig.ContinuousEnabled,
                 eventTypes = s.EventTypes,
                 knownTypes = CameraRecordingSettings.KnownLabels,
             };
@@ -392,11 +401,16 @@ public static class WebApi
                     types = req.EventTypes.Select(t => t.Trim().ToLowerInvariant())
                         .Where(t => t.Length > 0).Distinct().ToList();
                 }
-                var updated = recordingSettings.Update(cam.Name, req.Events, req.Continuous,
+                // The continuous switch is inert while the feature is disabled.
+                var continuous = RecordingConfig.ContinuousEnabled ? req.Continuous : null;
+                var updated = recordingSettings.Update(cam.Name, req.Events, continuous,
                     types, setEventTypes: req.EventTypes != null);
                 return Results.Json(ShapeSettings(updated));
             });
+        }
 
+        if (events != null && RecordingConfig.ContinuousEnabled)
+        {
             app.MapGet("/api/recordings/{camera}", (string camera) =>
             {
                 var cam = cameras.FirstOrDefault(c => string.Equals(c.Name, camera, StringComparison.OrdinalIgnoreCase));

--- a/src/Neolink.Server/config.example.json
+++ b/src/Neolink.Server/config.example.json
@@ -14,8 +14,8 @@
   // Serve the browser UI on web_port. Set false for API-only / headless setups.
   "webui": true,
 
-  // Optional: recording to disk — motion/AI detection events (clips + thumbnails)
-  // and, when switched on per camera in the web UI, continuous 24/7 footage.
+  // Optional: recording to disk — motion/AI detection events (clips + thumbnails).
+  // (Continuous 24/7 recording is temporarily disabled in this build.)
   // Remove this section to disable. In Docker, mount a volume at "path".
   // "recording": {
   //   "path": "/recordings",           // storage directory

--- a/src/Neolink.WebClient/Components/CameraPanel.razor
+++ b/src/Neolink.WebClient/Components/CameraPanel.razor
@@ -180,13 +180,16 @@
                         @(_recording.Events ? "on" : "off")
                     </button>
                 </div>
-                <div class="control-row">
-                    <span>Continuous (24/7)</span>
-                    <button class="chip @(_recording.Continuous ? "" : "chip-off")"
-                            @onclick="() => SetRecordingAsync(continuous: !_recording.Continuous)">
-                        @(_recording.Continuous ? "on" : "off")
-                    </button>
-                </div>
+                @if (_recording.ContinuousAvailable)
+                {
+                    <div class="control-row">
+                        <span>Continuous (24/7)</span>
+                        <button class="chip @(_recording.Continuous ? "" : "chip-off")"
+                                @onclick="() => SetRecordingAsync(continuous: !_recording.Continuous)">
+                            @(_recording.Continuous ? "on" : "off")
+                        </button>
+                    </div>
+                }
                 @if (_recording.Events)
                 {
                     <div class="control-row rec-types-row">

--- a/src/Neolink.WebClient/Components/Pages/Home.razor
+++ b/src/Neolink.WebClient/Components/Pages/Home.razor
@@ -143,7 +143,10 @@
                 <span class="tool-sep"></span>
                 <button class="tool-btn @(_showEventsPanel ? "active" : "")" title="Event history"
                         @onclick="() => _showEventsPanel = !_showEventsPanel">🕘 <span class="tool-name">Events</span></button>
-                <a class="tool-btn" href="timeline" title="Scrub recorded footage across all cameras">📼 <span class="tool-name">Timeline</span></a>
+                @if (_continuousSupported)
+                {
+                    <a class="tool-btn" href="timeline" title="Scrub recorded footage across all cameras">📼 <span class="tool-name">Timeline</span></a>
+                }
             }
         </div>
 
@@ -214,8 +217,11 @@
             <div class="campanel-head">
                 <button class="chip @(_panelTab == "events" ? "" : "chip-off")"
                         @onclick='() => _panelTab = "events"'>🕘 Events</button>
-                <button class="chip @(_panelTab == "recordings" ? "" : "chip-off")"
-                        @onclick="OpenRecordingsTabAsync">🎞 Recordings</button>
+                @if (_continuousSupported)
+                {
+                    <button class="chip @(_panelTab == "recordings" ? "" : "chip-off")"
+                            @onclick="OpenRecordingsTabAsync">🎞 Recordings</button>
+                }
                 <span class="tile-spacer"></span>
                 @if (_panelTab == "events")
                 {
@@ -406,6 +412,7 @@
     // Recorded events (populated when the server has recording enabled)
     private readonly List<ApiEvent> _events = new();
     private bool _eventsSupported;
+    private bool _continuousSupported;
     private bool _showEventsPanel;
     private string _eventCameraFilter = "";
     private bool _eventsUnreviewedOnly;
@@ -562,6 +569,16 @@
     private async Task RefreshEventsAsync()
     {
         if (string.IsNullOrWhiteSpace(_server)) return;
+        try
+        {
+            var features = await Http.GetFromJsonAsync<ApiFeaturesInfo>($"{_server.TrimEnd('/')}/api/features");
+            _continuousSupported = features?.Continuous == true;
+            if (!_continuousSupported && _panelTab == "recordings") _panelTab = "events";
+        }
+        catch
+        {
+            _continuousSupported = false;
+        }
         try
         {
             using var res = await Http.GetAsync($"{_server.TrimEnd('/')}/api/events?limit=300");

--- a/src/Neolink.WebClient/Components/Pages/Timeline.razor
+++ b/src/Neolink.WebClient/Components/Pages/Timeline.razor
@@ -36,6 +36,14 @@
             and switch cameras to Continuous (24/7) to use the timeline.
         </div>
     }
+    else if (!_continuous)
+    {
+        <div class="notice">
+            Continuous (24/7) recording is temporarily disabled in this build — the timeline
+            scrubs that footage and will return together with it. Detection events still record
+            and play from the 🕘 Events panel on the live view.
+        </div>
+    }
     else
     {
         <div class="tl-cams">
@@ -123,6 +131,7 @@
     private double _t;
     private bool _playing;
     private bool _supported = true;
+    private bool _continuous = true;
     private string? _error;
 
     private readonly List<ApiCamera> _cameras = new();
@@ -222,8 +231,21 @@
         _marks.Clear();
         _playing = false;
 
-        // Recording support is probed via the events endpoint (same feature gate),
-        // and the reply doubles as the day's colored lane marks.
+        // Feature gates first: the timeline needs recording AND continuous footage.
+        try
+        {
+            var features = await Http.GetFromJsonAsync<ApiFeaturesInfo>($"{Base}/api/features");
+            _supported = features?.Events == true;
+            _continuous = features?.Continuous == true;
+        }
+        catch
+        {
+            _supported = false;
+            return;
+        }
+        if (!_supported || !_continuous) return;
+
+        // The events reply doubles as the day's colored lane marks.
         try
         {
             using var res = await Http.GetAsync($"{Base}/api/events?limit=1000");
@@ -232,7 +254,6 @@
                 _supported = false;
                 return;
             }
-            _supported = true;
             var events = await res.Content.ReadFromJsonAsync<List<ApiEvent>>() ?? new List<ApiEvent>();
             foreach (var ev in events)
             {

--- a/src/Neolink.WebClient/Models.cs
+++ b/src/Neolink.WebClient/Models.cs
@@ -42,9 +42,12 @@ public sealed record ApiEncodeProfile(string Type, uint Width, uint Height,
 /// <summary>GET /api/cameras/{name}/streaminfo — the encode profiles of each stream.</summary>
 public sealed record ApiStreamProfiles(List<ApiEncodeProfile> Profiles);
 
+/// <summary>Server capability flags (GET /api/features).</summary>
+public sealed record ApiFeaturesInfo(bool Events, bool Continuous);
+
 /// <summary>GET/POST /api/cameras/{name}/recording — runtime recording switches.</summary>
 public sealed record ApiRecordingSettings(bool Events, bool Continuous,
-    List<string>? EventTypes, List<string>? KnownTypes)
+    List<string>? EventTypes, List<string>? KnownTypes, bool ContinuousAvailable = false)
 {
     /// <summary>null EventTypes = every detection type is recorded.</summary>
     public bool TypeEnabled(string label) => EventTypes == null || EventTypes.Contains(label);


### PR DESCRIPTION
Continuous recording caused too many problems in the field — switch it off until its file/playback issues are settled. **Detection events are unaffected and keep recording.**

## How
One flag gates everything: `RecordingConfig.ContinuousEnabled => false`.

- **Server**: no `ContinuousRecorder` tasks start (zero segment writes); the `/api/recordings/*` endpoints are not mapped; the per-camera continuous switch is inert — POSTs ignore it and replies report `continuous: false, continuousAvailable: false`.
- **Feature discovery**: new `GET /api/features` → `{ "events": true, "continuous": false }` so clients can hide UI for what the server won't do.
- **Web UI**: the 📼 Timeline button, the 🎞 Recordings tab and the Continuous (24/7) panel row hide themselves; navigating to `/timeline` directly shows a notice pointing at the still-working 🕘 Events panel.
- **Docs**: README + config.example note the state.

Flipping the flag back to `true` restores every surface — no other changes needed.

## Verified
- 18/18 self-tests.
- Live: `/api/features` reports the right flags, `/api/events` keeps working, `/api/recordings/{cam}` returns 404, and `POST .../recording {"continuous": true}` is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)