### PR TITLE
HDD-safe continuous recording, trickle previews, web-UI accounts + per-user settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,10 +241,11 @@ the original Rust neolink are also accepted.
 
 ### Recording (`"recording": { ... }`)
 
-> ⚠ **Continuous (24/7) recording is temporarily disabled** while its
-> file/playback issues are ironed out — the per-camera switch, the timeline and
-> the recordings browser are hidden until it returns. **Detection events are
-> unaffected** and record normally.
+> 💾 **Slow disks are handled**: all recording I/O runs on dedicated
+> low-priority writer threads behind a bounded memory budget, so an HDD that
+> stalls (cache flushes, spin-ups, network shares) can never lag the service or
+> the live streams — if the disk falls behind, *recorded* frames are dropped
+> (with a log warning) and recording resumes at the next keyframe.
 
 Two recording modes, both switchable **per camera at runtime** from the web UI
 (camera ⚙ → RECORDING) — the switches persist in `settings.json` next to your

--- a/README.md
+++ b/README.md
@@ -238,6 +238,26 @@ the original Rust neolink are also accepted.
 | `web_bind` | = `bind` | Separate bind address for the web port |
 | `users` | *(none)* | RTSP Basic-auth users: `{ "name", "pass" }`. Omit for open access |
 | `recording` | *(none)* | Event recording (see below). Omit to disable |
+| `reset_admin_password` | `false` | Web-UI recovery: while `true`, the login screen allows setting a new admin password. Turn it back off after use |
+
+### Web UI sign-in
+
+Authentication is **off by default** — no database, no config required. The
+first visitor is prompted to create the **admin** account (or dismiss and do it
+later via ⚙ → "Enable login…"); creating it turns sign-in on for the whole UI
+and API. Accounts live in `users.json` next to your config: passwords are
+stored as PBKDF2-SHA256 (210k iterations, per-user salt, constant-time
+verification — safe for an open-source, file-based setup), and sessions are
+HMAC-signed tokens that expire after 30 days and are invalidated the moment a
+password changes.
+
+The admin manages accounts from ⚙ → Users…: add normal users, change any
+password, delete users (the admin itself can't be deleted). **Every account
+keeps its own UI settings** — layout, tiles, review-strip filters — stored
+server-side, so people don't fight over one shared view. Forgot the admin
+password? Set `"reset_admin_password": true` in the config, restart, use
+"Reset admin password…" on the login screen, then set the flag back to
+`false`.
 
 ### Recording (`"recording": { ... }`)
 

--- a/src/Neolink.Server/Config/NeolinkConfig.cs
+++ b/src/Neolink.Server/Config/NeolinkConfig.cs
@@ -361,13 +361,12 @@ public sealed class UserConfig
 public sealed class RecordingConfig
 {
     /// <summary>
-    /// Kill switch for continuous (24/7) recording, temporarily off while its
-    /// file/playback issues are ironed out. Event recording is unaffected.
+    /// Kill switch for continuous (24/7) recording, kept for emergencies.
     /// When false: no ContinuousRecorder runs, the /api/recordings endpoints are
     /// absent, the per-camera switch is hidden, and the timeline page explains
-    /// itself. Flip to true to bring the feature back.
+    /// itself. Event recording is unaffected either way.
     /// </summary>
-    public static bool ContinuousEnabled => false;
+    public static bool ContinuousEnabled => true;
 
     /// <summary>Storage directory for clips/thumbnails/event metadata (mount a volume here in Docker).</summary>
     public string Path { get; set; } = "";

--- a/src/Neolink.Server/Config/NeolinkConfig.cs
+++ b/src/Neolink.Server/Config/NeolinkConfig.cs
@@ -15,6 +15,8 @@ public sealed class NeolinkConfig
     public bool WebUi { get; set; } = true;
     /// <summary>Event recording (motion/AI detections + clips); null = disabled.</summary>
     public RecordingConfig? Recording { get; set; }
+    /// <summary>Recovery switch: while true, the login screen allows setting a new admin password.</summary>
+    public bool ResetAdminPassword { get; set; }
     public List<UserConfig> Users { get; } = new();
     public List<CameraConfig> Cameras { get; } = new();
 
@@ -76,6 +78,9 @@ public sealed class NeolinkConfig
                     break;
                 case "recording":
                     config.Recording = ParseJsonRecording(prop.Value);
+                    break;
+                case "resetadminpassword":
+                    config.ResetAdminPassword = prop.Value.GetBoolean();
                     break;
                 case "users":
                     foreach (var u in prop.Value.EnumerateArray())
@@ -188,6 +193,7 @@ public sealed class NeolinkConfig
             WebPort = (int)(MiniToml.GetInt(root, "web_port") ?? 8655),
             WebBind = MiniToml.GetString(root, "web_bind"),
             WebUi = MiniToml.GetBool(root, "web_ui") ?? MiniToml.GetBool(root, "webui") ?? true,
+            ResetAdminPassword = MiniToml.GetBool(root, "reset_admin_password") ?? false,
         };
 
         if (MiniToml.GetString(root, "certificate") != null)

--- a/src/Neolink.Server/Program.cs
+++ b/src/Neolink.Server/Program.cs
@@ -195,12 +195,22 @@ foreach (var cam in config.Cameras)
 // Web API (camera list + fMP4 live streams for browsers); guarded like the cameras.
 if (config.WebPort > 0)
 {
+    // Web-UI accounts (users.json next to the config). Auth is off until the
+    // first account (the admin) is created from the UI itself.
+    var userStore = new UserStore(Path.GetDirectoryName(Path.GetFullPath(configPath))!);
+    if (!userStore.Enabled)
+        Log.Info("Web UI authentication is off — create the admin account from the UI to enable it");
+    if (config.ResetAdminPassword)
+        Log.Warn("reset_admin_password is TRUE: anyone reaching the login page can set a new admin " +
+                 "password. Set it back to false as soon as the reset is done!");
+
     tasks.Add(Task.Run(async () =>
     {
         try
         {
             await WebApi.RunAsync(config.WebBind ?? config.BindAddr, config.WebPort, config.WebUi,
-                webCameras, users, config.BindPort, eventStore, recordingSettings, shutdown.Token);
+                webCameras, users, config.BindPort, eventStore, recordingSettings,
+                userStore, config.ResetAdminPassword, shutdown.Token);
         }
         catch (OperationCanceledException) { }
         catch (Exception ex)

--- a/src/Neolink.Server/Recording/ClipWriter.cs
+++ b/src/Neolink.Server/Recording/ClipWriter.cs
@@ -1,4 +1,5 @@
 using System.Buffers.Binary;
+using System.Collections.Concurrent;
 using System.Text;
 using Neolink.Media;
 using Neolink.Streaming;
@@ -12,46 +13,74 @@ namespace Neolink.Recording;
 /// is held back and its measured delta spread evenly across its frames.
 /// Video-only by design — detection clips don't need the audio track.
 ///
+/// Disk I/O is fully decoupled from the caller: fragments are muxed on the
+/// caller's thread but written by a dedicated background thread (below-normal
+/// priority, never a thread-pool thread) behind a bounded memory budget. A slow
+/// disk — HDD flush stalls, spun-down drives, network shares — can therefore
+/// never block the media pipeline or starve the thread pool that live streaming
+/// runs on. When the disk falls behind the budget, recorded frames are dropped
+/// (with a warning) and writing resumes at the next keyframe.
+///
 /// The live-style init segment declares duration 0 (fine for MSE, where fragments
 /// stream in). A FILE with duration 0 freezes browsers on the first frame — the
 /// element believes the clip is zero-length. So the real duration is patched into
 /// mvhd/tkhd/mdhd when the clip closes, and an mfra random-access index (keyframe
 /// time → moof offset) is appended so external players (VLC, ffmpeg) can open and
-/// seek the file like any ordinary MP4.
+/// seek the file like any ordinary MP4. Finalization happens on the writer thread
+/// after <see cref="Dispose"/>; await <see cref="Completion"/> to observe it.
 /// </summary>
 public sealed class ClipWriter : IDisposable
 {
     private const uint NominalFrame = 3000; // ~1/30s @ 90 kHz
+    /// <summary>Max muxed video buffered in memory awaiting disk before frames are dropped.</summary>
+    private const long QueueBudget = 16 * 1024 * 1024;
 
-    private readonly FileStream _file;
+    private readonly string _path;
     private readonly VideoCodec _codec;
-    private readonly int _mvhdOffset;
-    private readonly int _tkhdOffset;
-    private readonly int _mdhdOffset;
+    private readonly BlockingCollection<QueueItem> _queue = new();
+    private readonly TaskCompletionSource _done = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
+    // Mux state — owned by the caller's thread (one producer per writer).
     private uint _sequence = 1;
-    private ulong _decodeTime;
+    private long _decodeTime; // 90 kHz ticks; long so the writer thread can Volatile.Read it
     private bool _haveTs;
     private uint _prevTs;
     private bool _waitKeyframe = true; // clips must start decodable
     private List<(byte[] Sample, bool Keyframe)>? _pending;
-    private readonly List<(ulong Time, long Offset)> _syncPoints = new();
+    private bool _dropping;
+    private int _dropped;
+    private bool _disposed;
 
-    private ClipWriter(FileStream file, VideoCodec codec, byte[] init)
+    // Shared with the writer thread.
+    private long _queuedBytes;
+    private volatile bool _faulted;
+
+    private readonly record struct QueueItem(byte[] Data, bool Keyframe, ulong DecodeTime);
+
+    private ClipWriter(string path, VideoCodec codec, byte[] init)
     {
-        _file = file;
+        _path = path;
         _codec = codec;
         var boxes = FindHeaderBoxes(init);
-        _mvhdOffset = boxes.GetValueOrDefault("mvhd", -1);
-        _tkhdOffset = boxes.GetValueOrDefault("tkhd", -1);
-        _mdhdOffset = boxes.GetValueOrDefault("mdhd", -1);
+        new Thread(() => WriteLoop(init, boxes))
+        {
+            IsBackground = true,
+            Name = "clip-writer",
+            Priority = ThreadPriority.BelowNormal, // disk work must never compete with streaming
+        }.Start();
     }
 
-    /// <summary>Seconds of video written so far (upper bound; pending frames included at nominal rate).</summary>
-    public double DurationSeconds =>
-        (_decodeTime + (ulong)(_pending?.Count ?? 0) * NominalFrame) / (double)FMp4.Timescale;
+    /// <summary>The file cannot be written (disk full/gone); callers should drop the writer.</summary>
+    public bool Faulted => _faulted;
 
-    /// <summary>Creates the file and writes the init segment; null when codec params are not known yet.</summary>
+    /// <summary>Completes once the file is finalized (or given up on) after <see cref="Dispose"/>.</summary>
+    public Task Completion => _done.Task;
+
+    /// <summary>Seconds of video muxed so far (upper bound; pending frames included at nominal rate).</summary>
+    public double DurationSeconds =>
+        ((ulong)_decodeTime + (ulong)(_pending?.Count ?? 0) * NominalFrame) / (double)FMp4.Timescale;
+
+    /// <summary>Prepares a clip file; null when codec params are not known yet. Never blocks on disk.</summary>
     public static ClipWriter? TryCreate(string path, IStreamHub hub)
     {
         var codec = hub.Codec;
@@ -59,19 +88,8 @@ public sealed class ClipWriter : IDisposable
         var pps = hub.Pps;
         if (codec == null || sps == null || pps == null)
             return null;
-
-        var file = new FileStream(path, FileMode.Create, FileAccess.ReadWrite, FileShare.Read, 64 * 1024);
-        try
-        {
-            var init = FMp4.BuildInit(codec.Value, sps, pps, hub.Vps, hub.Width, hub.Height);
-            file.Write(init);
-            return new ClipWriter(file, codec.Value, init);
-        }
-        catch
-        {
-            file.Dispose();
-            throw;
-        }
+        var init = FMp4.BuildInit(codec.Value, sps, pps, hub.Vps, hub.Width, hub.Height);
+        return new ClipWriter(path, codec.Value, init);
     }
 
     /// <summary>
@@ -80,7 +98,7 @@ public sealed class ClipWriter : IDisposable
     /// the hub index of EVERY packet (audio included): hub indices are global, so a
     /// video-only view sees non-consecutive indices whenever audio is interleaved,
     /// and treating those as drops would silently discard all P-frames.
-    /// After a real drop, writing resumes at the next keyframe.
+    /// After a real drop, writing resumes at the next keyframe. Never blocks on disk.
     /// </summary>
     public void Add(HubVideo v, bool gap = false)
     {
@@ -117,53 +135,146 @@ public sealed class ClipWriter : IDisposable
         uint per = Math.Clamp(totalDuration / (uint)_pending.Count, 900u, 45_000u); // 10..500ms per frame
         foreach (var (sample, key) in _pending)
         {
-            if (key)
-                _syncPoints.Add((_decodeTime, _file.Position)); // moof starts here
-            _file.Write(FMp4.BuildFragment(_sequence++, _decodeTime, per, sample, key));
+            Enqueue(FMp4.BuildFragment(_sequence++, (ulong)_decodeTime, per, sample, key), key, (ulong)_decodeTime);
             _decodeTime += per;
         }
         _pending = null;
     }
 
-    /// <summary>Writes the held-back frames, patches the duration and closes the file.</summary>
-    public void Dispose()
+    /// <summary>
+    /// Hands one muxed fragment to the writer thread — or drops it when the disk
+    /// is too far behind. Drops start when the budget is exceeded and end at the
+    /// first keyframe after the backlog has halved, so the file stays decodable.
+    /// </summary>
+    private void Enqueue(byte[] fragment, bool keyframe, ulong decodeTime)
     {
+        if (_faulted) return;
+        long queued = Interlocked.Read(ref _queuedBytes);
+        if (_dropping)
+        {
+            if (!keyframe || queued > QueueBudget / 2)
+            {
+                _dropped++;
+                return;
+            }
+            Log.Warn($"{_path}: storage caught up (dropped {_dropped} recorded frame(s))");
+            _dropping = false;
+            _dropped = 0;
+        }
+        else if (queued > QueueBudget)
+        {
+            _dropping = true;
+            _dropped = 1;
+            Log.Warn($"{_path}: storage cannot keep up (>{QueueBudget / (1024 * 1024)} MB pending); " +
+                     "dropping recorded frames until it recovers — live streaming is unaffected");
+            return;
+        }
+
+        Interlocked.Add(ref _queuedBytes, fragment.Length);
         try
         {
-            FlushPending((uint)(NominalFrame * (_pending?.Count ?? 1)));
-            WriteMfra();
-            PatchDurations();
-            _file.Flush();
+            _queue.Add(new QueueItem(fragment, keyframe, decodeTime));
         }
-        catch (IOException) { }
-        finally
+        catch (InvalidOperationException)
         {
-            _file.Dispose();
+            // Adding completed concurrently (disposed): give the budget back.
+            Interlocked.Add(ref _queuedBytes, -fragment.Length);
         }
     }
 
-    /// <summary>Backfills the total duration into the init-segment headers.</summary>
-    private void PatchDurations()
+    /// <summary>
+    /// Flushes the held-back frames and hands the file to the writer thread for
+    /// finalization (mfra index + duration patch). Returns immediately; the file
+    /// is complete when <see cref="Completion"/> finishes.
+    /// </summary>
+    public void Dispose()
     {
-        if (_decodeTime == 0) return;
+        if (_disposed) return;
+        FlushPending((uint)(NominalFrame * (_pending?.Count ?? 1)));
+        _disposed = true;
+        _queue.CompleteAdding();
+    }
+
+    // ------------------------------------------------------------------ writer thread
+
+    private void WriteLoop(byte[] init, Dictionary<string, int> boxes)
+    {
+        FileStream? file = null;
+        bool failed = false;
+        var syncPoints = new List<(ulong Time, long Offset)>();
+        try
+        {
+            // Large buffer: fewer, bigger writes are what HDDs want.
+            file = new FileStream(_path, FileMode.Create, FileAccess.ReadWrite, FileShare.Read, 1 << 20);
+            file.Write(init);
+        }
+        catch (Exception ex)
+        {
+            failed = true;
+            _faulted = true;
+            Log.Warn($"{_path}: cannot create clip file: {ex.Message}");
+        }
+
+        // Consume until the producer completes; after a failure keep draining so
+        // the producer's memory budget is released instead of pinned.
+        foreach (var item in _queue.GetConsumingEnumerable())
+        {
+            Interlocked.Add(ref _queuedBytes, -item.Data.Length);
+            if (failed) continue;
+            try
+            {
+                if (item.Keyframe)
+                    syncPoints.Add((item.DecodeTime, file!.Position));
+                file!.Write(item.Data);
+            }
+            catch (Exception ex)
+            {
+                failed = true;
+                _faulted = true;
+                Log.Warn($"{_path}: clip write failed: {ex.Message}");
+            }
+        }
+
+        if (!failed)
+        {
+            try
+            {
+                WriteMfra(file!, syncPoints);
+                PatchDurations(file!, boxes);
+                file!.Flush();
+            }
+            catch (Exception ex)
+            {
+                Log.Warn($"{_path}: clip finalize failed: {ex.Message}");
+            }
+        }
+        file?.Dispose();
+        _done.TrySetResult();
+    }
+
+    /// <summary>Backfills the total duration into the init-segment headers.</summary>
+    private void PatchDurations(FileStream file, Dictionary<string, int> boxes)
+    {
+        ulong decodeTime = (ulong)Volatile.Read(ref _decodeTime);
+        if (decodeTime == 0) return;
         // mvhd/tkhd run on the movie timescale (1000 = ms), mdhd on the media
         // timescale (90 kHz). All are version-0 boxes, i.e. 32-bit durations.
-        uint ms = (uint)Math.Min(uint.MaxValue, _decodeTime * 1000 / FMp4.Timescale);
-        uint ticks = (uint)Math.Min(uint.MaxValue, _decodeTime);
-        if (_mvhdOffset >= 0) WriteU32At(_mvhdOffset + 24, ms);
-        if (_tkhdOffset >= 0) WriteU32At(_tkhdOffset + 28, ms);
-        if (_mdhdOffset >= 0) WriteU32At(_mdhdOffset + 24, ticks);
-        _file.Seek(0, SeekOrigin.End);
+        uint ms = (uint)Math.Min(uint.MaxValue, decodeTime * 1000 / FMp4.Timescale);
+        uint ticks = (uint)Math.Min(uint.MaxValue, decodeTime);
+        if (boxes.TryGetValue("mvhd", out var mvhd)) WriteU32At(file, mvhd + 24, ms);
+        if (boxes.TryGetValue("tkhd", out var tkhd)) WriteU32At(file, tkhd + 28, ms);
+        if (boxes.TryGetValue("mdhd", out var mdhd)) WriteU32At(file, mdhd + 24, ticks);
+        file.Seek(0, SeekOrigin.End);
     }
 
     /// <summary>
     /// Appends the mfra box: one tfra entry per keyframe (media time → moof file
     /// offset) plus the mfro trailer players use to find the index from the file end.
     /// </summary>
-    private void WriteMfra()
+    private static void WriteMfra(FileStream file, List<(ulong Time, long Offset)> syncPoints)
     {
-        if (_syncPoints.Count == 0) return;
-        int tfraSize = 24 + _syncPoints.Count * 19;
+        if (syncPoints.Count == 0) return;
+        int tfraSize = 24 + syncPoints.Count * 19;
         int mfraSize = 8 + tfraSize + 16;
         var buf = new byte[mfraSize];
         var s = buf.AsSpan();
@@ -177,9 +288,9 @@ public sealed class ClipWriter : IDisposable
         BinaryPrimitives.WriteUInt32BigEndian(t[8..], 0x01000000); // version 1 (64-bit fields)
         BinaryPrimitives.WriteUInt32BigEndian(t[12..], 1);         // track_ID
         BinaryPrimitives.WriteUInt32BigEndian(t[16..], 0);         // 1-byte traf/trun/sample numbers
-        BinaryPrimitives.WriteUInt32BigEndian(t[20..], (uint)_syncPoints.Count);
+        BinaryPrimitives.WriteUInt32BigEndian(t[20..], (uint)syncPoints.Count);
         int p = 24;
-        foreach (var (time, offset) in _syncPoints)
+        foreach (var (time, offset) in syncPoints)
         {
             BinaryPrimitives.WriteUInt64BigEndian(t[p..], time);
             BinaryPrimitives.WriteUInt64BigEndian(t[(p + 8)..], (ulong)offset);
@@ -195,15 +306,15 @@ public sealed class ClipWriter : IDisposable
         BinaryPrimitives.WriteUInt32BigEndian(m[8..], 0);           // version/flags
         BinaryPrimitives.WriteUInt32BigEndian(m[12..], (uint)mfraSize);
 
-        _file.Write(buf);
+        file.Write(buf);
     }
 
-    private void WriteU32At(long offset, uint value)
+    private static void WriteU32At(FileStream file, long offset, uint value)
     {
         var buf = new byte[4];
         BinaryPrimitives.WriteUInt32BigEndian(buf, value);
-        _file.Seek(offset, SeekOrigin.Begin);
-        _file.Write(buf);
+        file.Seek(offset, SeekOrigin.Begin);
+        file.Write(buf);
     }
 
     /// <summary>Absolute offsets of the duration-carrying boxes inside the init segment.</summary>

--- a/src/Neolink.Server/Recording/ContinuousRecorder.cs
+++ b/src/Neolink.Server/Recording/ContinuousRecorder.cs
@@ -83,6 +83,8 @@ public sealed class ContinuousRecorder
                     if (!v.Keyframe || DateTime.UtcNow < retryAfter) continue;
                     try
                     {
+                        // Never blocks on disk: the file is opened and written by the
+                        // writer's own background thread.
                         writer = ClipWriter.TryCreate(_store.NewSegmentPath(_camera, DateTime.Now), _hub);
                     }
                     catch (Exception ex)
@@ -95,13 +97,10 @@ public sealed class ContinuousRecorder
                     gap = false; // fresh file: this keyframe is a clean start
                 }
 
-                try
+                writer.Add(v, gap);
+                if (writer.Faulted)
                 {
-                    writer.Add(v, gap);
-                }
-                catch (Exception ex)
-                {
-                    Log.Warn($"{_camera}: segment write failed: {ex.Message}");
+                    // Disk full/gone — the writer already logged why.
                     writer.Dispose();
                     writer = null;
                     retryAfter = DateTime.UtcNow + WriteErrorBackoff;
@@ -111,7 +110,13 @@ public sealed class ContinuousRecorder
         catch (OperationCanceledException) { }
         finally
         {
-            writer?.Dispose();
+            if (writer != null)
+            {
+                writer.Dispose();
+                // Give the writer thread a moment to finalize the file on shutdown.
+                try { await writer.Completion.WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false); }
+                catch { }
+            }
             _hub.Unsubscribe(id);
         }
     }

--- a/src/Neolink.Server/Recording/EventRecorder.cs
+++ b/src/Neolink.Server/Recording/EventRecorder.cs
@@ -66,12 +66,20 @@ public sealed class EventRecorder
         }
         finally
         {
+            ClipWriter? closing;
             lock (_mediaGate)
             {
-                _writer?.Dispose();
+                closing = _writer;
                 _writer = null;
             }
+            closing?.Dispose();
             try { await pump.ConfigureAwait(false); } catch { }
+            // Give the writer thread a moment to finalize the file on shutdown.
+            if (closing != null)
+            {
+                try { await closing.Completion.WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false); }
+                catch { }
+            }
         }
     }
 
@@ -97,13 +105,12 @@ public sealed class EventRecorder
                 {
                     if (_writer != null)
                     {
-                        try
+                        // Add never blocks on disk (background writer thread); a dead
+                        // disk surfaces as Faulted and the event continues clip-less.
+                        _writer.Add(v, gap);
+                        if (_writer.Faulted)
                         {
-                            _writer.Add(v, gap);
-                        }
-                        catch (Exception ex)
-                        {
-                            Log.Warn($"{_camera}: clip write failed: {ex.Message}");
+                            Log.Warn($"{_camera}: clip writer failed; event continues without further video");
                             _writer.Dispose();
                             _writer = null;
                         }

--- a/src/Neolink.Server/SelfTest.cs
+++ b/src/Neolink.Server/SelfTest.cs
@@ -368,27 +368,31 @@ public static class SelfTest
                     Au(sps, pps, Nal(0x65, 40))));
 
                 var path = Path.Combine(dir, "clip.mp4");
-                using (var writer = Recording.ClipWriter.TryCreate(path, hub))
+                var writer = Recording.ClipWriter.TryCreate(path, hub);
+                Assert(writer != null, "writer created once params are known");
+                // Hub indices jump by 2, as they do when audio packets are
+                // interleaved. That is NOT a drop: the writer must keep every
+                // frame (regression: index-based gap detection dropped all
+                // P-frames, producing near-zero-length clips).
+                long index = 0;
+                uint ts = 1000;
+                writer!.Add(new Streaming.HubVideo(index, Au(Nal(0x65, 40)), true, ts));
+                for (int i = 0; i < 5; i++)
                 {
-                    Assert(writer != null, "writer created once params are known");
-                    // Hub indices jump by 2, as they do when audio packets are
-                    // interleaved. That is NOT a drop: the writer must keep every
-                    // frame (regression: index-based gap detection dropped all
-                    // P-frames, producing near-zero-length clips).
-                    long index = 0;
-                    uint ts = 1000;
-                    writer!.Add(new Streaming.HubVideo(index, Au(Nal(0x65, 40)), true, ts));
-                    for (int i = 0; i < 5; i++)
-                    {
-                        index += 2;
-                        writer.Add(new Streaming.HubVideo(index, Au(Nal(0x41, 25)), false, ts += 3000));
-                    }
-                    Assert(writer.DurationSeconds > 0.15, "all frames survive audio interleave");
-
-                    // A real drop (gap flag) resumes at the next keyframe.
-                    writer.Add(new Streaming.HubVideo(index + 50, Au(Nal(0x41, 25)), false, ts += 3000), gap: true);
-                    writer.Add(new Streaming.HubVideo(index + 51, Au(Nal(0x65, 40)), true, ts += 3000));
+                    index += 2;
+                    writer.Add(new Streaming.HubVideo(index, Au(Nal(0x41, 25)), false, ts += 3000));
                 }
+                Assert(writer.DurationSeconds > 0.15, "all frames survive audio interleave");
+
+                // A real drop (gap flag) resumes at the next keyframe.
+                writer.Add(new Streaming.HubVideo(index + 50, Au(Nal(0x41, 25)), false, ts += 3000), gap: true);
+                writer.Add(new Streaming.HubVideo(index + 51, Au(Nal(0x65, 40)), true, ts += 3000));
+
+                // Disk work is asynchronous by design: the file is finalized on the
+                // writer's own thread after Dispose.
+                writer.Dispose();
+                Assert(writer.Completion.Wait(TimeSpan.FromSeconds(10)), "writer finalizes in background");
+                Assert(!writer.Faulted, "no write faults");
 
                 var bytes = File.ReadAllBytes(path);
                 Assert(bytes.Length > 200, "file has content");

--- a/src/Neolink.Server/SelfTest.cs
+++ b/src/Neolink.Server/SelfTest.cs
@@ -333,6 +333,45 @@ public static class SelfTest
             }
         });
 
+        Test("user store: hashing, tokens, accounts", () =>
+        {
+            var dir = Path.Combine(Path.GetTempPath(), $"neolink-selftest-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(dir);
+            try
+            {
+                var store = new Web.UserStore(dir);
+                Assert(!store.Enabled, "auth off until the first account exists");
+
+                var admin = store.Add("admin", "correct horse", admin: true);
+                Assert(store.Enabled, "auth on once an account exists");
+                Assert(store.Verify("admin", "correct horse") != null, "right password verifies");
+                Assert(store.Verify("admin", "wrong horse") == null, "wrong password fails");
+                Assert(store.Verify("ADMIN", "correct horse") != null, "usernames are case-insensitive");
+                Assert(admin.Hash.StartsWith("pbkdf2-sha256$210000$"), "PBKDF2 format with strong iteration count");
+
+                var token = store.IssueToken(admin);
+                Assert(store.ValidateToken(token)?.Name == "admin", "token round-trips");
+                Assert(store.ValidateToken(token + "x") == null, "tampered token rejected");
+                store.SetPassword("admin", "new password!");
+                Assert(store.ValidateToken(token) == null, "password change invalidates old tokens");
+
+                store.Add("viewer", "viewerpass", admin: false);
+                Assert(!store.Delete("admin"), "the admin cannot be deleted");
+                Assert(store.Delete("viewer"), "normal users can be deleted");
+
+                store.Add("viewer2", "viewerpass", admin: false);
+                store.SetSettings("viewer2", "{\"mode\":\"grid\"}");
+                var reloaded = new Web.UserStore(dir);
+                Assert(reloaded.Enabled, "accounts persist across restart");
+                Assert(reloaded.Verify("admin", "new password!") != null, "password persists");
+                Assert(reloaded.GetSettings("viewer2").Contains("grid"), "per-user settings persist");
+            }
+            finally
+            {
+                try { Directory.Delete(dir, recursive: true); } catch { }
+            }
+        });
+
         Test("clip writer produces a playable fmp4 structure", () =>
         {
             var dir = Path.Combine(Path.GetTempPath(), $"neolink-selftest-{Guid.NewGuid():N}");

--- a/src/Neolink.Server/Web/UserStore.cs
+++ b/src/Neolink.Server/Web/UserStore.cs
@@ -1,0 +1,281 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Neolink.Web;
+
+/// <summary>One web-UI account. Settings holds the user's UI state as raw JSON.</summary>
+public sealed class UserRecord
+{
+    public required string Name { get; init; }
+    /// <summary>"pbkdf2-sha256${iterations}${saltB64}${hashB64}"</summary>
+    public string Hash { get; set; } = "";
+    public bool Admin { get; set; }
+    public string? Settings { get; set; }
+}
+
+/// <summary>
+/// Web-UI accounts, deliberately database-free: users.json next to the config
+/// file holds the accounts and a server secret. Authentication stays DISABLED
+/// until the first account exists — creating it (the admin) turns it on.
+///
+/// Passwords are stored as PBKDF2-SHA256 (210k iterations, 16-byte random salt,
+/// constant-time comparison) — the file is safe to check into a password-manager
+/// era world, nothing recoverable. Sessions are stateless signed tokens:
+/// base64url(name|expiry|pwTag).base64url(HMAC-SHA256(secret, payload)); the
+/// pwTag is derived from the current password hash, so changing a password
+/// instantly invalidates that user's outstanding tokens.
+/// </summary>
+public sealed class UserStore
+{
+    private const int Iterations = 210_000;
+    private const int MaxSettingsBytes = 256 * 1024;
+    private static readonly TimeSpan TokenLifetime = TimeSpan.FromDays(30);
+
+    private readonly string _file;
+    private readonly object _gate = new();
+    private byte[] _secret = RandomNumberGenerator.GetBytes(32);
+    private List<UserRecord> _users = new();
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
+
+    private sealed class FileModel
+    {
+        public string Secret { get; set; } = "";
+        public List<UserRecord> Users { get; set; } = new();
+    }
+
+    public UserStore(string configDir)
+    {
+        _file = Path.Combine(configDir, "users.json");
+        try
+        {
+            if (File.Exists(_file))
+            {
+                var model = JsonSerializer.Deserialize<FileModel>(File.ReadAllText(_file), JsonOpts);
+                if (model != null)
+                {
+                    if (model.Secret.Length > 0) _secret = Convert.FromBase64String(model.Secret);
+                    _users = model.Users;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // Refuse half-read credentials: better to run open (and log loudly)
+            // than to lock people out with a broken account list.
+            Log.Error($"users.json unreadable ({ex.Message}); web-UI authentication is OFF until it is fixed or removed");
+            _users = new List<UserRecord>();
+        }
+    }
+
+    /// <summary>Authentication is enforced once any account exists.</summary>
+    public bool Enabled
+    {
+        get { lock (_gate) return _users.Count > 0; }
+    }
+
+    // ------------------------------------------------------------------ passwords
+
+    public static string HashPassword(string password)
+    {
+        var salt = RandomNumberGenerator.GetBytes(16);
+        var hash = Rfc2898DeriveBytes.Pbkdf2(password, salt, Iterations, HashAlgorithmName.SHA256, 32);
+        return $"pbkdf2-sha256${Iterations}${Convert.ToBase64String(salt)}${Convert.ToBase64String(hash)}";
+    }
+
+    public static bool VerifyPassword(string password, string stored)
+    {
+        var parts = stored.Split('$');
+        if (parts.Length != 4 || parts[0] != "pbkdf2-sha256" || !int.TryParse(parts[1], out var iterations))
+            return false;
+        byte[] salt, expected;
+        try
+        {
+            salt = Convert.FromBase64String(parts[2]);
+            expected = Convert.FromBase64String(parts[3]);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+        var actual = Rfc2898DeriveBytes.Pbkdf2(password, salt, iterations, HashAlgorithmName.SHA256, expected.Length);
+        return CryptographicOperations.FixedTimeEquals(actual, expected);
+    }
+
+    // ------------------------------------------------------------------ accounts
+
+    /// <summary>Login check. Null on unknown user or wrong password (constant-time).</summary>
+    public UserRecord? Verify(string name, string password)
+    {
+        UserRecord? user;
+        lock (_gate) { user = Find(name); }
+        if (user == null)
+        {
+            // Burn comparable CPU for unknown users so timing can't enumerate names.
+            VerifyPassword(password, HashPassword("timing-equalizer"));
+            return null;
+        }
+        return VerifyPassword(password, user.Hash) ? user : null;
+    }
+
+    /// <summary>Creates an account. The very first one becomes the admin.</summary>
+    public UserRecord Add(string name, string password, bool admin)
+    {
+        ValidateName(name);
+        ValidatePassword(password);
+        lock (_gate)
+        {
+            if (Find(name) != null)
+                throw new ArgumentException($"user '{name}' already exists");
+            var user = new UserRecord { Name = name, Hash = HashPassword(password), Admin = admin };
+            _users.Add(user);
+            SaveLocked();
+            return user;
+        }
+    }
+
+    public bool SetPassword(string name, string password)
+    {
+        ValidatePassword(password);
+        lock (_gate)
+        {
+            var user = Find(name);
+            if (user == null) return false;
+            user.Hash = HashPassword(password); // also invalidates the user's tokens
+            SaveLocked();
+            return true;
+        }
+    }
+
+    /// <summary>Deletes a normal user; admins cannot be deleted (there is exactly one).</summary>
+    public bool Delete(string name)
+    {
+        lock (_gate)
+        {
+            var user = Find(name);
+            if (user == null || user.Admin) return false;
+            _users.Remove(user);
+            SaveLocked();
+            return true;
+        }
+    }
+
+    public List<(string Name, bool Admin)> List()
+    {
+        lock (_gate) return _users.Select(u => (u.Name, u.Admin)).ToList();
+    }
+
+    /// <summary>The admin account (the first user ever created).</summary>
+    public UserRecord? AdminUser()
+    {
+        lock (_gate) return _users.FirstOrDefault(u => u.Admin);
+    }
+
+    // ------------------------------------------------------------------ per-user UI settings
+
+    public string GetSettings(string name)
+    {
+        lock (_gate) return Find(name)?.Settings ?? "{}";
+    }
+
+    public bool SetSettings(string name, string json)
+    {
+        if (Encoding.UTF8.GetByteCount(json) > MaxSettingsBytes)
+            throw new ArgumentException("settings blob too large");
+        using (JsonDocument.Parse(json)) { } // must be valid JSON
+        lock (_gate)
+        {
+            var user = Find(name);
+            if (user == null) return false;
+            user.Settings = json;
+            SaveLocked();
+            return true;
+        }
+    }
+
+    // ------------------------------------------------------------------ session tokens
+
+    public string IssueToken(UserRecord user)
+    {
+        long expiry = DateTimeOffset.UtcNow.Add(TokenLifetime).ToUnixTimeSeconds();
+        var payload = $"{user.Name}|{expiry}|{PasswordTag(user.Hash)}";
+        var payloadBytes = Encoding.UTF8.GetBytes(payload);
+        var signature = HMACSHA256.HashData(_secret, payloadBytes);
+        return $"{Base64Url(payloadBytes)}.{Base64Url(signature)}";
+    }
+
+    /// <summary>Returns the token's user when the signature, expiry and password generation all check out.</summary>
+    public UserRecord? ValidateToken(string token)
+    {
+        var dot = token.IndexOf('.');
+        if (dot <= 0) return null;
+        byte[] payloadBytes, signature;
+        try
+        {
+            payloadBytes = FromBase64Url(token[..dot]);
+            signature = FromBase64Url(token[(dot + 1)..]);
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+        var expected = HMACSHA256.HashData(_secret, payloadBytes);
+        if (!CryptographicOperations.FixedTimeEquals(expected, signature))
+            return null;
+
+        var parts = Encoding.UTF8.GetString(payloadBytes).Split('|');
+        if (parts.Length != 3 || !long.TryParse(parts[1], out var expiry))
+            return null;
+        if (DateTimeOffset.UtcNow.ToUnixTimeSeconds() > expiry)
+            return null;
+
+        lock (_gate)
+        {
+            var user = Find(parts[0]);
+            return user != null && PasswordTag(user.Hash) == parts[2] ? user : null;
+        }
+    }
+
+    /// <summary>Short fingerprint of the password hash: rotating the password kills old tokens.</summary>
+    private static string PasswordTag(string hash) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(hash)))[..12];
+
+    private static string Base64Url(byte[] data) =>
+        Convert.ToBase64String(data).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    private static byte[] FromBase64Url(string s)
+    {
+        var b64 = s.Replace('-', '+').Replace('_', '/');
+        return Convert.FromBase64String(b64.PadRight(b64.Length + (4 - b64.Length % 4) % 4, '='));
+    }
+
+    // ------------------------------------------------------------------ plumbing
+
+    public static void ValidateName(string name)
+    {
+        if (name.Length is < 1 or > 32 || !name.All(c => char.IsAsciiLetterOrDigit(c) || c is '_' or '-' or '.'))
+            throw new ArgumentException("username must be 1-32 characters: letters, digits, _ - .");
+    }
+
+    public static void ValidatePassword(string password)
+    {
+        if (password.Length < 8)
+            throw new ArgumentException("password must be at least 8 characters");
+    }
+
+    private UserRecord? Find(string name) =>
+        _users.FirstOrDefault(u => string.Equals(u.Name, name, StringComparison.OrdinalIgnoreCase));
+
+    private void SaveLocked()
+    {
+        var model = new FileModel { Secret = Convert.ToBase64String(_secret), Users = _users };
+        var tmp = _file + ".tmp";
+        File.WriteAllText(tmp, JsonSerializer.Serialize(model, JsonOpts));
+        File.Move(tmp, _file, overwrite: true);
+    }
+}

--- a/src/Neolink.Server/Web/WebApi.cs
+++ b/src/Neolink.Server/Web/WebApi.cs
@@ -32,6 +32,10 @@ public sealed record WebCameraInfo(string Name, List<WebStreamInfo> Streams, ICa
 ///   GET /api/events/{id}/clip /thumb        — event artifacts; POST .../review to (un)dismiss
 ///   GET/POST /api/cameras/{name}/recording  — per-camera recording switches + event-type filter
 ///   GET /api/recordings/{camera}[/{date}[/{file}]] — browse/play continuous footage
+///   /api/auth/* (status/setup/login/reset-admin), /api/users (admin CRUD),
+///   GET/PUT /api/me/settings — web-UI accounts; once any account exists, every
+///   other /api route requires a Bearer session token (or ?token= where headers
+///   can't go: media elements and the stream WebSocket)
 ///   /                                       — web UI (when enabled in the config)
 /// Mutating endpoints require HTTP Basic auth when users are configured (same
 /// credentials and per-camera permissions as RTSP).
@@ -45,10 +49,13 @@ public static class WebApi
         uint? Framerate, uint? Bitrate);
     private sealed record ReviewRequest(bool? Reviewed);
     private sealed record RecordingSettingsRequest(bool? Events, bool? Continuous, List<string>? EventTypes);
+    private sealed record CredentialsRequest(string? Username, string? Password);
+    private sealed record PasswordRequest(string? Password);
 
     public static async Task RunAsync(string bindAddr, int port, bool webUi,
         IReadOnlyList<WebCameraInfo> cameras, IReadOnlyDictionary<string, string> users,
-        int rtspPort, EventStore? events, RecordingSettings? recordingSettings, CancellationToken ct)
+        int rtspPort, EventStore? events, RecordingSettings? recordingSettings,
+        UserStore userStore, bool resetAdminPassword, CancellationToken ct)
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
         {
@@ -82,6 +89,183 @@ public static class WebApi
 
         app.UseWebSockets(new WebSocketOptions { KeepAliveInterval = TimeSpan.FromSeconds(20) });
 
+        // ------------------------------------------------------------ web-UI accounts
+
+        // The session token travels as a Bearer header, or as ?token= for the
+        // places headers can't go (video/img elements, the stream WebSocket).
+        UserRecord? SessionUser(HttpContext ctx)
+        {
+            string? token = null;
+            var header = ctx.Request.Headers.Authorization.ToString();
+            if (header.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                token = header["Bearer ".Length..].Trim();
+            token ??= ctx.Request.Query["token"];
+            return string.IsNullOrEmpty(token) ? null : userStore.ValidateToken(token);
+        }
+
+        // Once any account exists, every /api call (except the auth handshake
+        // itself) requires a valid session. The Blazor UI shell stays public so
+        // the login screen can render.
+        app.Use(async (ctx, next) =>
+        {
+            if (userStore.Enabled
+                && ctx.Request.Path.StartsWithSegments("/api")
+                && !ctx.Request.Path.StartsWithSegments("/api/auth"))
+            {
+                var user = SessionUser(ctx);
+                if (user == null)
+                {
+                    ctx.Response.StatusCode = 401;
+                    await ctx.Response.WriteAsJsonAsync(new { error = "authentication required" });
+                    return;
+                }
+                ctx.Items["authUser"] = user;
+            }
+            await next();
+        });
+
+        bool IsAdmin(HttpContext ctx) => ctx.Items["authUser"] is UserRecord { Admin: true };
+        string? SessionName(HttpContext ctx) => (ctx.Items["authUser"] as UserRecord)?.Name;
+
+        app.MapGet("/api/auth/status", (HttpContext ctx) =>
+        {
+            var user = userStore.Enabled ? SessionUser(ctx) : null;
+            return Results.Json(new
+            {
+                enabled = userStore.Enabled,
+                setupRequired = !userStore.Enabled,
+                resetAvailable = resetAdminPassword && userStore.Enabled,
+                user = user?.Name,
+                admin = user?.Admin ?? false,
+            });
+        });
+
+        // First account = the admin; creating it is what turns authentication on.
+        app.MapPost("/api/auth/setup", (CredentialsRequest req) =>
+        {
+            if (userStore.Enabled)
+                return Results.Json(new { error = "already set up" }, statusCode: 409);
+            if (string.IsNullOrWhiteSpace(req.Username) || string.IsNullOrEmpty(req.Password))
+                return Results.Json(new { error = "provide username and password" }, statusCode: 400);
+            try
+            {
+                var admin = userStore.Add(req.Username.Trim(), req.Password, admin: true);
+                Log.Warn($"Web UI authentication ENABLED: admin account '{admin.Name}' created");
+                return Results.Json(new { token = userStore.IssueToken(admin), user = admin.Name, admin = true });
+            }
+            catch (ArgumentException ex)
+            {
+                return Results.Json(new { error = ex.Message }, statusCode: 400);
+            }
+        });
+
+        app.MapPost("/api/auth/login", async (CredentialsRequest req) =>
+        {
+            var user = req.Username == null || req.Password == null
+                ? null
+                : userStore.Verify(req.Username.Trim(), req.Password);
+            if (user == null)
+            {
+                await Task.Delay(Random.Shared.Next(250, 500)); // blunt brute-force pacing
+                return Results.Json(new { error = "wrong username or password" }, statusCode: 401);
+            }
+            return Results.Json(new { token = userStore.IssueToken(user), user = user.Name, admin = user.Admin });
+        });
+
+        // Recovery: only while reset_admin_password=true in the config.
+        app.MapPost("/api/auth/reset-admin", (PasswordRequest req) =>
+        {
+            if (!resetAdminPassword || !userStore.Enabled)
+                return Results.Json(new { error = "reset not enabled" }, statusCode: 404);
+            var admin = userStore.AdminUser();
+            if (admin == null || string.IsNullOrEmpty(req.Password))
+                return Results.Json(new { error = "provide password" }, statusCode: 400);
+            try
+            {
+                userStore.SetPassword(admin.Name, req.Password);
+            }
+            catch (ArgumentException ex)
+            {
+                return Results.Json(new { error = ex.Message }, statusCode: 400);
+            }
+            Log.Warn($"Admin password for '{admin.Name}' was RESET via reset_admin_password — " +
+                     "set the flag back to false now");
+            return Results.Json(new { ok = true, user = admin.Name });
+        });
+
+        // Account management (admin only). Normal users are added by the admin.
+        app.MapGet("/api/users", (HttpContext ctx) =>
+            !IsAdmin(ctx)
+                ? Results.Json(new { error = "admin only" }, statusCode: 403)
+                : Results.Json(userStore.List().Select(u => new { name = u.Name, admin = u.Admin })));
+
+        app.MapPost("/api/users", (CredentialsRequest req, HttpContext ctx) =>
+        {
+            if (!IsAdmin(ctx))
+                return Results.Json(new { error = "admin only" }, statusCode: 403);
+            if (string.IsNullOrWhiteSpace(req.Username) || string.IsNullOrEmpty(req.Password))
+                return Results.Json(new { error = "provide username and password" }, statusCode: 400);
+            try
+            {
+                userStore.Add(req.Username.Trim(), req.Password, admin: false);
+                return Results.Json(new { ok = true });
+            }
+            catch (ArgumentException ex)
+            {
+                return Results.Json(new { error = ex.Message }, statusCode: 400);
+            }
+        });
+
+        app.MapPut("/api/users/{name}", (string name, PasswordRequest req, HttpContext ctx) =>
+        {
+            if (!IsAdmin(ctx))
+                return Results.Json(new { error = "admin only" }, statusCode: 403);
+            if (string.IsNullOrEmpty(req.Password))
+                return Results.Json(new { error = "provide password" }, statusCode: 400);
+            try
+            {
+                return userStore.SetPassword(name, req.Password)
+                    ? Results.Json(new { ok = true })
+                    : Results.Json(new { error = "unknown user" }, statusCode: 404);
+            }
+            catch (ArgumentException ex)
+            {
+                return Results.Json(new { error = ex.Message }, statusCode: 400);
+            }
+        });
+
+        app.MapDelete("/api/users/{name}", (string name, HttpContext ctx) =>
+        {
+            if (!IsAdmin(ctx))
+                return Results.Json(new { error = "admin only" }, statusCode: 403);
+            return userStore.Delete(name)
+                ? Results.Json(new { ok = true })
+                : Results.Json(new { error = "unknown user (the admin cannot be deleted)" }, statusCode: 400);
+        });
+
+        // Per-user UI settings: an opaque JSON blob the client owns.
+        app.MapGet("/api/me/settings", (HttpContext ctx) =>
+            SessionName(ctx) is { } me
+                ? Results.Content(userStore.GetSettings(me), "application/json")
+                : Results.Json(new { error = "authentication disabled" }, statusCode: 404));
+
+        app.MapPut("/api/me/settings", async (HttpContext ctx) =>
+        {
+            if (SessionName(ctx) is not { } me)
+                return Results.Json(new { error = "authentication disabled" }, statusCode: 404);
+            using var reader = new StreamReader(ctx.Request.Body);
+            var json = await reader.ReadToEndAsync();
+            try
+            {
+                userStore.SetSettings(me, json);
+                return Results.Json(new { ok = true });
+            }
+            catch (Exception ex) when (ex is ArgumentException or JsonException)
+            {
+                return Results.Json(new { error = "invalid settings payload" }, statusCode: 400);
+            }
+        });
+
         // Feature discovery, so clients can hide UI for what this server won't do.
         app.MapGet("/api/features", () => Results.Json(new
         {
@@ -113,8 +297,14 @@ public static class WebApi
 
         // Denies a mutating request unless it carries valid Basic credentials of a
         // permitted user. Mirrors the RTSP rules: no configured users = open access.
+        // When web-UI accounts exist, the session (already checked by the auth
+        // middleware) supersedes the RTSP Basic mapping entirely.
         IResult? CheckAuth(HttpContext ctx, WebCameraInfo cam)
         {
+            if (userStore.Enabled)
+                return ctx.Items.ContainsKey("authUser")
+                    ? null
+                    : Results.Json(new { error = "authentication required" }, statusCode: 401);
             if (cam.PermittedUsers == null || users.Count == 0)
                 return null;
             var creds = NetUtil.DecodeBasicAuth(ctx.Request.Headers.Authorization);
@@ -346,9 +536,14 @@ public static class WebApi
                 if (rec == null)
                     return Results.Json(new { error = "unknown event" }, statusCode: 404);
                 // Same rules as camera control: reviewing an event needs control rights
-                // on its camera. Events of removed cameras fall back to any valid user.
+                // on its camera. Web-UI sessions (validated by the middleware) always
+                // qualify; events of removed cameras fall back to any valid RTSP user.
                 var cam = cameras.FirstOrDefault(c => string.Equals(c.Name, rec.Camera, StringComparison.OrdinalIgnoreCase));
-                if (cam != null)
+                if (userStore.Enabled)
+                {
+                    // authenticated by the middleware — allowed
+                }
+                else if (cam != null)
                 {
                     if (CheckAuth(ctx, cam) is { } denied) return denied;
                 }

--- a/src/Neolink.Server/config.example.json
+++ b/src/Neolink.Server/config.example.json
@@ -14,8 +14,8 @@
   // Serve the browser UI on web_port. Set false for API-only / headless setups.
   "webui": true,
 
-  // Optional: recording to disk — motion/AI detection events (clips + thumbnails).
-  // (Continuous 24/7 recording is temporarily disabled in this build.)
+  // Optional: recording to disk — motion/AI detection events (clips + thumbnails)
+  // and, when switched on per camera in the web UI, continuous 24/7 footage.
   // Remove this section to disable. In Docker, mount a volume at "path".
   // "recording": {
   //   "path": "/recordings",           // storage directory

--- a/src/Neolink.Server/config.example.json
+++ b/src/Neolink.Server/config.example.json
@@ -14,6 +14,12 @@
   // Serve the browser UI on web_port. Set false for API-only / headless setups.
   "webui": true,
 
+  // Web-UI sign-in recovery: while true, the login screen allows setting a new
+  // admin password WITHOUT the old one. Set it back to false right after use!
+  // (Web-UI accounts live in users.json next to this file; sign-in stays off
+  // until the first account — the admin — is created from the UI itself.)
+  "reset_admin_password": false,
+
   // Optional: recording to disk — motion/AI detection events (clips + thumbnails)
   // and, when switched on per camera in the web UI, continuous 24/7 footage.
   // Remove this section to disable. In Docker, mount a volume at "path".

--- a/src/Neolink.WebClient/Components/CameraPanel.razor
+++ b/src/Neolink.WebClient/Components/CameraPanel.razor
@@ -246,6 +246,8 @@
     [Parameter] public ApiCamera? Camera { get; set; }
     [Parameter] public string? User { get; set; }
     [Parameter] public string? Pass { get; set; }
+    /// <summary>Web-UI session token; when present it supersedes the Basic credentials.</summary>
+    [Parameter] public string? Token { get; set; }
     [Parameter] public EventCallback OnClose { get; set; }
 
     private ApiCapabilities? _caps;
@@ -388,7 +390,11 @@
     private HttpRequestMessage NewRequest(HttpMethod method, string path)
     {
         var req = new HttpRequestMessage(method, $"{BaseUrl}/{path}");
-        if (!string.IsNullOrEmpty(User))
+        if (!string.IsNullOrEmpty(Token))
+        {
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+        }
+        else if (!string.IsNullOrEmpty(User))
         {
             var token = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes($"{User}:{Pass}"));
             req.Headers.Authorization = new AuthenticationHeaderValue("Basic", token);

--- a/src/Neolink.WebClient/Components/Pages/Home.razor
+++ b/src/Neolink.WebClient/Components/Pages/Home.razor
@@ -83,12 +83,23 @@
             <div class="events-bar">
                 <span class="events-bar-count" title="Unreviewed events">⚡ @_events.Count(e => !e.Reviewed)</span>
                 <div class="events-bar-scroll">
+                    @{ int trickleBudget = 8; }
                     @foreach (var ev in _events.Where(e => !e.Reviewed).Take(30))
                     {
+                        @* Ambient "trickle" preview: the newest few cards loop their clip
+                           muted, so the strip shows what happened without any clicks.
+                           Capped so a big backlog doesn't decode dozens of videos. *@
+                        bool trickle = ev.HasClip && !ev.Ongoing && trickleBudget-- > 0;
                         <div class="event-card @(ev.Ongoing ? "live" : "")" @key="ev.Id"
                              title="@ev.Title — click to play" @onclick="() => OpenEvent(ev)">
                             <div class="event-thumb">
-                                @if (ev.HasThumb)
+                                @if (trickle)
+                                {
+                                    <video data-trickle="1" muted loop playsinline preload="metadata"
+                                           poster="@(ev.HasThumb ? EventArtifactUrl(ev, "thumb") : null)"
+                                           src="@EventArtifactUrl(ev, "clip")"></video>
+                                }
+                                else if (ev.HasThumb)
                                 {
                                     <img src="@EventArtifactUrl(ev, "thumb")" loading="lazy" alt="" />
                                 }
@@ -100,13 +111,13 @@
                                 {
                                     <span class="event-live">● REC</span>
                                 }
+                                <button class="icon-btn event-dismiss" title="Dismiss (mark reviewed)"
+                                        @onclick="() => DismissAsync(ev)" @onclick:stopPropagation="true">✕</button>
                             </div>
                             <div class="event-meta">
                                 <span class="event-title">@ev.Icon @ev.Title</span>
                                 <span class="event-sub">@ev.Camera · @Ago(ev.Start)</span>
                             </div>
-                            <button class="icon-btn event-dismiss" title="Dismiss (mark reviewed)"
-                                    @onclick="() => DismissAsync(ev)" @onclick:stopPropagation="true">✕</button>
                         </div>
                     }
                 </div>
@@ -443,6 +454,10 @@
         await ReconcilePlayersAsync();
         if (_mode == "free")
             await JS.InvokeVoidAsync("neolink.freeInit", "stage-grid");
+        // Blazor's `muted` attribute only sets defaultMuted on dynamically created
+        // elements, which blocks autoplay — the helper mutes for real and plays.
+        if (_eventsSupported && _events.Any(e => !e.Reviewed))
+            await JS.InvokeVoidAsync("neolink.trickle");
     }
 
     // ------------------------------------------------------------ persistence

--- a/src/Neolink.WebClient/Components/Pages/Home.razor
+++ b/src/Neolink.WebClient/Components/Pages/Home.razor
@@ -17,6 +17,17 @@
             <button class="icon-btn" title="Server settings" @onclick="() => _showSettings = !_showSettings">⚙</button>
         </div>
 
+        @if (_setupRequired && !_secWarnDismissed)
+        {
+            <div class="sec-banner">
+                <span class="sec-banner-text">⚠ This server has no sign-in — anyone who can reach it can watch and control your cameras.</span>
+                <div class="sec-banner-actions">
+                    <button class="chip" @onclick="() => { _loginError = null; _showSetupPrompt = true; }">Secure now</button>
+                    <button class="icon-btn" title="Dismiss this warning" @onclick="DismissSecWarnAsync">✕</button>
+                </div>
+            </div>
+        }
+
         @if (_showSettings)
         {
             <div class="settings">
@@ -26,6 +37,25 @@
                 <input @bind="_user" @bind:after="SaveAsync" placeholder="username" autocomplete="off" />
                 <label>Control password</label>
                 <input type="password" @bind="_pass" @bind:after="SaveAsync" placeholder="password" autocomplete="off" />
+
+                @if (_authUser != null)
+                {
+                    <div class="auth-row">
+                        <span class="event-sub">👤 @_authUser@(_authAdmin ? " · admin" : "")</span>
+                        @if (_authAdmin)
+                        {
+                            <button class="chip" @onclick="OpenUsersAsync">Users…</button>
+                        }
+                        <button class="chip chip-off" @onclick="LogoutAsync">Sign out</button>
+                    </div>
+                }
+                else if (_setupRequired)
+                {
+                    <div class="auth-row">
+                        <button class="chip" title="Create the admin account and require sign-in"
+                                @onclick="() => { _loginError = null; _showSetupPrompt = true; }">🔐 Enable login…</button>
+                    </div>
+                }
             </div>
         }
 
@@ -80,11 +110,17 @@
            Disappears entirely once everything is dismissed (or recording is off). *@
         @if (_eventsSupported && _events.Any(e => !e.Reviewed))
         {
-            <div class="events-bar">
-                <span class="events-bar-count" title="Unreviewed events">⚡ @_events.Count(e => !e.Reviewed)</span>
+            <div class="events-bar" id="events-bar" style="height:@(_stripHeight)px">
+                <span class="events-bar-count" title="Unreviewed events (after filters)">⚡ @StripEvents.Count()</span>
+                <button class="icon-btn strip-filter-btn @(_showStripFilter || _hiddenTypes.Count > 0 || _hiddenCams.Count > 0 ? "active" : "")"
+                        title="Filter which events appear here" @onclick="() => _showStripFilter = !_showStripFilter">⚟</button>
                 <div class="events-bar-scroll">
+                    @if (!StripEvents.Any())
+                    {
+                        <span class="event-sub">every unreviewed event is hidden by the filters</span>
+                    }
                     @{ int trickleBudget = 8; }
-                    @foreach (var ev in _events.Where(e => !e.Reviewed).Take(30))
+                    @foreach (var ev in StripEvents.Take(30))
                     {
                         @* Ambient "trickle" preview: the newest few cards loop their clip
                            muted, so the strip shows what happened without any clicks.
@@ -122,7 +158,32 @@
                     }
                 </div>
                 <button class="chip events-clear" title="Dismiss all events" @onclick="DismissAllAsync">Clear all</button>
+                <div class="strip-resize" title="Drag to resize the event strip"></div>
             </div>
+
+            @if (_showStripFilter)
+            {
+                @* Real-time strip filters: lit chips show, dimmed chips hide.
+                   Persisted with the view settings (per account when signed in). *@
+                <div class="strip-filter">
+                    <span class="tool-label">SHOW</span>
+                    @foreach (var t in StripTypes)
+                    {
+                        <button class="chip @(_hiddenTypes.Contains(t) ? "chip-off" : "")"
+                                title="@(_hiddenTypes.Contains(t) ? "Hidden — click to show" : "Shown — click to hide")"
+                                @onclick="() => ToggleTypeFilterAsync(t)">@StripTypeIcon(t) @t</button>
+                    }
+                    <span class="tool-sep"></span>
+                    <span class="tool-label">CAMERAS</span>
+                    @foreach (var cam in _cameras)
+                    {
+                        var name = cam.Name;
+                        <button class="chip @(_hiddenCams.Contains(name) ? "chip-off" : "")"
+                                title="@(_hiddenCams.Contains(name) ? "Hidden — click to show" : "Shown — click to hide")"
+                                @onclick="() => ToggleCamFilterAsync(name)">@name</button>
+                    }
+                </div>
+            }
         }
 
         <div class="toolbar">
@@ -217,8 +278,127 @@
     {
         <CameraPanel Server="@_server" CameraName="@_panelCamera"
                      Camera="_cameras.FirstOrDefault(c => c.Name == _panelCamera)"
-                     User="@_user" Pass="@_pass"
+                     User="@_user" Pass="@_pass" Token="@_authToken"
                      OnClose="() => _panelCamera = null" />
+    }
+
+    @if (_showSetupPrompt && !_showLogin)
+    {
+        <div class="backdrop panel-backdrop"></div>
+        <aside class="campanel auth-panel" role="dialog" aria-label="Create admin account">
+            <div class="campanel-head"><span class="campanel-title">🔐 SECURE THIS SERVER</span></div>
+            <div class="notice">
+                No accounts exist yet, so the UI is open to anyone who can reach this address.
+                Create the admin account to require sign-in — you can add more users afterwards.
+                Your layout and filters will be saved per account.
+            </div>
+            <div class="settings">
+                <label>Admin username</label>
+                <input @bind="_loginUser" autocomplete="off" />
+                <label>Password (min 8 characters)</label>
+                <input type="password" @bind="_loginPass" autocomplete="new-password" />
+            </div>
+            @if (_loginError != null)
+            {
+                <div class="notice error">@_loginError</div>
+            }
+            <div class="event-player-foot">
+                <button class="chip" @onclick="SetupAdminAsync">Create admin &amp; enable login</button>
+                <span class="tile-spacer"></span>
+                <button class="chip chip-off" @onclick="DismissSetupAsync">Not now</button>
+            </div>
+        </aside>
+    }
+
+    @if (_showLogin)
+    {
+        <div class="auth-overlay">
+            <div class="auth-box">
+                <div class="brand"><span class="brand-dot"></span> NEOLINK<span class="brand-net">.NET</span></div>
+                @if (!_resetMode)
+                {
+                    <label>Username</label>
+                    <input @bind="_loginUser" autocomplete="username" />
+                    <label>Password</label>
+                    <input type="password" @bind="_loginPass" autocomplete="current-password"
+                           @onkeydown='e => { if (e.Key == "Enter") _ = LoginAsync(); }' />
+                    @if (_loginError != null)
+                    {
+                        <div class="notice error">@_loginError</div>
+                    }
+                    <button class="chip auth-btn" @onclick="LoginAsync">Sign in</button>
+                    @if (_resetAvailable)
+                    {
+                        <button class="chip chip-off" @onclick="() => { _resetMode = true; _loginError = null; }">Reset admin password…</button>
+                    }
+                }
+                else
+                {
+                    <div class="notice">
+                        reset_admin_password is enabled in config.json. Set a new admin password below,
+                        sign in with it, then turn the flag back off.
+                    </div>
+                    <label>New admin password</label>
+                    <input type="password" @bind="_resetPass" autocomplete="new-password" />
+                    @if (_loginError != null)
+                    {
+                        <div class="notice error">@_loginError</div>
+                    }
+                    <button class="chip auth-btn" @onclick="ResetAdminAsync">Set new password</button>
+                    <button class="chip chip-off" @onclick="() => { _resetMode = false; _loginError = null; }">Back to sign in</button>
+                }
+            </div>
+        </div>
+    }
+
+    @if (_showUsersPanel)
+    {
+        <div class="backdrop panel-backdrop" @onclick="() => _showUsersPanel = false"></div>
+        <aside class="campanel auth-panel" role="dialog" aria-label="User management">
+            <div class="campanel-head">
+                <span class="campanel-title">👥 USERS</span>
+                <span class="tile-spacer"></span>
+                <button class="icon-btn" title="Close" @onclick="() => _showUsersPanel = false">✕</button>
+            </div>
+            @if (_usersError != null)
+            {
+                <div class="notice error">@_usersError</div>
+            }
+            @foreach (var u in _uiUsers)
+            {
+                <div class="control-row user-row" @key="u.Name">
+                    <span>@(u.Admin ? "🛡" : "👤") @u.Name@(u.Admin ? " · admin" : "")</span>
+                    @if (_pwEditUser == u.Name)
+                    {
+                        <input class="user-pass-input" type="password" placeholder="new password (min 8)"
+                               @bind="_pwEditPass" autocomplete="new-password" />
+                        <button class="chip" @onclick="() => SetUserPasswordAsync(u.Name)">save</button>
+                        <button class="chip chip-off" @onclick="() => _pwEditUser = null">cancel</button>
+                    }
+                    else
+                    {
+                        <button class="chip" @onclick="() => { _pwEditUser = u.Name; _pwEditPass = string.Empty; }">password…</button>
+                        @if (!u.Admin)
+                        {
+                            <button class="chip chip-danger" @onclick="() => DeleteUserAsync(u.Name)">delete</button>
+                        }
+                    }
+                </div>
+            }
+            <div class="campanel-section">
+                <div class="campanel-section-title">ADD USER</div>
+                <div class="control-row user-row">
+                    <input class="user-pass-input" placeholder="username" @bind="_newUserName" autocomplete="off" />
+                    <input class="user-pass-input" type="password" placeholder="password (min 8)"
+                           @bind="_newUserPass" autocomplete="new-password" />
+                    <button class="chip" @onclick="AddUserAsync">add</button>
+                </div>
+                <div class="notice small">
+                    New accounts are normal users: they can view and control cameras and review events,
+                    but cannot manage users. Each account keeps its own layout and filters.
+                </div>
+            </div>
+        </aside>
     }
 
     @if (_showEventsPanel)
@@ -429,6 +609,40 @@
     private bool _eventsUnreviewedOnly;
     private ApiEvent? _playEvent;
 
+    // Web-UI authentication (enabled once the first account exists server-side)
+    private string? _authToken;
+    private string? _authUser;
+    private bool _authAdmin;
+    private bool _authEnabled;
+    private bool _setupRequired;
+    private bool _resetAvailable;
+    private bool _setupDismissed;
+    private bool _showLogin;
+    private bool _showSetupPrompt;
+    private bool _resetMode;
+    private string _loginUser = "";
+    private string _loginPass = "";
+    private string _resetPass = "";
+    private string? _loginError;
+
+    // Admin user management
+    private bool _showUsersPanel;
+    private readonly List<ApiUserInfo> _uiUsers = new();
+    private string _newUserName = "";
+    private string _newUserPass = "";
+    private string? _usersError;
+    private string? _pwEditUser;
+    private string _pwEditPass = "";
+
+    // Review-strip filters (persisted with the view settings, per user when logged in)
+    private static readonly string[] StripTypes = { "person", "vehicle", "animal", "package", "motion" };
+    private HashSet<string> _hiddenTypes = new(StringComparer.OrdinalIgnoreCase);
+    private HashSet<string> _hiddenCams = new(StringComparer.OrdinalIgnoreCase);
+    private bool _showStripFilter;
+    private int _stripHeight = 160;
+    private bool _secWarnDismissed;
+    private DotNetObjectReference<Home>? _selfRef;
+
     // Continuous (24/7) footage browser
     private string _panelTab = "events";
     private string _recCamera = "";
@@ -445,6 +659,7 @@
         {
             await LoadPersistedAsync();
             _loaded = true;
+            await RefreshAuthAsync();
             await RefreshCamerasAsync();
             await RefreshEventsAsync();
             StateHasChanged();
@@ -457,7 +672,23 @@
         // Blazor's `muted` attribute only sets defaultMuted on dynamically created
         // elements, which blocks autoplay — the helper mutes for real and plays.
         if (_eventsSupported && _events.Any(e => !e.Reviewed))
+        {
             await JS.InvokeVoidAsync("neolink.trickle");
+            _selfRef ??= DotNetObjectReference.Create(this);
+            await JS.InvokeVoidAsync("neolink.stripResizeInit", "events-bar", _selfRef);
+        }
+    }
+
+    /// <summary>Called from JS when the strip's resize-handle drag ends.</summary>
+    [JSInvokable]
+    public async Task OnStripResized(double height)
+    {
+        _stripHeight = (int)Math.Clamp(height, 96, 640);
+        await InvokeAsync(async () =>
+        {
+            await SaveAsync();
+            StateHasChanged();
+        });
     }
 
     // ------------------------------------------------------------ persistence
@@ -479,6 +710,9 @@
                     _count = v.Count;
                     _slots = v.Slots;
                     _backup = v.Backup;
+                    _hiddenTypes = new HashSet<string>(v.HiddenTypes, StringComparer.OrdinalIgnoreCase);
+                    _hiddenCams = new HashSet<string>(v.HiddenCams, StringComparer.OrdinalIgnoreCase);
+                    if (v.StripHeight > 0) _stripHeight = Math.Clamp(v.StripHeight, 96, 640);
                 }
             }
         }
@@ -497,18 +731,326 @@
 
         if (string.IsNullOrWhiteSpace(_server))
             _server = await JS.InvokeAsync<string>("neolink.defaultServer");
+
+        // Session + one-time flags
+        try
+        {
+            var auth = await JS.InvokeAsync<string?>("neolink.lsGet", "neolink.auth");
+            if (!string.IsNullOrWhiteSpace(auth))
+            {
+                var el = JsonSerializer.Deserialize<JsonElement>(auth);
+                if (el.TryGetProperty("token", out var t)) _authToken = t.GetString();
+            }
+            _setupDismissed = await JS.InvokeAsync<string?>("neolink.lsGet", "neolink.setupDismissed") == "1";
+            _secWarnDismissed = await JS.InvokeAsync<string?>("neolink.lsGet", "neolink.secWarnDismissed") == "1";
+        }
+        catch { }
     }
+
+    private async Task DismissSecWarnAsync()
+    {
+        _secWarnDismissed = true;
+        await JS.InvokeVoidAsync("neolink.lsSet", "neolink.secWarnDismissed", "1");
+    }
+
+    private PersistedView SnapshotView() => new()
+    {
+        Server = _server, User = _user, Pass = _pass,
+        Mode = _mode, Count = _count, Slots = _slots, Backup = _backup,
+        HiddenTypes = _hiddenTypes.ToList(), HiddenCams = _hiddenCams.ToList(),
+        StripHeight = _stripHeight,
+    };
 
     private async Task SaveAsync()
     {
         if (!_loaded) return;
-        var v = new PersistedView
+        var json = JsonSerializer.Serialize(SnapshotView());
+        await JS.InvokeVoidAsync("neolink.lsSet", StorageKey, json);
+        // Logged-in users own their settings server-side (per account).
+        if (_authUser != null)
         {
-            Server = _server, User = _user, Pass = _pass,
-            Mode = _mode, Count = _count, Slots = _slots, Backup = _backup,
-        };
-        await JS.InvokeVoidAsync("neolink.lsSet", StorageKey, JsonSerializer.Serialize(v));
+            try
+            {
+                var req = ApiRequest(HttpMethod.Put, "/api/me/settings");
+                req.Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+                using var _ = await Http.SendAsync(req);
+            }
+            catch { /* transient: localStorage still has it */ }
+        }
     }
+
+    /// <summary>Applies the server-stored per-user view (everything except the server address).</summary>
+    private void ApplyView(PersistedView v)
+    {
+        _mode = Modes.Any(m => m.Mode == v.Mode) ? v.Mode : _mode;
+        if (v.Count > 0) _count = ClampCount(_mode, v.Count);
+        if (v.Slots.Count > 0) _slots = v.Slots;
+        _backup = v.Backup;
+        _user = v.User;
+        _pass = v.Pass;
+        _hiddenTypes = new HashSet<string>(v.HiddenTypes, StringComparer.OrdinalIgnoreCase);
+        _hiddenCams = new HashSet<string>(v.HiddenCams, StringComparer.OrdinalIgnoreCase);
+        if (v.StripHeight > 0) _stripHeight = Math.Clamp(v.StripHeight, 96, 640);
+        EnsureSlots();
+    }
+
+    // ------------------------------------------------------------ authentication
+
+    private HttpRequestMessage ApiRequest(HttpMethod method, string path)
+    {
+        var req = new HttpRequestMessage(method, $"{_server.TrimEnd('/')}{path}");
+        if (!string.IsNullOrEmpty(_authToken))
+            req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _authToken);
+        return req;
+    }
+
+    /// <summary>Token as a query parameter, for URLs headers can't reach (video/img/WS).</summary>
+    private string TokenQuery(char sep) =>
+        string.IsNullOrEmpty(_authToken) ? "" : $"{sep}token={Uri.EscapeDataString(_authToken)}";
+
+    private async Task RefreshAuthAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_server)) return;
+        try
+        {
+            using var res = await Http.SendAsync(ApiRequest(HttpMethod.Get, "/api/auth/status"));
+            var st = await res.Content.ReadFromJsonAsync<ApiAuthStatus>();
+            if (st == null) return;
+            _authEnabled = st.Enabled;
+            _setupRequired = st.SetupRequired;
+            _resetAvailable = st.ResetAvailable;
+            _authUser = st.User;
+            _authAdmin = st.Admin;
+            _showLogin = _authEnabled && _authUser == null;
+            if (_authUser != null)
+                await LoadUserSettingsAsync();
+            if (_setupRequired && !_setupDismissed)
+                _showSetupPrompt = true;
+        }
+        catch { /* unreachable server: the camera fetch reports it */ }
+    }
+
+    private async Task LoadUserSettingsAsync()
+    {
+        try
+        {
+            using var res = await Http.SendAsync(ApiRequest(HttpMethod.Get, "/api/me/settings"));
+            if (!res.IsSuccessStatusCode) return;
+            var json = await res.Content.ReadAsStringAsync();
+            if (string.IsNullOrWhiteSpace(json) || json.Trim() == "{}") return;
+            var v = JsonSerializer.Deserialize<PersistedView>(json);
+            if (v != null) ApplyView(v);
+        }
+        catch { }
+    }
+
+    private async Task AcceptTokenAsync(ApiAuthToken? tok)
+    {
+        if (tok == null) return;
+        _authToken = tok.Token;
+        _authUser = tok.User;
+        _authAdmin = tok.Admin;
+        _authEnabled = true;
+        _setupRequired = false;
+        _showLogin = false;
+        _showSetupPrompt = false;
+        _resetMode = false;
+        _loginPass = "";
+        _loginError = null;
+        await JS.InvokeVoidAsync("neolink.lsSet", "neolink.auth",
+            JsonSerializer.Serialize(new { token = _authToken, user = _authUser, admin = _authAdmin }));
+        await LoadUserSettingsAsync();
+        await RefreshCamerasAsync();
+        await RefreshEventsAsync();
+    }
+
+    private async Task LoginAsync()
+    {
+        _loginError = null;
+        try
+        {
+            var req = ApiRequest(HttpMethod.Post, "/api/auth/login");
+            req.Content = JsonContent.Create(new { username = _loginUser.Trim(), password = _loginPass });
+            using var res = await Http.SendAsync(req);
+            if (!res.IsSuccessStatusCode)
+            {
+                _loginError = await ApiErrorAsync(res) ?? "sign-in failed";
+                return;
+            }
+            await AcceptTokenAsync(await res.Content.ReadFromJsonAsync<ApiAuthToken>());
+        }
+        catch (Exception ex)
+        {
+            _loginError = $"Cannot reach {_server}: {ex.Message}";
+        }
+    }
+
+    private async Task SetupAdminAsync()
+    {
+        _loginError = null;
+        try
+        {
+            var req = ApiRequest(HttpMethod.Post, "/api/auth/setup");
+            req.Content = JsonContent.Create(new { username = _loginUser.Trim(), password = _loginPass });
+            using var res = await Http.SendAsync(req);
+            if (!res.IsSuccessStatusCode)
+            {
+                _loginError = await ApiErrorAsync(res) ?? "setup failed";
+                return;
+            }
+            await AcceptTokenAsync(await res.Content.ReadFromJsonAsync<ApiAuthToken>());
+        }
+        catch (Exception ex)
+        {
+            _loginError = $"Cannot reach {_server}: {ex.Message}";
+        }
+    }
+
+    private async Task ResetAdminAsync()
+    {
+        _loginError = null;
+        try
+        {
+            var req = ApiRequest(HttpMethod.Post, "/api/auth/reset-admin");
+            req.Content = JsonContent.Create(new { password = _resetPass });
+            using var res = await Http.SendAsync(req);
+            if (!res.IsSuccessStatusCode)
+            {
+                _loginError = await ApiErrorAsync(res) ?? "reset failed";
+                return;
+            }
+            _resetMode = false;
+            _resetPass = "";
+            _loginError = "Password updated — sign in with it now, then set reset_admin_password back to false.";
+        }
+        catch (Exception ex)
+        {
+            _loginError = $"Cannot reach {_server}: {ex.Message}";
+        }
+    }
+
+    private async Task LogoutAsync()
+    {
+        _authToken = null;
+        _authUser = null;
+        _authAdmin = false;
+        _showUsersPanel = false;
+        await JS.InvokeVoidAsync("neolink.lsSet", "neolink.auth", "");
+        _showLogin = _authEnabled;
+    }
+
+    private async Task DismissSetupAsync()
+    {
+        _showSetupPrompt = false;
+        _setupDismissed = true;
+        await JS.InvokeVoidAsync("neolink.lsSet", "neolink.setupDismissed", "1");
+    }
+
+    private static async Task<string?> ApiErrorAsync(HttpResponseMessage res)
+    {
+        try
+        {
+            var el = await res.Content.ReadFromJsonAsync<JsonElement>();
+            return el.TryGetProperty("error", out var err) ? err.GetString() : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    // ------------------------------------------------------------ user management (admin)
+
+    private async Task OpenUsersAsync()
+    {
+        _showUsersPanel = true;
+        await LoadUsersAsync();
+    }
+
+    private async Task LoadUsersAsync()
+    {
+        _usersError = null;
+        try
+        {
+            using var res = await Http.SendAsync(ApiRequest(HttpMethod.Get, "/api/users"));
+            var list = res.IsSuccessStatusCode ? await res.Content.ReadFromJsonAsync<List<ApiUserInfo>>() : null;
+            _uiUsers.Clear();
+            if (list != null) _uiUsers.AddRange(list);
+            if (!res.IsSuccessStatusCode) _usersError = await ApiErrorAsync(res);
+        }
+        catch (Exception ex)
+        {
+            _usersError = ex.Message;
+        }
+    }
+
+    private async Task AddUserAsync()
+    {
+        _usersError = null;
+        var req = ApiRequest(HttpMethod.Post, "/api/users");
+        req.Content = JsonContent.Create(new { username = _newUserName.Trim(), password = _newUserPass });
+        using var res = await Http.SendAsync(req);
+        if (!res.IsSuccessStatusCode)
+        {
+            _usersError = await ApiErrorAsync(res) ?? "cannot add user";
+            return;
+        }
+        _newUserName = "";
+        _newUserPass = "";
+        await LoadUsersAsync();
+    }
+
+    private async Task SetUserPasswordAsync(string name)
+    {
+        _usersError = null;
+        var req = ApiRequest(HttpMethod.Put, $"/api/users/{Uri.EscapeDataString(name)}");
+        req.Content = JsonContent.Create(new { password = _pwEditPass });
+        using var res = await Http.SendAsync(req);
+        _usersError = res.IsSuccessStatusCode ? null : await ApiErrorAsync(res) ?? "cannot change password";
+        if (res.IsSuccessStatusCode)
+        {
+            _pwEditUser = null;
+            _pwEditPass = "";
+        }
+    }
+
+    private async Task DeleteUserAsync(string name)
+    {
+        _usersError = null;
+        using var res = await Http.SendAsync(ApiRequest(HttpMethod.Delete, $"/api/users/{Uri.EscapeDataString(name)}"));
+        if (!res.IsSuccessStatusCode)
+            _usersError = await ApiErrorAsync(res) ?? "cannot delete user";
+        await LoadUsersAsync();
+    }
+
+    // ------------------------------------------------------------ review-strip filters
+
+    /// <summary>The strip after the user's real-time filters (type + camera).</summary>
+    private IEnumerable<ApiEvent> StripEvents => _events.Where(e => !e.Reviewed
+        && !_hiddenCams.Contains(e.Camera)
+        && e.Labels.Any(l => !_hiddenTypes.Contains(l)));
+
+    private Task ToggleTypeFilterAsync(string label)
+    {
+        if (!_hiddenTypes.Remove(label)) _hiddenTypes.Add(label);
+        return SaveAsync();
+    }
+
+    private Task ToggleCamFilterAsync(string camera)
+    {
+        if (!_hiddenCams.Remove(camera)) _hiddenCams.Add(camera);
+        return SaveAsync();
+    }
+
+    private static string StripTypeIcon(string label) => label switch
+    {
+        "person" => "🧍",
+        "vehicle" => "🚗",
+        "animal" => "🐾",
+        "package" => "📦",
+        "motion" => "👁",
+        _ => "•",
+    };
 
     // ------------------------------------------------------------ data
 
@@ -536,7 +1078,25 @@
         if (string.IsNullOrWhiteSpace(server)) return false;
         try
         {
-            var cams = await Http.GetFromJsonAsync<List<ApiCamera>>($"{server.TrimEnd('/')}/api/cameras");
+            var req = new HttpRequestMessage(HttpMethod.Get, $"{server.TrimEnd('/')}/api/cameras");
+            if (!string.IsNullOrEmpty(_authToken))
+                req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _authToken);
+            using var res = await Http.SendAsync(req);
+            if (res.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+            {
+                // Reachable, but a session is required (or ours expired).
+                _authEnabled = true;
+                _showLogin = true;
+                _cameras.Clear();
+                _error = null;
+                return true;
+            }
+            if (!res.IsSuccessStatusCode)
+            {
+                _error = $"Cannot reach {server}: HTTP {(int)res.StatusCode}";
+                return false;
+            }
+            var cams = await res.Content.ReadFromJsonAsync<List<ApiCamera>>();
             _cameras.Clear();
             if (cams != null) _cameras.AddRange(cams);
             _error = null;
@@ -579,14 +1139,15 @@
         .Where(e => !_eventsUnreviewedOnly || !e.Reviewed);
 
     private string EventArtifactUrl(ApiEvent ev, string kind) =>
-        $"{_server.TrimEnd('/')}/api/events/{Uri.EscapeDataString(ev.Id)}/{kind}";
+        $"{_server.TrimEnd('/')}/api/events/{Uri.EscapeDataString(ev.Id)}/{kind}{TokenQuery('?')}";
 
     private async Task RefreshEventsAsync()
     {
         if (string.IsNullOrWhiteSpace(_server)) return;
         try
         {
-            var features = await Http.GetFromJsonAsync<ApiFeaturesInfo>($"{_server.TrimEnd('/')}/api/features");
+            using var fres = await Http.SendAsync(ApiRequest(HttpMethod.Get, "/api/features"));
+            var features = fres.IsSuccessStatusCode ? await fres.Content.ReadFromJsonAsync<ApiFeaturesInfo>() : null;
             _continuousSupported = features?.Continuous == true;
             if (!_continuousSupported && _panelTab == "recordings") _panelTab = "events";
         }
@@ -596,7 +1157,13 @@
         }
         try
         {
-            using var res = await Http.GetAsync($"{_server.TrimEnd('/')}/api/events?limit=300");
+            using var res = await Http.SendAsync(ApiRequest(HttpMethod.Get, "/api/events?limit=300"));
+            if (res.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+            {
+                _authEnabled = true;
+                _showLogin = true;
+                return;
+            }
             if (!res.IsSuccessStatusCode)
             {
                 _eventsSupported = false; // recording disabled on the server: hide the UI
@@ -671,7 +1238,11 @@
         {
             var req = new HttpRequestMessage(HttpMethod.Post,
                 $"{_server.TrimEnd('/')}/api/events/{Uri.EscapeDataString(ev.Id)}/review");
-            if (!string.IsNullOrEmpty(_user))
+            if (!string.IsNullOrEmpty(_authToken))
+            {
+                req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _authToken);
+            }
+            else if (!string.IsNullOrEmpty(_user))
             {
                 var token = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes($"{_user}:{_pass}"));
                 req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", token);
@@ -716,7 +1287,7 @@
     // ------------------------------------------------------------ continuous footage
 
     private string SegmentUrl(string camera, string date, string file) =>
-        $"{_server.TrimEnd('/')}/api/recordings/{Uri.EscapeDataString(camera)}/{date}/{file}";
+        $"{_server.TrimEnd('/')}/api/recordings/{Uri.EscapeDataString(camera)}/{date}/{file}{TokenQuery('?')}";
 
     private static string RecDayLabel(string day) =>
         DateTime.TryParseExact(day, "yyyy-MM-dd", null, System.Globalization.DateTimeStyles.None, out var d)
@@ -745,8 +1316,9 @@
         if (_recCamera.Length == 0 || string.IsNullOrWhiteSpace(_server)) return;
         try
         {
-            var days = await Http.GetFromJsonAsync<List<string>>(
-                $"{_server.TrimEnd('/')}/api/recordings/{Uri.EscapeDataString(_recCamera)}");
+            using var res = await Http.SendAsync(ApiRequest(HttpMethod.Get,
+                $"/api/recordings/{Uri.EscapeDataString(_recCamera)}"));
+            var days = res.IsSuccessStatusCode ? await res.Content.ReadFromJsonAsync<List<string>>() : null;
             if (days != null) _recDays = days;
         }
         catch (Exception ex)
@@ -769,8 +1341,9 @@
         if (_recSegments.ContainsKey(day)) return;
         try
         {
-            var segments = await Http.GetFromJsonAsync<List<ApiSegment>>(
-                $"{_server.TrimEnd('/')}/api/recordings/{Uri.EscapeDataString(_recCamera)}/{day}");
+            using var res = await Http.SendAsync(ApiRequest(HttpMethod.Get,
+                $"/api/recordings/{Uri.EscapeDataString(_recCamera)}/{day}"));
+            var segments = res.IsSuccessStatusCode ? await res.Content.ReadFromJsonAsync<List<ApiSegment>>() : null;
             _recSegments[day] = segments ?? new List<ApiSegment>();
         }
         catch
@@ -957,7 +1530,7 @@
         baseUrl = baseUrl.StartsWith("https", StringComparison.OrdinalIgnoreCase)
             ? "wss" + baseUrl["https".Length..]
             : "ws" + baseUrl["http".Length..];
-        return $"{baseUrl}/api/stream?path={Uri.EscapeDataString(slot.Path)}";
+        return $"{baseUrl}/api/stream?path={Uri.EscapeDataString(slot.Path)}{TokenQuery('&')}";
     }
 
     private async Task ReconcilePlayersAsync()
@@ -985,6 +1558,7 @@
     public async ValueTask DisposeAsync()
     {
         _pollTimer?.Dispose();
+        _selfRef?.Dispose();
         foreach (var i in _attached.Keys.ToList())
         {
             try { await JS.InvokeVoidAsync("neolink.detach", $"vid-{i}"); }

--- a/src/Neolink.WebClient/Components/Pages/Timeline.razor
+++ b/src/Neolink.WebClient/Components/Pages/Timeline.razor
@@ -127,6 +127,7 @@
     private const double DaySeconds = 24 * 3600;
 
     private string _server = "";
+    private string? _token; // web-UI session (shared with the live view via localStorage)
     private DateTime _date = DateTime.Today;
     private double _t;
     private bool _playing;
@@ -167,6 +168,12 @@
                 var json = await JS.InvokeAsync<string?>("neolink.lsGet", "neolink.view");
                 if (json != null)
                     _server = JsonSerializer.Deserialize<PersistedView>(json)?.Server ?? "";
+                var auth = await JS.InvokeAsync<string?>("neolink.lsGet", "neolink.auth");
+                if (!string.IsNullOrWhiteSpace(auth))
+                {
+                    var el = JsonSerializer.Deserialize<JsonElement>(auth);
+                    if (el.TryGetProperty("token", out var t)) _token = t.GetString();
+                }
             }
             catch { }
             if (string.IsNullOrWhiteSpace(_server))
@@ -210,14 +217,36 @@
 
     private string Base => _server.TrimEnd('/');
 
+    private string TokenQuery(char sep) =>
+        string.IsNullOrEmpty(_token) ? "" : $"{sep}token={Uri.EscapeDataString(_token)}";
+
+    /// <summary>Authenticated GET; null on failure (401 also sets the sign-in notice).</summary>
+    private async Task<T?> GetJsonAsync<T>(string path)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, $"{Base}{path}");
+        if (!string.IsNullOrEmpty(_token))
+            req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _token);
+        using var res = await Http.SendAsync(req);
+        if (res.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+        {
+            _error = "Authentication required — sign in on the live view first.";
+            return default;
+        }
+        if (!res.IsSuccessStatusCode) return default;
+        return await res.Content.ReadFromJsonAsync<T>();
+    }
+
     private async Task LoadCamerasAsync()
     {
         try
         {
-            var cams = await Http.GetFromJsonAsync<List<ApiCamera>>($"{Base}/api/cameras");
+            var cams = await GetJsonAsync<List<ApiCamera>>("/api/cameras");
             _cameras.Clear();
-            if (cams != null) _cameras.AddRange(cams);
-            _error = null;
+            if (cams != null)
+            {
+                _cameras.AddRange(cams);
+                _error = null;
+            }
         }
         catch (Exception ex)
         {
@@ -234,7 +263,7 @@
         // Feature gates first: the timeline needs recording AND continuous footage.
         try
         {
-            var features = await Http.GetFromJsonAsync<ApiFeaturesInfo>($"{Base}/api/features");
+            var features = await GetJsonAsync<ApiFeaturesInfo>("/api/features");
             _supported = features?.Events == true;
             _continuous = features?.Continuous == true;
         }
@@ -248,13 +277,12 @@
         // The events reply doubles as the day's colored lane marks.
         try
         {
-            using var res = await Http.GetAsync($"{Base}/api/events?limit=1000");
-            if (!res.IsSuccessStatusCode)
+            var events = await GetJsonAsync<List<ApiEvent>>("/api/events?limit=1000");
+            if (events == null)
             {
                 _supported = false;
                 return;
             }
-            var events = await res.Content.ReadFromJsonAsync<List<ApiEvent>>() ?? new List<ApiEvent>();
             foreach (var ev in events)
             {
                 var start = ev.Start.ToLocalTime();
@@ -288,8 +316,8 @@
         var date = _date.ToString("yyyy-MM-dd");
         try
         {
-            var segs = await Http.GetFromJsonAsync<List<ApiSegment>>(
-                $"{Base}/api/recordings/{Uri.EscapeDataString(camera)}/{date}");
+            var segs = await GetJsonAsync<List<ApiSegment>>(
+                $"/api/recordings/{Uri.EscapeDataString(camera)}/{date}");
             _cov[camera] = BuildSegs(segs ?? new List<ApiSegment>(), camera, date);
         }
         catch
@@ -325,7 +353,7 @@
                 if (gap <= typical * 1.5) span = gap;
             }
             segs.Add(new Seg(start, span,
-                $"{Base}/api/recordings/{Uri.EscapeDataString(camera)}/{date}/{parsed[i].File}"));
+                $"{Base}/api/recordings/{Uri.EscapeDataString(camera)}/{date}/{parsed[i].File}{TokenQuery('?')}"));
         }
         return segs;
     }

--- a/src/Neolink.WebClient/Models.cs
+++ b/src/Neolink.WebClient/Models.cs
@@ -45,6 +45,16 @@ public sealed record ApiStreamProfiles(List<ApiEncodeProfile> Profiles);
 /// <summary>Server capability flags (GET /api/features).</summary>
 public sealed record ApiFeaturesInfo(bool Events, bool Continuous);
 
+/// <summary>GET /api/auth/status — whether/how the UI must authenticate.</summary>
+public sealed record ApiAuthStatus(bool Enabled, bool SetupRequired, bool ResetAvailable,
+    string? User, bool Admin);
+
+/// <summary>POST /api/auth/login|setup reply.</summary>
+public sealed record ApiAuthToken(string Token, string User, bool Admin);
+
+/// <summary>GET /api/users — one account row.</summary>
+public sealed record ApiUserInfo(string Name, bool Admin);
+
 /// <summary>GET/POST /api/cameras/{name}/recording — runtime recording switches.</summary>
 public sealed record ApiRecordingSettings(bool Events, bool Continuous,
     List<string>? EventTypes, List<string>? KnownTypes, bool ContinuousAvailable = false)
@@ -131,4 +141,10 @@ public sealed class PersistedView
     public List<ViewSlot> Slots { get; set; } = new();
     /// <summary>Set while a tile is maximized: the view to restore. Survives reloads.</summary>
     public ViewSnapshot? Backup { get; set; }
+    /// <summary>Review-strip filter: event types hidden from the top bar.</summary>
+    public List<string> HiddenTypes { get; set; } = new();
+    /// <summary>Review-strip filter: cameras hidden from the top bar.</summary>
+    public List<string> HiddenCams { get; set; } = new();
+    /// <summary>Height of the review strip in px (user-resizable by dragging its bottom edge).</summary>
+    public int StripHeight { get; set; } = 160;
 }

--- a/src/Neolink.WebClient/wwwroot/css/app.css
+++ b/src/Neolink.WebClient/wwwroot/css/app.css
@@ -492,12 +492,19 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
     box-shadow: 0 24px 64px rgba(0, 0, 0, 0.55);
 }
 
+/* Pinned header: the title/close row must stay visible while the panel body
+   scrolls (applies to the camera settings dialog and the events panel alike). */
 .campanel-head {
     display: flex;
     align-items: center;
     gap: 8px;
     font-weight: 700;
     letter-spacing: 1px;
+    position: sticky;
+    top: -16px; /* campanel padding: pin flush to the panel edge */
+    background: var(--panel);
+    z-index: 2;
+    padding: 6px 0;
 }
 
 .campanel-title {
@@ -559,15 +566,16 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
 
 /* ------------------------------------------------------------ events (NVR) */
 
-/* Frigate-style review strip across the top of the stage */
+/* Frigate-style review strip across the top of the stage.
+   Tall cards: preview on top (with ambient trickle playback), label below. */
 .events-bar {
     display: flex;
     align-items: center;
     gap: 8px;
-    padding: 6px 10px;
+    padding: 8px 10px;
     background: var(--panel);
     border-bottom: 1px solid var(--line);
-    min-height: 64px;
+    min-height: 160px;
 }
 
 .events-bar-count {
@@ -588,15 +596,15 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
 
 .event-card {
     display: flex;
-    align-items: center;
-    gap: 8px;
+    flex-direction: column;
+    align-items: stretch;
     background: var(--bg);
     border: 1px solid var(--line);
     border-radius: 8px;
-    padding: 4px 6px;
+    overflow: hidden;
     cursor: pointer;
     flex: 0 0 auto;
-    max-width: 260px;
+    width: 196px;
 }
 
 .event-card:hover { border-color: var(--accent); }
@@ -604,19 +612,25 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
 
 .event-thumb {
     position: relative;
-    width: 84px;
-    height: 48px;
-    border-radius: 5px;
+    width: 100%;
+    height: 106px;
     overflow: hidden;
     background: #000;
     display: flex;
     align-items: center;
     justify-content: center;
-    flex: 0 0 auto;
 }
 
-.event-thumb img { width: 100%; height: 100%; object-fit: cover; }
-.event-thumb-icon { font-size: 22px; opacity: 0.8; }
+.event-thumb img,
+.event-thumb video {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    pointer-events: none; /* clicks land on the card (open player) */
+}
+
+.event-thumb-icon { font-size: 30px; opacity: 0.8; }
 
 .event-live {
     position: absolute;
@@ -638,6 +652,7 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
     flex-direction: column;
     gap: 2px;
     min-width: 0;
+    padding: 5px 8px 7px;
 }
 
 .event-title {
@@ -656,7 +671,17 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
     text-overflow: ellipsis;
 }
 
-.event-dismiss { flex: 0 0 auto; }
+.event-dismiss {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    background: rgba(0, 0, 0, 0.55);
+    border-radius: 6px;
+    padding: 1px 6px;
+}
+
+.event-dismiss:hover { background: rgba(0, 0, 0, 0.8); }
+
 .events-clear { flex: 0 0 auto; }
 
 /* Event history panel (reuses the campanel chrome).
@@ -664,14 +689,6 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
    scroll inside the panel, never resize the popup itself. */
 .events-panel {
     height: min(92vh, 960px);
-}
-
-.events-panel .campanel-head {
-    position: sticky;
-    top: -16px; /* campanel padding: pin flush to the panel edge */
-    background: var(--panel);
-    z-index: 2;
-    padding: 6px 0;
 }
 
 .events-panel .event-filter {

--- a/src/Neolink.WebClient/wwwroot/css/app.css
+++ b/src/Neolink.WebClient/wwwroot/css/app.css
@@ -567,16 +567,50 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
 /* ------------------------------------------------------------ events (NVR) */
 
 /* Frigate-style review strip across the top of the stage.
-   Tall cards: preview on top (with ambient trickle playback), label below. */
+   Tall cards: preview on top (with ambient trickle playback), label below.
+   The height comes from an inline style (user-resizable via the bottom handle);
+   cards scale to fill it, and the stage below takes whatever remains. */
 .events-bar {
+    position: relative;
     display: flex;
-    align-items: center;
+    align-items: stretch;
     gap: 8px;
-    padding: 8px 10px;
+    padding: 8px 10px 12px;
     background: var(--panel);
     border-bottom: 1px solid var(--line);
-    min-height: 160px;
+    min-height: 96px;
+    max-height: 60vh;
+    flex: 0 0 auto;
 }
+
+.events-bar-count,
+.strip-filter-btn,
+.events-clear { align-self: center; }
+
+.strip-resize {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -2px;
+    height: 10px;
+    cursor: ns-resize;
+    touch-action: none;
+    z-index: 5;
+}
+
+.strip-resize::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    top: 3px;
+    width: 48px;
+    height: 4px;
+    margin-left: -24px;
+    border-radius: 2px;
+    background: var(--line);
+}
+
+.strip-resize:hover::after { background: var(--accent); }
 
 .events-bar-count {
     font-size: 12px;
@@ -587,8 +621,10 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
 
 .events-bar-scroll {
     display: flex;
+    align-items: stretch;
     gap: 8px;
     overflow-x: auto;
+    overflow-y: hidden;
     scrollbar-width: thin;
     flex: 1;
     padding: 2px 0;
@@ -604,7 +640,10 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
     overflow: hidden;
     cursor: pointer;
     flex: 0 0 auto;
-    width: 196px;
+    /* Width follows the (resizable) bar height so previews scale with it */
+    height: 100%;
+    aspect-ratio: 5 / 4;
+    min-width: 150px;
 }
 
 .event-card:hover { border-color: var(--accent); }
@@ -613,7 +652,8 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
 .event-thumb {
     position: relative;
     width: 100%;
-    height: 106px;
+    flex: 1;
+    min-height: 0;
     overflow: hidden;
     background: #000;
     display: flex;
@@ -964,6 +1004,113 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
     display: flex;
     align-items: center;
     gap: 8px;
+}
+
+/* Sidebar security warning (server runs without sign-in) */
+.sec-banner {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin: 8px 10px 4px;
+    padding: 8px 10px;
+    border: 1px solid #ffb020;
+    border-radius: 8px;
+    background: color-mix(in srgb, #ffb020 12%, transparent);
+}
+
+.sec-banner-text {
+    font-size: 12px;
+    color: #ffcf70;
+    line-height: 1.35;
+}
+
+.sec-banner-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.sec-banner-actions .icon-btn { margin-left: auto; }
+
+/* Strip filter row (under the events bar) */
+.strip-filter {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    background: var(--panel);
+    border-bottom: 1px solid var(--line);
+}
+
+.strip-filter-btn.active { color: var(--accent); }
+
+/* ------------------------------------------------------------ authentication */
+
+.auth-overlay {
+    position: fixed;
+    inset: 0;
+    background: var(--bg);
+    z-index: 300;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.auth-box {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: min(340px, 90vw);
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    padding: 24px;
+    box-shadow: 0 24px 64px rgba(0, 0, 0, 0.55);
+}
+
+.auth-box .brand { margin-bottom: 8px; }
+
+.auth-box label {
+    font-size: 11px;
+    color: var(--muted);
+    letter-spacing: 1px;
+    text-transform: uppercase;
+}
+
+.auth-box input {
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 8px 10px;
+    font-size: 14px;
+    outline: none;
+}
+
+.auth-box input:focus { border-color: var(--accent); }
+.auth-btn { justify-content: center; padding: 8px; font-size: 14px; margin-top: 6px; }
+
+.auth-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 10px;
+    flex-wrap: wrap;
+}
+
+.auth-panel { width: min(460px, 94vw); }
+
+.user-row { flex-wrap: wrap; }
+
+.user-pass-input {
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 4px 8px;
+    font-size: 12px;
+    max-width: 160px;
 }
 
 /* ------------------------------------------------------------ stream chips */

--- a/src/Neolink.WebClient/wwwroot/js/neolink.js
+++ b/src/Neolink.WebClient/wwwroot/js/neolink.js
@@ -309,6 +309,36 @@
             });
         },
 
+        // Review-strip vertical resizing: drag the handle at the bar's bottom edge.
+        // The height is applied live in the DOM (no SignalR churn while dragging)
+        // and reported to Blazor once on release for persistence.
+        stripResizeInit(id, dotnetRef) {
+            const el = document.getElementById(id);
+            if (!el || el.dataset.resizeInit) return;
+            const handle = el.querySelector('.strip-resize');
+            if (!handle) return;
+            el.dataset.resizeInit = '1';
+            handle.addEventListener('pointerdown', (e) => {
+                if (e.button !== 0 && e.pointerType === 'mouse') return;
+                e.preventDefault();
+                e.stopPropagation();
+                try { handle.setPointerCapture(e.pointerId); } catch { }
+                const startY = e.clientY;
+                const startH = el.getBoundingClientRect().height;
+                const move = (ev) => {
+                    const h = Math.max(96, Math.min(window.innerHeight * 0.6, startH + ev.clientY - startY));
+                    el.style.height = h + 'px';
+                };
+                const up = () => {
+                    handle.removeEventListener('pointermove', move);
+                    handle.removeEventListener('pointerup', up);
+                    dotnetRef.invokeMethodAsync('OnStripResized', el.getBoundingClientRect().height);
+                };
+                handle.addEventListener('pointermove', move);
+                handle.addEventListener('pointerup', up);
+            });
+        },
+
         // Points a <video> at a recording segment and keeps it at the wanted
         // offset. Tolerance while playing avoids constant reseeks (the video
         // advances on its own); paused scrubbing snaps tightly.

--- a/src/Neolink.WebClient/wwwroot/js/neolink.js
+++ b/src/Neolink.WebClient/wwwroot/js/neolink.js
@@ -300,6 +300,15 @@
     window.neolink = {
         freeInit,
 
+        // Ambient event previews (review strip): ensure real muting and start
+        // looped playback on every trickle video. Idempotent, called per render.
+        trickle() {
+            document.querySelectorAll('video[data-trickle]').forEach(v => {
+                v.muted = true;
+                if (v.paused) v.play().catch(() => { });
+            });
+        },
+
         // Points a <video> at a recording segment and keeps it at the wanted
         // offset. Tolerance while playing avoids constant reseeks (the video
         // advances on its own); paused scrubbing snaps tightly.


### PR DESCRIPTION
Two commits.

## 1. Re-enable continuous recording with an HDD-safe writer; trickle previews (`3c0cc7c`)
- `ClipWriter` muxes on the caller but does ALL disk I/O on a dedicated below-normal-priority thread per file behind a 16 MB memory budget — a stalling HDD can never starve the thread pool that live streaming runs on; when the disk falls behind, recorded frames are dropped (warning logged) and recording resumes at the next keyframe.
- `RecordingConfig.ContinuousEnabled` flipped back to `true`; recorders handle disk death via a `Faulted` flag + backoff; files finalize (duration patch + mfra index) on the writer thread.
- Review strip: taller Frigate-style vertical cards whose newest few loop their clip muted inline (capped at 8); camera-settings popup gets a pinned header.

## 2. Web-UI accounts, per-user settings, strip filters, resizable strip (`feb1385`)
- **Auth, file-based (no DB)**: `users.json` next to the config. PBKDF2-SHA256 (210k iterations, per-user salt, constant-time compare); stateless HMAC-SHA256 session tokens (30-day expiry, invalidated on password change); timing-equalized login for unknown users. **Off by default** — the first visitor is prompted to create the admin, which turns enforcement on for the whole API (Bearer header, `?token=` for media/WS URLs).
- **Admin user management** from the UI: add normal users, change passwords, delete (admin undeletable). **Recovery** via `"reset_admin_password": true` → login-screen flow to capture a new admin password.
- **Per-user UI settings** (layout, slots, filters, strip height) persist server-side per account; localStorage fallback when auth is off.
- **Strip filters**: type + camera chips filter the review strip in real time (event stays while any of its labels is shown).
- **Resizable strip**: drag the bar's bottom handle (96px–60vh); cards scale (5:4) and the stage reflows; height persists.
- **Sidebar warning banner** (dismissable) while the server runs without sign-in, with a "Secure now" shortcut.

## Reviewer notes
- 19/19 self-tests (adds user-store hashing/token/CRUD/settings coverage; clip-writer test awaits background finalization).
- Verified in live browser sessions: storage backpressure surfaces (fault flag), trickle playback, setup → 401/200 enforcement → login persistence → filters → user CRUD → resize/reflow → banner dismissal.
- Plain-HTTP caveat: tokens ride URLs for media elements; use a TLS proxy if the UI leaves the LAN.
- Real-hardware check: confirm live-feed gaps stay gone with continuous recording ON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)