### PR TITLE
"ui" config section, relocatable UI state, 4x sub-stream trickle previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,9 +236,27 @@ the original Rust neolink are also accepted.
 | `web_port` | `8655` | Web UI + HTTP/WS API port; `0` disables both |
 | `webui` | `true` | Serve the browser UI on `web_port`; `false` = API only |
 | `web_bind` | = `bind` | Separate bind address for the web port |
-| `users` | *(none)* | RTSP Basic-auth users: `{ "name", "pass" }`. Omit for open access |
+| `users` | *(none)* | **RTSP** Basic-auth users: `{ "name", "pass" }`. Omit for open access. Separate from web-UI accounts! |
 | `recording` | *(none)* | Event recording (see below). Omit to disable |
-| `reset_admin_password` | `false` | Web-UI recovery: while `true`, the login screen allows setting a new admin password. Turn it back off after use |
+| `ui` | *(defaults)* | Web-UI specific settings (see below) |
+
+### Web-UI settings (`"ui": { ... }`)
+
+| Option | Default | Description |
+|---|---|---|
+| `enabled` / `port` / `bind` | = `webui` / `web_port` / `web_bind` | Grouped aliases of the top-level web options |
+| `state_dir` | config dir | Where the UI's server-side state persists: `users.json` (sign-in accounts) and `settings.json` (per-user layouts/filters/recording switches) |
+| `reset_admin_password` | `false` | Recovery: while `true`, the login screen allows setting a new admin password. Turn it back off after use |
+| `trickle_speed` | `4` | Playback speed of the review strip's ambient clip previews |
+
+> **Persistence across deployments** — three locations must live on volumes or
+> your state resets every deploy: **(1)** the config directory (or `ui.state_dir`)
+> holding `users.json` + `settings.json` — lose it and accounts, layouts and
+> filters reset; **(2)** the `recording.path` directory — lose it and footage
+> *and the reviewed/dismissed state* (stored in each event's `event.json`) reset,
+> so previously dismissed events reappear; **(3)** `config.json` itself. The
+> docker-compose example mounts (1)+(3) via `./config:/config` and (2) via
+> `./recordings:/recordings`.
 
 ### Web UI sign-in
 

--- a/src/Neolink.Server/Config/NeolinkConfig.cs
+++ b/src/Neolink.Server/Config/NeolinkConfig.cs
@@ -15,8 +15,13 @@ public sealed class NeolinkConfig
     public bool WebUi { get; set; } = true;
     /// <summary>Event recording (motion/AI detections + clips); null = disabled.</summary>
     public RecordingConfig? Recording { get; set; }
-    /// <summary>Recovery switch: while true, the login screen allows setting a new admin password.</summary>
+    /// <summary>Web-UI specific settings ("ui" section).</summary>
+    public UiConfig Ui { get; set; } = new();
+    /// <summary>Recovery switch (legacy top-level spelling; "ui.reset_admin_password" preferred).</summary>
     public bool ResetAdminPassword { get; set; }
+
+    /// <summary>Either spelling of the admin-password recovery switch.</summary>
+    public bool EffectiveResetAdminPassword => ResetAdminPassword || Ui.ResetAdminPassword;
     public List<UserConfig> Users { get; } = new();
     public List<CameraConfig> Cameras { get; } = new();
 
@@ -81,6 +86,9 @@ public sealed class NeolinkConfig
                     break;
                 case "resetadminpassword":
                     config.ResetAdminPassword = prop.Value.GetBoolean();
+                    break;
+                case "ui":
+                    ParseJsonUi(prop.Value, config);
                     break;
                 case "users":
                     foreach (var u in prop.Value.EnumerateArray())
@@ -177,6 +185,27 @@ public sealed class NeolinkConfig
         return rec;
     }
 
+    private static void ParseJsonUi(JsonElement el, NeolinkConfig config)
+    {
+        foreach (var prop in el.EnumerateObject())
+        {
+            switch (Key(prop.Name))
+            {
+                // Grouped aliases of the top-level web options
+                case "enabled": config.WebUi = prop.Value.GetBoolean(); break;
+                case "port": config.WebPort = prop.Value.GetInt32(); break;
+                case "bind": config.WebBind = prop.Value.GetString(); break;
+                // UI-only settings
+                case "statedir": config.Ui.StateDir = prop.Value.GetString(); break;
+                case "resetadminpassword": config.Ui.ResetAdminPassword = prop.Value.GetBoolean(); break;
+                case "tricklespeed": config.Ui.TrickleSpeed = prop.Value.GetDouble(); break;
+                default:
+                    Log.Warn($"Config: ignoring unknown ui option '{prop.Name}'");
+                    break;
+            }
+        }
+    }
+
     /// <summary>Normalizes JSON keys: case-insensitive, tolerates snake_case and kebab-case.</summary>
     private static string Key(string name) =>
         name.Replace("_", "").Replace("-", "").ToLowerInvariant();
@@ -198,6 +227,16 @@ public sealed class NeolinkConfig
 
         if (MiniToml.GetString(root, "certificate") != null)
             WarnTls();
+
+        if (MiniToml.GetTable(root, "ui") is { } ui)
+        {
+            if (MiniToml.GetBool(ui, "enabled") is { } en) config.WebUi = en;
+            if (MiniToml.GetInt(ui, "port") is { } p) config.WebPort = (int)p;
+            config.WebBind = MiniToml.GetString(ui, "bind") ?? config.WebBind;
+            config.Ui.StateDir = MiniToml.GetString(ui, "state_dir");
+            config.Ui.ResetAdminPassword = MiniToml.GetBool(ui, "reset_admin_password") ?? false;
+            if (MiniToml.GetInt(ui, "trickle_speed") is { } ts) config.Ui.TrickleSpeed = ts;
+        }
 
         if (MiniToml.GetTable(root, "recording") is { } rec)
         {
@@ -331,6 +370,11 @@ public sealed class NeolinkConfig
             if (Recording.ContinuousRetentionDays is < 0)
                 throw new FormatException("recording.continuous_retention_days must be >= 0 (0 = keep forever)");
         }
+
+        if (Ui.TrickleSpeed is < 0.25 or > 16)
+            throw new FormatException("ui.trickle_speed must be 0.25..16");
+        if (Ui.StateDir is { Length: 0 })
+            throw new FormatException("ui.state_dir must not be empty when set");
     }
 
     private static (string host, int port) SplitHostPort(string address)
@@ -361,6 +405,25 @@ public sealed class UserConfig
 {
     public required string Name { get; init; }
     public required string Pass { get; init; }
+}
+
+/// <summary>
+/// Web-UI settings ("ui" in the config). Note: UI accounts (sign-in) are NOT
+/// configured here — they live in users.json under <see cref="StateDir"/> and
+/// are managed from the UI itself; the top-level "users" list is RTSP-only.
+/// </summary>
+public sealed class UiConfig
+{
+    /// <summary>
+    /// Where the UI's server-side state persists (users.json, settings.json).
+    /// Defaults to the config file's directory — point it at a persistent volume
+    /// if the config is mounted read-only or replaced on deployments.
+    /// </summary>
+    public string? StateDir { get; set; }
+    /// <summary>Recovery: while true, the login screen allows setting a new admin password.</summary>
+    public bool ResetAdminPassword { get; set; }
+    /// <summary>Playback rate of the review-strip's ambient clip previews.</summary>
+    public double TrickleSpeed { get; set; } = 4;
 }
 
 /// <summary>Event recording settings ("recording" in the config).</summary>

--- a/src/Neolink.Server/Program.cs
+++ b/src/Neolink.Server/Program.cs
@@ -73,6 +73,21 @@ catch (Exception ex)
 
 Log.Info($"Neolink.NET {Version} starting");
 
+// Server-side UI state (accounts, runtime settings) lives in state_dir — the
+// config directory unless relocated (e.g. because the config mount is read-only).
+var configDir = Path.GetDirectoryName(Path.GetFullPath(configPath))!;
+var stateDir = config.Ui.StateDir ?? configDir;
+try
+{
+    Directory.CreateDirectory(stateDir);
+}
+catch (Exception ex)
+{
+    return Fail($"ui.state_dir '{stateDir}' is unusable: {ex.Message}");
+}
+if (stateDir != configDir)
+    Log.Info($"UI state directory: {stateDir}");
+
 using var shutdown = new CancellationTokenSource();
 Console.CancelKeyPress += (_, e) =>
 {
@@ -102,10 +117,9 @@ if (config.Recording is { } recCfg)
     {
         eventStore = new EventStore(recCfg.Path);
         eventStore.Load();
-        // Runtime switches live next to the config file; the recordings root is
-        // checked once to migrate the old location.
-        recordingSettings = new RecordingSettings(
-            Path.GetDirectoryName(Path.GetFullPath(configPath))!, legacyDir: eventStore.Root);
+        // Runtime switches live in the state dir; older locations (config dir,
+        // recordings root) are checked once for migration.
+        recordingSettings = new RecordingSettings(stateDir, configDir, eventStore.Root);
         Log.Info($"Recording to {eventStore.Root} " +
                  $"(events: {(recCfg.RetentionDays > 0 ? $"{recCfg.RetentionDays} days" : "forever")}, " +
                  $"continuous: {(recCfg.EffectiveContinuousRetentionDays > 0 ? $"{recCfg.EffectiveContinuousRetentionDays} days" : "forever")})");
@@ -175,8 +189,12 @@ foreach (var cam in config.Cameras)
         else
         {
             recordingSettings.Seed(cam.Name, eventsDefault: cam.Record);
+            // Strip previews are cut from the sub stream when it is served and
+            // differs from the recording stream (no point recording twice).
+            var previewStream = webStreams.FirstOrDefault(s => s.Kind == "subStream");
+            if (previewStream == recordStream) previewStream = null;
             var recorder = new EventRecorder(cam.Name, recordStream.Hub, control, eventStore,
-                config.Recording, recordingSettings);
+                config.Recording, recordingSettings, previewStream?.Hub);
             primaryService.MotionSink = recorder.OnMotion;
             tasks.Add(Task.Run(() => recorder.RunAsync(shutdown.Token)));
 
@@ -195,12 +213,12 @@ foreach (var cam in config.Cameras)
 // Web API (camera list + fMP4 live streams for browsers); guarded like the cameras.
 if (config.WebPort > 0)
 {
-    // Web-UI accounts (users.json next to the config). Auth is off until the
+    // Web-UI accounts (users.json in the state dir). Auth is off until the
     // first account (the admin) is created from the UI itself.
-    var userStore = new UserStore(Path.GetDirectoryName(Path.GetFullPath(configPath))!);
+    var userStore = new UserStore(stateDir, legacyDir: configDir);
     if (!userStore.Enabled)
         Log.Info("Web UI authentication is off — create the admin account from the UI to enable it");
-    if (config.ResetAdminPassword)
+    if (config.EffectiveResetAdminPassword)
         Log.Warn("reset_admin_password is TRUE: anyone reaching the login page can set a new admin " +
                  "password. Set it back to false as soon as the reset is done!");
 
@@ -210,7 +228,7 @@ if (config.WebPort > 0)
         {
             await WebApi.RunAsync(config.WebBind ?? config.BindAddr, config.WebPort, config.WebUi,
                 webCameras, users, config.BindPort, eventStore, recordingSettings,
-                userStore, config.ResetAdminPassword, shutdown.Token);
+                userStore, config.EffectiveResetAdminPassword, config.Ui.TrickleSpeed, shutdown.Token);
         }
         catch (OperationCanceledException) { }
         catch (Exception ex)

--- a/src/Neolink.Server/Recording/EventRecorder.cs
+++ b/src/Neolink.Server/Recording/EventRecorder.cs
@@ -24,6 +24,7 @@ public sealed class EventRecorder
 {
     private readonly string _camera;
     private readonly IStreamHub _hub;
+    private readonly IStreamHub? _previewHub;
     private readonly ICameraControl _control;
     private readonly EventStore _store;
     private readonly RecordingConfig _cfg;
@@ -32,19 +33,25 @@ public sealed class EventRecorder
     private readonly Channel<MotionPush> _pushes = Channel.CreateUnbounded<MotionPush>(
         new UnboundedChannelOptions { SingleReader = true });
 
-    // Pre-roll buffer and clip writer are handed between the pump and the event
-    // loop under one gate; both touch them briefly (local file I/O only).
+    // Pre-roll buffers and clip writers are handed between the pumps and the event
+    // loop under one gate; all touch them briefly (never blocking on disk).
     // Each buffered packet carries its drop flag so a clip started later still
-    // knows where the stream was discontinuous.
+    // knows where the stream was discontinuous. The optional preview capture
+    // records the sub stream into preview.mp4 alongside the full clip — that's
+    // what the review strip's ambient players use, keeping client decode cheap.
     private readonly object _mediaGate = new();
     private readonly List<(HubVideo Video, bool Gap)> _preroll = new();
+    private readonly List<(HubVideo Video, bool Gap)> _previewPreroll = new();
     private ClipWriter? _writer;
+    private ClipWriter? _previewWriter;
 
     public EventRecorder(string camera, IStreamHub hub, ICameraControl control,
-        EventStore store, RecordingConfig cfg, RecordingSettings settings)
+        EventStore store, RecordingConfig cfg, RecordingSettings settings,
+        IStreamHub? previewHub = null)
     {
         _camera = camera;
         _hub = hub;
+        _previewHub = previewHub;
         _control = control;
         _store = store;
         _cfg = cfg;
@@ -58,26 +65,35 @@ public sealed class EventRecorder
 
     public async Task RunAsync(CancellationToken ct)
     {
-        Log.Info($"{_camera}: event recording enabled ({_hub.Name}, pre={_cfg.PreSeconds}s, post={_cfg.PostSeconds}s)");
-        var pump = Task.Run(() => PumpPacketsAsync(ct), CancellationToken.None);
+        Log.Info($"{_camera}: event recording enabled ({_hub.Name}, pre={_cfg.PreSeconds}s, post={_cfg.PostSeconds}s" +
+                 $"{(_previewHub != null ? $", previews from {_previewHub.Name}" : "")})");
+        var pump = Task.Run(() => PumpPacketsAsync(_hub, preview: false, ct), CancellationToken.None);
+        var previewPump = _previewHub == null
+            ? Task.CompletedTask
+            : Task.Run(() => PumpPacketsAsync(_previewHub, preview: true, ct), CancellationToken.None);
         try
         {
             await EventLoopAsync(ct).ConfigureAwait(false);
         }
         finally
         {
-            ClipWriter? closing;
+            ClipWriter? closing, closingPreview;
             lock (_mediaGate)
             {
                 closing = _writer;
+                closingPreview = _previewWriter;
                 _writer = null;
+                _previewWriter = null;
             }
             closing?.Dispose();
+            closingPreview?.Dispose();
             try { await pump.ConfigureAwait(false); } catch { }
-            // Give the writer thread a moment to finalize the file on shutdown.
-            if (closing != null)
+            try { await previewPump.ConfigureAwait(false); } catch { }
+            // Give the writer threads a moment to finalize files on shutdown.
+            foreach (var w in new[] { closing, closingPreview })
             {
-                try { await closing.Completion.WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false); }
+                if (w == null) continue;
+                try { await w.Completion.WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false); }
                 catch { }
             }
         }
@@ -85,9 +101,9 @@ public sealed class EventRecorder
 
     // ------------------------------------------------------------------ packet pump
 
-    private async Task PumpPacketsAsync(CancellationToken ct)
+    private async Task PumpPacketsAsync(IStreamHub hub, bool preview, CancellationToken ct)
     {
-        var (id, reader) = _hub.Subscribe();
+        var (id, reader) = hub.Subscribe();
         try
         {
             // The hub index is global across video AND audio packets, so it must be
@@ -103,22 +119,26 @@ public sealed class EventRecorder
                 if (packet is not HubVideo v) continue;
                 lock (_mediaGate)
                 {
-                    if (_writer != null)
+                    var writer = preview ? _previewWriter : _writer;
+                    if (writer != null)
                     {
                         // Add never blocks on disk (background writer thread); a dead
                         // disk surfaces as Faulted and the event continues clip-less.
-                        _writer.Add(v, gap);
-                        if (_writer.Faulted)
+                        writer.Add(v, gap);
+                        if (writer.Faulted)
                         {
-                            Log.Warn($"{_camera}: clip writer failed; event continues without further video");
-                            _writer.Dispose();
-                            _writer = null;
+                            Log.Warn($"{_camera}: {(preview ? "preview" : "clip")} writer failed; " +
+                                     "event continues without further video");
+                            writer.Dispose();
+                            if (preview) _previewWriter = null;
+                            else _writer = null;
                         }
                     }
                     else
                     {
-                        _preroll.Add((v, gap));
-                        TrimPreroll();
+                        var buffer = preview ? _previewPreroll : _preroll;
+                        buffer.Add((v, gap));
+                        TrimPreroll(buffer);
                     }
                 }
             }
@@ -126,34 +146,34 @@ public sealed class EventRecorder
         catch (OperationCanceledException) { }
         finally
         {
-            _hub.Unsubscribe(id);
+            hub.Unsubscribe(id);
         }
     }
 
     /// <summary>
-    /// Keeps the pre-roll spanning at least PreSeconds while starting on a keyframe
+    /// Keeps a pre-roll spanning at least PreSeconds while starting on a keyframe
     /// (a clip must begin decodable): drop everything before the latest keyframe
     /// that still preserves the wanted span.
     /// </summary>
-    private void TrimPreroll()
+    private void TrimPreroll(List<(HubVideo Video, bool Gap)> buffer)
     {
         uint want = (uint)_cfg.PreSeconds * FMp4.Timescale;
-        uint last = _preroll[^1].Video.RtpTs;
+        uint last = buffer[^1].Video.RtpTs;
         int cut = -1;
-        for (int i = _preroll.Count - 1; i >= 0; i--)
+        for (int i = buffer.Count - 1; i >= 0; i--)
         {
-            if (!_preroll[i].Video.Keyframe) continue;
-            if (unchecked(last - _preroll[i].Video.RtpTs) >= want)
+            if (!buffer[i].Video.Keyframe) continue;
+            if (unchecked(last - buffer[i].Video.RtpTs) >= want)
             {
                 cut = i;
                 break;
             }
         }
         if (cut > 0)
-            _preroll.RemoveRange(0, cut);
+            buffer.RemoveRange(0, cut);
         // Safety valve for streams with pathological keyframe intervals.
-        if (_preroll.Count > 4096)
-            _preroll.RemoveRange(0, _preroll.Count - 4096);
+        if (buffer.Count > 4096)
+            buffer.RemoveRange(0, buffer.Count - 4096);
     }
 
     // ------------------------------------------------------------------ event lifecycle
@@ -250,6 +270,8 @@ public sealed class EventRecorder
         {
             _writer?.Dispose();
             _writer = null;
+            _previewWriter?.Dispose();
+            _previewWriter = null;
         }
         rec.EndUtc = DateTime.UtcNow;
         rec.Ongoing = false;
@@ -269,11 +291,13 @@ public sealed class EventRecorder
                 if (_writer == null)
                 {
                     Log.Warn($"{_camera}: stream not ready; event stored without a clip");
-                    return;
                 }
-                foreach (var (v, gap) in _preroll)
-                    _writer.Add(v, gap);
-                _preroll.Clear();
+                else
+                {
+                    foreach (var (v, gap) in _preroll)
+                        _writer.Add(v, gap);
+                    _preroll.Clear();
+                }
             }
             catch (Exception ex)
             {
@@ -281,12 +305,32 @@ public sealed class EventRecorder
                 _writer?.Dispose();
                 _writer = null;
             }
+
+            // The low-res twin from the sub stream, for the review strip's previews.
+            if (_previewHub != null)
+            {
+                try
+                {
+                    _previewWriter = ClipWriter.TryCreate(Path.Combine(_store.EventDir(rec), "preview.mp4"), _previewHub);
+                    if (_previewWriter != null)
+                    {
+                        foreach (var (v, gap) in _previewPreroll)
+                            _previewWriter.Add(v, gap);
+                        _previewPreroll.Clear();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.Warn($"{_camera}: cannot start preview clip: {ex.Message}");
+                    _previewWriter?.Dispose();
+                    _previewWriter = null;
+                }
+            }
         }
-        if (_writer != null)
-        {
-            rec.HasClip = true;
+        rec.HasClip = _writer != null;
+        rec.HasPreview = _previewWriter != null;
+        if (rec.HasClip || rec.HasPreview)
             _store.Save(rec);
-        }
     }
 
     /// <summary>Best-effort thumbnail via the camera's own JPEG snapshot command.</summary>

--- a/src/Neolink.Server/Recording/EventStore.cs
+++ b/src/Neolink.Server/Recording/EventStore.cs
@@ -17,6 +17,8 @@ public sealed class EventRecord
     public bool Ongoing { get; set; }
     public bool HasClip { get; set; }
     public bool HasThumb { get; set; }
+    /// <summary>A low-res sub-stream twin of the clip exists (preview.mp4), for strip previews.</summary>
+    public bool HasPreview { get; set; }
 }
 
 /// <summary>

--- a/src/Neolink.Server/Recording/RecordingSettings.cs
+++ b/src/Neolink.Server/Recording/RecordingSettings.cs
@@ -33,18 +33,23 @@ public sealed class RecordingSettings
     private readonly object _gate = new();
     private Dictionary<string, CameraRecordingSettings> _cameras = new(StringComparer.OrdinalIgnoreCase);
 
-    public RecordingSettings(string configDir, string? legacyDir = null)
+    public RecordingSettings(string stateDir, params string?[] legacyDirs)
     {
-        _file = Path.Combine(configDir, "settings.json");
+        _file = Path.Combine(stateDir, "settings.json");
         try
         {
-            // Older versions kept settings.json in the recordings root; migrate once.
+            // Older versions kept settings.json in the config dir or the recordings
+            // root; a relocated state_dir migrates from whichever exists, once.
             var source = _file;
-            if (!File.Exists(source) && legacyDir != null
-                && File.Exists(Path.Combine(legacyDir, "settings.json")))
+            foreach (var legacy in legacyDirs)
             {
-                source = Path.Combine(legacyDir, "settings.json");
-                Log.Info($"Recording settings: migrating {source} -> {_file}");
+                if (File.Exists(source) || legacy == null) break;
+                var candidate = Path.Combine(legacy, "settings.json");
+                if (File.Exists(candidate))
+                {
+                    source = candidate;
+                    Log.Info($"Recording settings: migrating {source} -> {_file}");
+                }
             }
             if (File.Exists(source))
             {

--- a/src/Neolink.Server/SelfTest.cs
+++ b/src/Neolink.Server/SelfTest.cs
@@ -323,7 +323,7 @@ public static class SelfTest
                 // config dir must pick it up from there and re-home it.
                 var newDir = Path.Combine(dir, "new-config-dir");
                 Directory.CreateDirectory(newDir);
-                var migrated = new Recording.RecordingSettings(newDir, legacyDir: dir);
+                var migrated = new Recording.RecordingSettings(newDir, dir);
                 Assert(migrated.Get("cam1").Continuous, "legacy settings migrated");
                 Assert(File.Exists(Path.Combine(newDir, "settings.json")), "settings re-homed to config dir");
             }

--- a/src/Neolink.Server/Web/UserStore.cs
+++ b/src/Neolink.Server/Web/UserStore.cs
@@ -49,19 +49,29 @@ public sealed class UserStore
         public List<UserRecord> Users { get; set; } = new();
     }
 
-    public UserStore(string configDir)
+    public UserStore(string stateDir, string? legacyDir = null)
     {
-        _file = Path.Combine(configDir, "users.json");
+        _file = Path.Combine(stateDir, "users.json");
         try
         {
-            if (File.Exists(_file))
+            // A relocated state_dir picks the accounts up from the old location once.
+            var source = _file;
+            if (!File.Exists(source) && legacyDir != null
+                && File.Exists(Path.Combine(legacyDir, "users.json")))
             {
-                var model = JsonSerializer.Deserialize<FileModel>(File.ReadAllText(_file), JsonOpts);
+                source = Path.Combine(legacyDir, "users.json");
+                Log.Info($"UI accounts: migrating {source} -> {_file}");
+            }
+            if (File.Exists(source))
+            {
+                var model = JsonSerializer.Deserialize<FileModel>(File.ReadAllText(source), JsonOpts);
                 if (model != null)
                 {
                     if (model.Secret.Length > 0) _secret = Convert.FromBase64String(model.Secret);
                     _users = model.Users;
                 }
+                if (source != _file)
+                    lock (_gate) { SaveLocked(); }
             }
         }
         catch (Exception ex)

--- a/src/Neolink.Server/Web/WebApi.cs
+++ b/src/Neolink.Server/Web/WebApi.cs
@@ -55,7 +55,7 @@ public static class WebApi
     public static async Task RunAsync(string bindAddr, int port, bool webUi,
         IReadOnlyList<WebCameraInfo> cameras, IReadOnlyDictionary<string, string> users,
         int rtspPort, EventStore? events, RecordingSettings? recordingSettings,
-        UserStore userStore, bool resetAdminPassword, CancellationToken ct)
+        UserStore userStore, bool resetAdminPassword, double trickleSpeed, CancellationToken ct)
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
         {
@@ -271,6 +271,7 @@ public static class WebApi
         {
             events = events != null,
             continuous = events != null && RecordingConfig.ContinuousEnabled,
+            trickleSpeed,
         }));
 
         app.MapGet("/api/cameras", () =>
@@ -509,6 +510,7 @@ public static class WebApi
                 ongoing = r.Ongoing,
                 hasClip = r.HasClip,
                 hasThumb = r.HasThumb,
+                hasPreview = r.HasPreview,
             };
 
             app.MapGet("/api/events", (string? camera, bool? reviewed, int? limit) =>
@@ -528,6 +530,15 @@ public static class WebApi
                 return path == null
                     ? Results.Json(new { error = "no thumbnail for this event" }, statusCode: 404)
                     : Results.File(path, "image/jpeg");
+            });
+
+            // The clip's low-res sub-stream twin, used by the strip's ambient previews.
+            app.MapGet("/api/events/{id}/preview", (string id) =>
+            {
+                var path = events.ArtifactPath(id, "preview.mp4");
+                return path == null
+                    ? Results.Json(new { error = "no preview for this event" }, statusCode: 404)
+                    : Results.File(path, "video/mp4", enableRangeProcessing: true);
             });
 
             app.MapPost("/api/events/{id}/review", (string id, ReviewRequest req, HttpContext ctx) =>

--- a/src/Neolink.Server/config.example.json
+++ b/src/Neolink.Server/config.example.json
@@ -14,11 +14,24 @@
   // Serve the browser UI on web_port. Set false for API-only / headless setups.
   "webui": true,
 
-  // Web-UI sign-in recovery: while true, the login screen allows setting a new
-  // admin password WITHOUT the old one. Set it back to false right after use!
-  // (Web-UI accounts live in users.json next to this file; sign-in stays off
-  // until the first account — the admin — is created from the UI itself.)
-  "reset_admin_password": false,
+  // Web-UI specific settings. NOTE: UI sign-in accounts are NOT configured here —
+  // they live in users.json (created from the UI itself) and are entirely separate
+  // from the RTSP "users" list below.
+  "ui": {
+    // Where the UI's server-side state persists: users.json (accounts) and
+    // settings.json (per-user layouts, filters, recording switches).
+    // Defaults to this config file's directory — point it at a persistent volume
+    // if your config is mounted read-only or replaced on deployments, otherwise
+    // accounts and layouts are lost every deploy.
+    // "state_dir": "/config",
+
+    // Sign-in recovery: while true, the login screen allows setting a new admin
+    // password WITHOUT the old one. Set it back to false right after use!
+    "reset_admin_password": false,
+
+    // Playback speed of the ambient clip previews in the review strip.
+    "trickle_speed": 4
+  },
 
   // Optional: recording to disk — motion/AI detection events (clips + thumbnails)
   // and, when switched on per camera in the web UI, continuous 24/7 footage.

--- a/src/Neolink.WebClient/Components/Pages/Home.razor
+++ b/src/Neolink.WebClient/Components/Pages/Home.razor
@@ -125,15 +125,17 @@
                         @* Ambient "trickle" preview: the newest few cards loop their clip
                            muted, so the strip shows what happened without any clicks.
                            Capped so a big backlog doesn't decode dozens of videos. *@
-                        bool trickle = ev.HasClip && !ev.Ongoing && trickleBudget-- > 0;
+                        bool trickle = (ev.HasPreview || ev.HasClip) && !ev.Ongoing && trickleBudget-- > 0;
                         <div class="event-card @(ev.Ongoing ? "live" : "")" @key="ev.Id"
                              title="@ev.Title — click to play" @onclick="() => OpenEvent(ev)">
                             <div class="event-thumb">
                                 @if (trickle)
                                 {
+                                    @* Previews prefer the low-res sub-stream twin; the full
+                                       main-stream clip only plays in the click-through player. *@
                                     <video data-trickle="1" muted loop playsinline preload="metadata"
                                            poster="@(ev.HasThumb ? EventArtifactUrl(ev, "thumb") : null)"
-                                           src="@EventArtifactUrl(ev, "clip")"></video>
+                                           src="@EventArtifactUrl(ev, ev.HasPreview ? "preview" : "clip")"></video>
                                 }
                                 else if (ev.HasThumb)
                                 {
@@ -604,6 +606,7 @@
     private readonly List<ApiEvent> _events = new();
     private bool _eventsSupported;
     private bool _continuousSupported;
+    private double _trickleSpeed = 4;
     private bool _showEventsPanel;
     private string _eventCameraFilter = "";
     private bool _eventsUnreviewedOnly;
@@ -673,7 +676,7 @@
         // elements, which blocks autoplay — the helper mutes for real and plays.
         if (_eventsSupported && _events.Any(e => !e.Reviewed))
         {
-            await JS.InvokeVoidAsync("neolink.trickle");
+            await JS.InvokeVoidAsync("neolink.trickle", _trickleSpeed);
             _selfRef ??= DotNetObjectReference.Create(this);
             await JS.InvokeVoidAsync("neolink.stripResizeInit", "events-bar", _selfRef);
         }
@@ -1149,6 +1152,7 @@
             using var fres = await Http.SendAsync(ApiRequest(HttpMethod.Get, "/api/features"));
             var features = fres.IsSuccessStatusCode ? await fres.Content.ReadFromJsonAsync<ApiFeaturesInfo>() : null;
             _continuousSupported = features?.Continuous == true;
+            if (features != null && features.TrickleSpeed > 0) _trickleSpeed = features.TrickleSpeed;
             if (!_continuousSupported && _panelTab == "recordings") _panelTab = "events";
         }
         catch

--- a/src/Neolink.WebClient/Models.cs
+++ b/src/Neolink.WebClient/Models.cs
@@ -43,7 +43,7 @@ public sealed record ApiEncodeProfile(string Type, uint Width, uint Height,
 public sealed record ApiStreamProfiles(List<ApiEncodeProfile> Profiles);
 
 /// <summary>Server capability flags (GET /api/features).</summary>
-public sealed record ApiFeaturesInfo(bool Events, bool Continuous);
+public sealed record ApiFeaturesInfo(bool Events, bool Continuous, double TrickleSpeed = 4);
 
 /// <summary>GET /api/auth/status — whether/how the UI must authenticate.</summary>
 public sealed record ApiAuthStatus(bool Enabled, bool SetupRequired, bool ResetAvailable,
@@ -77,7 +77,8 @@ public sealed record ApiSegment(string File, long Size)
 
 /// <summary>GET /api/events — one recorded detection event.</summary>
 public sealed record ApiEvent(string Id, string Camera, DateTime Start, DateTime End,
-    List<string> Labels, bool Reviewed, bool Ongoing, bool HasClip, bool HasThumb)
+    List<string> Labels, bool Reviewed, bool Ongoing, bool HasClip, bool HasThumb,
+    bool HasPreview = false)
 {
     private static readonly (string Label, string Icon, string Name)[] Known =
     {

--- a/src/Neolink.WebClient/wwwroot/js/neolink.js
+++ b/src/Neolink.WebClient/wwwroot/js/neolink.js
@@ -300,11 +300,12 @@
     window.neolink = {
         freeInit,
 
-        // Ambient event previews (review strip): ensure real muting and start
-        // looped playback on every trickle video. Idempotent, called per render.
-        trickle() {
+        // Ambient event previews (review strip): ensure real muting, fast-forward
+        // playback rate and looped playback. Idempotent, called per render.
+        trickle(speed) {
             document.querySelectorAll('video[data-trickle]').forEach(v => {
                 v.muted = true;
+                v.defaultPlaybackRate = v.playbackRate = speed || 4;
                 if (v.paused) v.play().catch(() => { });
             });
         },


### PR DESCRIPTION
Follow-up to #8.

## `ui` config section
Groups the web-UI settings: `enabled`/`port`/`bind` (aliases of the top-level options), `reset_admin_password` (old top-level spelling still accepted), `trickle_speed`, and `state_dir`. Docs now state explicitly that **UI sign-in accounts are not in the config** — they live in `users.json`, managed from the UI, entirely separate from the RTSP `users` list.

## Fix: UI state lost on redeploys
Layouts/accounts reset on deployments because `users.json`/`settings.json` were written next to a config mounted as a single read-only file — i.e. into the container filesystem. `ui.state_dir` relocates that state to any persistent volume, with one-time migration from the old locations (config dir, recordings root) covered by self-tests. The README gains a **"persistence across deployments"** box listing exactly which paths must be volumes — including that reviewed/dismissed flags live in each event's `event.json` under `recording.path`, so a non-persistent recordings mount is what makes dismissed events reappear.

## Review-strip previews
- **4× trickle**: ambient previews now fast-forward (default 4×, `ui.trickle_speed` 0.25–16, delivered via `/api/features`).
- **Sub-stream twins**: events record a low-res `preview.mp4` from the sub stream alongside the main-stream `clip.mp4` (own pre-roll buffer, same HDD-safe writer and lifecycle). The strip's ambient players use the preview — eight trickling cards decode tiny sub-stream video instead of eight 2K+ clips — and clicking through still plays the full main-stream clip. No sub stream → automatic fallback to the clip. New `GET /api/events/{id}/preview` (range-enabled); events carry `hasPreview`.

## Reviewer notes
- 19/19 self-tests (settings migration updated for multi-legacy dirs).
- Verified live: config → `/api/features` → `playbackRate` chain with a non-default speed (6), preview endpoint serving 200 with range support, card `src` targeting `/preview` while the player keeps `/clip`.
- Real dual-capture (preview.mp4 from an actual sub stream) needs camera hardware; wiring verified structurally + with seeded artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)