### PR TITLE
Admin server settings + version banner; Docker TZ support; timeline fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,11 +32,23 @@ FROM mcr.microsoft.com/dotnet/aspnet:10.0
 WORKDIR /app
 COPY --from=build /app .
 
+# Time zone support: the base image ships no zoneinfo database, so the TZ env
+# var would otherwise be ignored and all timestamps (event folders, clip names,
+# the UI clock) would be UTC. Install tzdata so `TZ` is honoured.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
 # 8654 = RTSP, 8655 = web UI + HTTP/WebSocket API
 EXPOSE 8654 8655
 VOLUME /config
 
 # Don't advertise the default ASP.NET port; the app binds from its config file.
 ENV ASPNETCORE_URLS=""
+
+# Set the container's time zone here or, preferably, at runtime:
+#   docker run -e TZ=Europe/London ...   (or "environment: [TZ=...]" in compose)
+# Defaults to UTC when unset.
+ENV TZ=UTC
 
 ENTRYPOINT ["dotnet", "neolink.net.dll", "--config", "/config/config.json"]

--- a/README.md
+++ b/README.md
@@ -111,8 +111,10 @@ Edit it: camera names, IP addresses, and credentials (same login as the Reolink 
 ```bash
 # /config is a directory mount: config.json lives in it, and runtime settings
 # from the web UI (settings.json) are persisted next to it.
+# TZ sets the time zone for timestamps and the UI clock (defaults to UTC).
 docker run -d --name neolink --restart unless-stopped \
     -p 8654:8654 -p 8655:8655 \
+    -e TZ=Europe/London \
     -v "$PWD/config:/config" \
     ghcr.io/borexola/neolink.net:latest
 ```
@@ -137,6 +139,8 @@ services:
     image: ghcr.io/borexola/neolink.net:latest
     container_name: neolink
     restart: unless-stopped
+    environment:
+      - TZ=Europe/London   # time zone for timestamps + the UI clock (defaults to UTC)
     ports:
       - "8654:8654"   # RTSP (TCP-interleaved works for ffmpeg/Frigate/VLC)
       - "8655:8655"   # web UI + API; remove if webui:false and API unused
@@ -276,6 +280,15 @@ server-side, so people don't fight over one shared view. Forgot the admin
 password? Set `"reset_admin_password": true` in the config, restart, use
 "Reset admin password…" on the login screen, then set the flag back to
 `false`.
+
+The admin also gets ⚙ → **Server settings…**: a form that edits most of
+`config.json` (network ports, web UI, recording) and writes it back to the file
+(atomically, keeping a `.bak`; comments are not preserved, and cameras/RTSP
+users still need a text editor). Saved changes apply on the next restart, which
+the admin can trigger with **Restart service…** — the process exits and your
+container/systemd restart policy brings it back within seconds while the UI
+reconnects on its own. When a newer release exists on GitHub, a dismissable
+banner links to it.
 
 ### Recording (`"recording": { ... }`)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,10 @@ services:
     # build: .
     container_name: neolink
     restart: unless-stopped
+    environment:
+      # Time zone for timestamps (event folders, clip names, the UI clock).
+      # Use a tz database name; defaults to UTC when unset.
+      - TZ=Europe/London
     ports:
       - "8654:8654"   # RTSP (TCP-interleaved works for ffmpeg/Frigate/VLC)
       - "8655:8655"   # web UI + API; remove if webui:false and API unused

--- a/src/Neolink.Server/Config/ConfigEditor.cs
+++ b/src/Neolink.Server/Config/ConfigEditor.cs
@@ -1,0 +1,134 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Neolink.Config;
+
+/// <summary>
+/// Read-modify-write editing of config.json for the admin settings UI.
+/// The raw file is the source of truth: unknown fields survive untouched, every
+/// candidate is validated through the normal <see cref="NeolinkConfig.Load"/>
+/// before it replaces the file (atomically, keeping a .bak of the previous
+/// version). Comments do NOT survive a rewrite — the UI says so.
+/// Cameras and RTSP users are deliberately not editable here; they are lists
+/// with credentials and deserve a text editor.
+/// </summary>
+public static class ConfigEditor
+{
+    private static readonly JsonSerializerOptions WriteOpts = new() { WriteIndented = true };
+    private static readonly object Gate = new();
+
+    public static bool IsWritable(string path)
+    {
+        try
+        {
+            using var _ = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>The editable settings, read fresh from the file.</summary>
+    public static object Describe(string path)
+    {
+        var cfg = NeolinkConfig.Load(path);
+        return new
+        {
+            path = Path.GetFullPath(path),
+            writable = IsWritable(path),
+            settings = new
+            {
+                bind = cfg.BindAddr,
+                bindPort = cfg.BindPort,
+                webPort = cfg.WebPort,
+                webBind = cfg.WebBind,
+                webUi = cfg.WebUi,
+                ui = new
+                {
+                    trickleSpeed = cfg.Ui.TrickleSpeed,
+                    stateDir = cfg.Ui.StateDir,
+                    resetAdminPassword = cfg.EffectiveResetAdminPassword,
+                },
+                recording = cfg.Recording == null ? null : new
+                {
+                    path = cfg.Recording.Path,
+                    retentionDays = cfg.Recording.RetentionDays,
+                    preSeconds = cfg.Recording.PreSeconds,
+                    postSeconds = cfg.Recording.PostSeconds,
+                    maxClipSeconds = cfg.Recording.MaxClipSeconds,
+                    stream = cfg.Recording.Stream,
+                    segmentMinutes = cfg.Recording.SegmentMinutes,
+                    continuousRetentionDays = cfg.Recording.ContinuousRetentionDays,
+                },
+            },
+        };
+    }
+
+    /// <summary>
+    /// Applies a mutation to the raw config document, validates the result and
+    /// atomically replaces the file. Throws <see cref="FormatException"/> when the
+    /// candidate does not validate, IO exceptions when the file cannot be written.
+    /// </summary>
+    public static void Apply(string path, Action<JsonObject> mutate)
+    {
+        lock (Gate)
+        {
+            var text = File.ReadAllText(path);
+            var root = JsonNode.Parse(text, documentOptions: new JsonDocumentOptions
+            {
+                CommentHandling = JsonCommentHandling.Skip,
+                AllowTrailingCommas = true,
+            }) as JsonObject ?? throw new FormatException("config root must be a JSON object");
+
+            mutate(root);
+
+            // Validate the candidate exactly the way startup would.
+            var candidate = root.ToJsonString(WriteOpts);
+            var tmp = path + ".tmp";
+            File.WriteAllText(tmp, candidate);
+            try
+            {
+                NeolinkConfig.Load(tmp); // throws FormatException on anything invalid
+            }
+            catch
+            {
+                File.Delete(tmp);
+                throw;
+            }
+
+            try { File.Copy(path, path + ".bak", overwrite: true); }
+            catch (IOException) { /* backup is best-effort */ }
+            File.Move(tmp, path, overwrite: true);
+        }
+    }
+
+    /// <summary>Sets or removes a key on an object node (null removes).</summary>
+    public static void Set(JsonObject obj, string key, JsonNode? value)
+    {
+        // The loader accepts any casing/underscore variant; normalize to the
+        // canonical snake_case spelling and drop other spellings of the same key.
+        string Normalized(string k) => k.Replace("_", "").Replace("-", "").ToLowerInvariant();
+        var target = Normalized(key);
+        foreach (var existing in obj.Where(kv => Normalized(kv.Key) == target).Select(kv => kv.Key).ToList())
+            obj.Remove(existing);
+        if (value != null)
+            obj[key] = value;
+    }
+
+    /// <summary>The (possibly differently-spelled) child object for a section, created on demand.</summary>
+    public static JsonObject Section(JsonObject root, string key)
+    {
+        string Normalized(string k) => k.Replace("_", "").Replace("-", "").ToLowerInvariant();
+        var target = Normalized(key);
+        foreach (var kv in root)
+        {
+            if (Normalized(kv.Key) == target && kv.Value is JsonObject existing)
+                return existing;
+        }
+        var section = new JsonObject();
+        root[key] = section;
+        return section;
+    }
+}

--- a/src/Neolink.Server/Program.cs
+++ b/src/Neolink.Server/Program.cs
@@ -72,6 +72,10 @@ catch (Exception ex)
 }
 
 Log.Info($"Neolink.NET {Version} starting");
+var tzOffset = DateTimeOffset.Now.Offset;
+Log.Info($"Local time: {DateTime.Now:yyyy-MM-dd HH:mm:ss} " +
+         $"({TimeZoneInfo.Local.Id}, UTC{(tzOffset < TimeSpan.Zero ? "-" : "+")}{tzOffset:hh\\:mm}) — " +
+         "set the TZ env var to change it");
 
 // Server-side UI state (accounts, runtime settings) lives in state_dir — the
 // config directory unless relocated (e.g. because the config mount is read-only).
@@ -222,13 +226,39 @@ if (config.WebPort > 0)
         Log.Warn("reset_admin_password is TRUE: anyone reaching the login page can set a new admin " +
                  "password. Set it back to false as soon as the reset is done!");
 
+    // Daily best-effort check for newer releases (feeds the UI's update banner).
+    var updates = new UpdateChecker(Version);
+    tasks.Add(Task.Run(() => updates.RunAsync(shutdown.Token)));
+
+    var webOptions = new WebApiOptions
+    {
+        BindAddr = config.WebBind ?? config.BindAddr,
+        Port = config.WebPort,
+        WebUi = config.WebUi,
+        Cameras = webCameras,
+        Users = users,
+        RtspPort = config.BindPort,
+        Events = eventStore,
+        RecordingSettings = recordingSettings,
+        UserStore = userStore,
+        ResetAdminPassword = config.EffectiveResetAdminPassword,
+        TrickleSpeed = config.Ui.TrickleSpeed,
+        Version = Version,
+        ConfigPath = Path.GetFullPath(configPath),
+        Updates = updates,
+        // Graceful shutdown; docker's restart policy (or systemd) starts us again.
+        RestartRequested = () =>
+        {
+            Log.Warn("Shutting down for a UI-requested restart");
+            shutdown.Cancel();
+        },
+    };
+
     tasks.Add(Task.Run(async () =>
     {
         try
         {
-            await WebApi.RunAsync(config.WebBind ?? config.BindAddr, config.WebPort, config.WebUi,
-                webCameras, users, config.BindPort, eventStore, recordingSettings,
-                userStore, config.EffectiveResetAdminPassword, config.Ui.TrickleSpeed, shutdown.Token);
+            await WebApi.RunAsync(webOptions, shutdown.Token);
         }
         catch (OperationCanceledException) { }
         catch (Exception ex)

--- a/src/Neolink.Server/SelfTest.cs
+++ b/src/Neolink.Server/SelfTest.cs
@@ -372,6 +372,50 @@ public static class SelfTest
             }
         });
 
+        Test("config editor: read-modify-write with validation", () =>
+        {
+            var dir = Path.Combine(Path.GetTempPath(), $"neolink-selftest-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, "config.json");
+            try
+            {
+                File.WriteAllText(path, """
+                    { "bind": "0.0.0.0", "web_port": 8655,
+                      "cameras": [ { "name": "cam", "username": "u", "address": "1.2.3.4" } ] }
+                    """);
+
+                // A valid edit persists and round-trips through the loader.
+                Config.ConfigEditor.Apply(path, root =>
+                {
+                    Config.ConfigEditor.Set(root, "web_port", 9001);
+                    var ui = Config.ConfigEditor.Section(root, "ui");
+                    Config.ConfigEditor.Set(ui, "trickle_speed", 8);
+                });
+                var reloaded = Config.NeolinkConfig.Load(path);
+                AssertEq(reloaded.WebPort, 9001);
+                Assert(Math.Abs(reloaded.Ui.TrickleSpeed - 8) < 0.001, "ui.trickle_speed written");
+                Assert(File.Exists(path + ".bak"), "previous config backed up");
+
+                // Camera list (and any unknown fields) survive an unrelated edit.
+                AssertEq(reloaded.Cameras.Count, 1);
+                AssertEq(reloaded.Cameras[0].Name, "cam");
+
+                // An invalid edit is rejected and the file is left untouched.
+                bool threw = false;
+                try
+                {
+                    Config.ConfigEditor.Apply(path, root => Config.ConfigEditor.Set(root, "web_port", 999999));
+                }
+                catch (FormatException) { threw = true; }
+                Assert(threw, "invalid port rejected");
+                AssertEq(Config.NeolinkConfig.Load(path).WebPort, 9001); // unchanged
+            }
+            finally
+            {
+                try { Directory.Delete(dir, recursive: true); } catch { }
+            }
+        });
+
         Test("clip writer produces a playable fmp4 structure", () =>
         {
             var dir = Path.Combine(Path.GetTempPath(), $"neolink-selftest-{Guid.NewGuid():N}");

--- a/src/Neolink.Server/Web/UpdateChecker.cs
+++ b/src/Neolink.Server/Web/UpdateChecker.cs
@@ -1,0 +1,82 @@
+using System.Text.Json;
+
+namespace Neolink.Web;
+
+/// <summary>
+/// Once a day, asks GitHub whether a newer release of Neolink.NET exists.
+/// Best-effort by design: offline/LAN-only boxes just never see the banner.
+/// Only the latest version STRING is exposed — the UI links to the repo, no
+/// code or artifacts are ever fetched.
+/// </summary>
+public sealed class UpdateChecker
+{
+    public const string RepoUrl = "https://github.com/borexola/neolink.net";
+    private const string ApiLatest = "https://api.github.com/repos/borexola/neolink.net/releases/latest";
+    private const string ApiTags = "https://api.github.com/repos/borexola/neolink.net/tags";
+    private static readonly TimeSpan Interval = TimeSpan.FromHours(24);
+
+    private readonly System.Version _current;
+    private volatile string? _latest;
+
+    public UpdateChecker(string currentVersion)
+    {
+        System.Version.TryParse(currentVersion, out var v);
+        _current = v ?? new System.Version(0, 0);
+    }
+
+    /// <summary>The newest available version, only when strictly newer than the running one.</summary>
+    public string? Latest => _latest;
+
+    public async Task RunAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                await CheckAsync(ct).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Log.Debug($"Update check failed: {Log.Flatten(ex)}");
+            }
+            try { await Task.Delay(Interval, ct).ConfigureAwait(false); }
+            catch (OperationCanceledException) { return; }
+        }
+    }
+
+    private async Task CheckAsync(CancellationToken ct)
+    {
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
+        http.DefaultRequestHeaders.UserAgent.ParseAdd($"neolink.net/{_current}"); // GitHub requires a UA
+
+        var tag = await FetchTagAsync(http, ct).ConfigureAwait(false);
+        if (tag == null) return;
+
+        if (System.Version.TryParse(tag.TrimStart('v', 'V'), out var latest) && latest > _current)
+        {
+            if (_latest != tag)
+                Log.Info($"Update available: {tag} (running {_current}) — {RepoUrl}");
+            _latest = tag;
+        }
+    }
+
+    private static async Task<string?> FetchTagAsync(HttpClient http, CancellationToken ct)
+    {
+        using var res = await http.GetAsync(ApiLatest, ct).ConfigureAwait(false);
+        if (res.IsSuccessStatusCode)
+        {
+            using var doc = JsonDocument.Parse(await res.Content.ReadAsStringAsync(ct).ConfigureAwait(false));
+            return doc.RootElement.TryGetProperty("tag_name", out var t) ? t.GetString() : null;
+        }
+        if (res.StatusCode != System.Net.HttpStatusCode.NotFound)
+            return null;
+
+        // No formal releases yet: fall back to the newest tag.
+        using var tagsRes = await http.GetAsync(ApiTags, ct).ConfigureAwait(false);
+        if (!tagsRes.IsSuccessStatusCode) return null;
+        using var tags = JsonDocument.Parse(await tagsRes.Content.ReadAsStringAsync(ct).ConfigureAwait(false));
+        return tags.RootElement.ValueKind == JsonValueKind.Array && tags.RootElement.GetArrayLength() > 0
+            ? tags.RootElement[0].GetProperty("name").GetString()
+            : null;
+    }
+}

--- a/src/Neolink.Server/Web/WebApi.cs
+++ b/src/Neolink.Server/Web/WebApi.cs
@@ -20,6 +20,27 @@ public sealed record WebStreamInfo(string Kind, string Path, IStreamHub Hub);
 public sealed record WebCameraInfo(string Name, List<WebStreamInfo> Streams, ICameraControl Control,
     HashSet<string>? PermittedUsers);
 
+/// <summary>Everything the web API needs from the host.</summary>
+public sealed class WebApiOptions
+{
+    public required string BindAddr { get; init; }
+    public required int Port { get; init; }
+    public required bool WebUi { get; init; }
+    public required IReadOnlyList<WebCameraInfo> Cameras { get; init; }
+    public required IReadOnlyDictionary<string, string> Users { get; init; }
+    public required int RtspPort { get; init; }
+    public EventStore? Events { get; init; }
+    public RecordingSettings? RecordingSettings { get; init; }
+    public required UserStore UserStore { get; init; }
+    public bool ResetAdminPassword { get; init; }
+    public double TrickleSpeed { get; init; } = 4;
+    public required string Version { get; init; }
+    public required string ConfigPath { get; init; }
+    public UpdateChecker? Updates { get; init; }
+    /// <summary>Gracefully stops the process; the supervisor (docker/systemd) restarts it.</summary>
+    public required Action RestartRequested { get; init; }
+}
+
 /// <summary>
 /// HTTP/WebSocket API for web clients, optionally serving the Blazor web UI:
 ///   GET /api/cameras                        — JSON list of cameras and their streams
@@ -51,12 +72,26 @@ public static class WebApi
     private sealed record RecordingSettingsRequest(bool? Events, bool? Continuous, List<string>? EventTypes);
     private sealed record CredentialsRequest(string? Username, string? Password);
     private sealed record PasswordRequest(string? Password);
+    private sealed record AdminUiSettings(double? TrickleSpeed, string? StateDir, bool? ResetAdminPassword);
+    private sealed record AdminRecordingSettings(string? Path, int? RetentionDays, int? PreSeconds,
+        int? PostSeconds, int? MaxClipSeconds, string? Stream, int? SegmentMinutes, int? ContinuousRetentionDays);
+    private sealed record AdminConfigRequest(string? Bind, int? BindPort, int? WebPort, string? WebBind,
+        bool? WebUi, AdminUiSettings? Ui, AdminRecordingSettings? Recording, bool? RemoveRecording);
 
-    public static async Task RunAsync(string bindAddr, int port, bool webUi,
-        IReadOnlyList<WebCameraInfo> cameras, IReadOnlyDictionary<string, string> users,
-        int rtspPort, EventStore? events, RecordingSettings? recordingSettings,
-        UserStore userStore, bool resetAdminPassword, double trickleSpeed, CancellationToken ct)
+    public static async Task RunAsync(WebApiOptions o, CancellationToken ct)
     {
+        var bindAddr = o.BindAddr;
+        var port = o.Port;
+        var webUi = o.WebUi;
+        var cameras = o.Cameras;
+        var users = o.Users;
+        var rtspPort = o.RtspPort;
+        var events = o.Events;
+        var recordingSettings = o.RecordingSettings;
+        var userStore = o.UserStore;
+        var resetAdminPassword = o.ResetAdminPassword;
+        var trickleSpeed = o.TrickleSpeed;
+
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
         {
             ContentRootPath = AppContext.BaseDirectory,
@@ -243,6 +278,102 @@ public static class WebApi
                 : Results.Json(new { error = "unknown user (the admin cannot be deleted)" }, statusCode: 400);
         });
 
+        // ------------------------------------------------------------ admin: server settings + restart
+
+        IResult? AdminOnly(HttpContext ctx) => IsAdmin(ctx)
+            ? null
+            : Results.Json(new
+            {
+                error = userStore.Enabled ? "admin only" : "create the admin account first (server settings need one)",
+            }, statusCode: 403);
+
+        app.MapGet("/api/admin/config", (HttpContext ctx) =>
+        {
+            if (AdminOnly(ctx) is { } denied) return denied;
+            try
+            {
+                return Results.Json(ConfigEditor.Describe(o.ConfigPath));
+            }
+            catch (Exception ex)
+            {
+                return Results.Json(new { error = ex.Message }, statusCode: 500);
+            }
+        });
+
+        app.MapPut("/api/admin/config", (AdminConfigRequest req, HttpContext ctx) =>
+        {
+            if (AdminOnly(ctx) is { } denied) return denied;
+            try
+            {
+                ConfigEditor.Apply(o.ConfigPath, root =>
+                {
+                    if (req.Bind != null) ConfigEditor.Set(root, "bind", req.Bind);
+                    if (req.BindPort != null) ConfigEditor.Set(root, "bind_port", req.BindPort);
+                    if (req.WebPort != null) ConfigEditor.Set(root, "web_port", req.WebPort);
+                    if (req.WebBind != null)
+                        ConfigEditor.Set(root, "web_bind", req.WebBind.Length == 0 ? null : req.WebBind);
+                    if (req.WebUi != null) ConfigEditor.Set(root, "webui", req.WebUi);
+
+                    if (req.Ui is { } u)
+                    {
+                        var ui = ConfigEditor.Section(root, "ui");
+                        if (u.TrickleSpeed != null) ConfigEditor.Set(ui, "trickle_speed", u.TrickleSpeed);
+                        if (u.StateDir != null)
+                            ConfigEditor.Set(ui, "state_dir", u.StateDir.Length == 0 ? null : u.StateDir);
+                        if (u.ResetAdminPassword != null)
+                        {
+                            ConfigEditor.Set(ui, "reset_admin_password", u.ResetAdminPassword);
+                            ConfigEditor.Set(root, "reset_admin_password", null); // retire the legacy spelling
+                        }
+                    }
+
+                    if (req.RemoveRecording == true)
+                    {
+                        ConfigEditor.Set(root, "recording", null);
+                    }
+                    else if (req.Recording is { } r)
+                    {
+                        var rec = ConfigEditor.Section(root, "recording");
+                        if (r.Path != null) ConfigEditor.Set(rec, "path", r.Path);
+                        if (r.RetentionDays != null) ConfigEditor.Set(rec, "retention_days", r.RetentionDays);
+                        if (r.PreSeconds != null) ConfigEditor.Set(rec, "pre_seconds", r.PreSeconds);
+                        if (r.PostSeconds != null) ConfigEditor.Set(rec, "post_seconds", r.PostSeconds);
+                        if (r.MaxClipSeconds != null) ConfigEditor.Set(rec, "max_clip_seconds", r.MaxClipSeconds);
+                        if (r.Stream != null) ConfigEditor.Set(rec, "stream", r.Stream);
+                        if (r.SegmentMinutes != null) ConfigEditor.Set(rec, "segment_minutes", r.SegmentMinutes);
+                        if (r.ContinuousRetentionDays != null)
+                            ConfigEditor.Set(rec, "continuous_retention_days", r.ContinuousRetentionDays);
+                    }
+                });
+                Log.Warn($"config.json updated via the web UI by '{SessionName(ctx)}' — restart to apply");
+                return Results.Json(new { ok = true, requiresRestart = true });
+            }
+            catch (FormatException ex)
+            {
+                return Results.Json(new { error = ex.Message }, statusCode: 400);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                return Results.Json(new { error = $"config.json is not writable: {ex.Message}" }, statusCode: 409);
+            }
+        });
+
+        app.MapPost("/api/admin/restart", (HttpContext ctx) =>
+        {
+            if (AdminOnly(ctx) is { } denied) return denied;
+            Log.Warn($"Restart requested via the web UI by '{SessionName(ctx)}'");
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(700); // let this response reach the browser first
+                o.RestartRequested();
+            });
+            return Results.Json(new
+            {
+                ok = true,
+                note = "shutting down — the restart policy (docker / systemd) brings the service back",
+            });
+        });
+
         // Per-user UI settings: an opaque JSON blob the client owns.
         app.MapGet("/api/me/settings", (HttpContext ctx) =>
             SessionName(ctx) is { } me
@@ -272,6 +403,9 @@ public static class WebApi
             events = events != null,
             continuous = events != null && RecordingConfig.ContinuousEnabled,
             trickleSpeed,
+            version = o.Version,
+            latestVersion = o.Updates?.Latest,
+            repoUrl = UpdateChecker.RepoUrl,
         }));
 
         app.MapGet("/api/cameras", () =>

--- a/src/Neolink.WebClient/Components/Pages/Home.razor
+++ b/src/Neolink.WebClient/Components/Pages/Home.razor
@@ -28,6 +28,17 @@
             </div>
         }
 
+        @if (UpdateAvailable)
+        {
+            <div class="update-banner">
+                <span class="update-banner-text">🎉 Neolink.NET @_latestVersion is available (you have @_version).</span>
+                <div class="sec-banner-actions">
+                    <a class="chip" href="@_repoUrl" target="_blank" rel="noopener">View release</a>
+                    <button class="icon-btn" title="Dismiss" @onclick="DismissUpdateAsync">✕</button>
+                </div>
+            </div>
+        }
+
         @if (_showSettings)
         {
             <div class="settings">
@@ -45,6 +56,7 @@
                         @if (_authAdmin)
                         {
                             <button class="chip" @onclick="OpenUsersAsync">Users…</button>
+                            <button class="chip" @onclick="OpenServerSettingsAsync">Server settings…</button>
                         }
                         <button class="chip chip-off" @onclick="LogoutAsync">Sign out</button>
                     </div>
@@ -403,6 +415,92 @@
         </aside>
     }
 
+    @if (_showServerSettings)
+    {
+        <div class="backdrop panel-backdrop" @onclick="() => _showServerSettings = false"></div>
+        <aside class="campanel auth-panel" role="dialog" aria-label="Server settings">
+            <div class="campanel-head">
+                <span class="campanel-title">🛠 SERVER SETTINGS</span>
+                <span class="tile-spacer"></span>
+                <button class="icon-btn" title="Close" @onclick="() => _showServerSettings = false">✕</button>
+            </div>
+
+            @if (_adminError != null)
+            {
+                <div class="notice error">@_adminError</div>
+            }
+            else if (_adminConfig == null)
+            {
+                <div class="notice">Loading…</div>
+            }
+            else
+            {
+                <div class="notice small">
+                    Editing <code>@_adminConfigPath</code>.
+                    @if (!_adminWritable)
+                    {
+                        <b> Read-only — the file cannot be written (check the mount).</b>
+                    }
+                    Changes are saved to the file and take effect after a restart. Comments in the file are not preserved.
+                </div>
+
+                <div class="campanel-section">
+                    <div class="campanel-section-title">NETWORK</div>
+                    @AdminField("Bind address", "bind", "text")
+                    @AdminField("RTSP port", "bindPort", "number")
+                    @AdminField("Web port", "webPort", "number")
+                    @AdminField("Web bind (blank = same as bind)", "webBind", "text")
+                    @AdminToggle("Serve the web UI", "webUi")
+                </div>
+
+                <div class="campanel-section">
+                    <div class="campanel-section-title">WEB UI</div>
+                    @AdminField("Preview playback speed (×)", "ui.trickleSpeed", "number")
+                    @AdminField("State directory (accounts/settings)", "ui.stateDir", "text")
+                    @AdminToggle("Allow admin-password reset on login", "ui.resetAdminPassword")
+                </div>
+
+                @if (_adminHasRecording)
+                {
+                    <div class="campanel-section">
+                        <div class="campanel-section-title">RECORDING</div>
+                        @AdminField("Storage path", "recording.path", "text")
+                        @AdminField("Event retention (days, 0 = forever)", "recording.retentionDays", "number")
+                        @AdminField("Pre-roll (seconds)", "recording.preSeconds", "number")
+                        @AdminField("Post-roll (seconds)", "recording.postSeconds", "number")
+                        @AdminField("Max clip length (seconds)", "recording.maxClipSeconds", "number")
+                        @AdminField("Record stream (auto|mainStream|subStream)", "recording.stream", "text")
+                        @AdminField("Segment length (minutes)", "recording.segmentMinutes", "number")
+                        @AdminField("Continuous retention (days, blank = event value)", "recording.continuousRetentionDays", "number")
+                    </div>
+                }
+
+                @if (_adminStatus != null)
+                {
+                    <div class="notice">@_adminStatus</div>
+                }
+
+                <div class="event-player-foot">
+                    <button class="chip" disabled="@(!_adminWritable)" @onclick="SaveServerSettingsAsync">Save to config.json</button>
+                    <span class="tile-spacer"></span>
+                    @if (!_confirmRestart)
+                    {
+                        <button class="chip chip-danger" @onclick="() => _confirmRestart = true">Restart service…</button>
+                    }
+                    else
+                    {
+                        <button class="chip chip-danger" @onclick="RestartServiceAsync">Confirm restart</button>
+                        <button class="chip" @onclick="() => _confirmRestart = false">Cancel</button>
+                    }
+                </div>
+                <div class="notice small">
+                    Restart stops the service; your container/systemd restart policy brings it back within seconds
+                    (needed to apply saved changes). The UI reconnects automatically.
+                </div>
+            }
+        </aside>
+    }
+
     @if (_showEventsPanel)
     {
         <div class="backdrop panel-backdrop" @onclick="() => _showEventsPanel = false"></div>
@@ -546,8 +644,16 @@
             @if (_playEvent.HasClip)
             {
                 @* @key forces a fresh <video> when navigating between events *@
-                <video controls autoplay playsinline @key="_playEvent.Id"
+                <video id="event-player-video" controls autoplay playsinline @key="_playEvent.Id"
                        src="@EventArtifactUrl(_playEvent, "clip")"></video>
+                <div class="player-speed">
+                    <span class="tool-label">SPEED</span>
+                    @foreach (var s in PlaybackSpeeds)
+                    {
+                        <button class="chip @(_playSpeed == s ? "chip-active" : "")"
+                                @onclick="() => SetPlaySpeedAsync(s)">@FormatSpeed(s)</button>
+                    }
+                </div>
             }
             else
             {
@@ -607,6 +713,19 @@
     private bool _eventsSupported;
     private bool _continuousSupported;
     private double _trickleSpeed = 4;
+
+    // Update banner + admin server settings
+    private string? _version;
+    private string? _latestVersion;
+    private string _repoUrl = "https://github.com/borexola/neolink.net";
+    private bool _showServerSettings;
+    private JsonElement? _adminConfig;
+    private bool _adminWritable;
+    private string _adminConfigPath = "";
+    private string? _adminError;
+    private string? _adminStatus;
+    private bool _confirmRestart;
+    private readonly Dictionary<string, string> _adminEdits = new();
     private bool _showEventsPanel;
     private string _eventCameraFilter = "";
     private bool _eventsUnreviewedOnly;
@@ -680,6 +799,9 @@
             _selfRef ??= DotNetObjectReference.Create(this);
             await JS.InvokeVoidAsync("neolink.stripResizeInit", "events-bar", _selfRef);
         }
+        // Keep a chosen playback rate across the <video>'s reloads/renders.
+        if (_playEvent is { HasClip: true } && _playSpeed != 1)
+            await JS.InvokeVoidAsync("neolink.setRate", "event-player-video", _playSpeed);
     }
 
     /// <summary>Called from JS when the strip's resize-handle drag ends.</summary>
@@ -746,9 +868,13 @@
             }
             _setupDismissed = await JS.InvokeAsync<string?>("neolink.lsGet", "neolink.setupDismissed") == "1";
             _secWarnDismissed = await JS.InvokeAsync<string?>("neolink.lsGet", "neolink.secWarnDismissed") == "1";
+            _updateDismissedVersion = await JS.InvokeAsync<string?>("neolink.lsGet", "neolink.updateDismissed");
         }
         catch { }
     }
+
+    /// <summary>Which version's update banner the user dismissed (a newer one re-shows it).</summary>
+    private string? _updateDismissedVersion;
 
     private async Task DismissSecWarnAsync()
     {
@@ -1026,6 +1152,182 @@
         await LoadUsersAsync();
     }
 
+    // ------------------------------------------------------------ admin: server settings
+
+    private bool UpdateAvailable =>
+        !string.IsNullOrEmpty(_latestVersion) && _latestVersion != _version
+        && _latestVersion != _updateDismissedVersion;
+
+    private bool _adminHasRecording;
+
+    private async Task DismissUpdateAsync()
+    {
+        _updateDismissedVersion = _latestVersion;
+        // Keyed by version so a newer release surfaces the banner again.
+        await JS.InvokeVoidAsync("neolink.lsSet", "neolink.updateDismissed", _latestVersion ?? "");
+    }
+
+    private async Task OpenServerSettingsAsync()
+    {
+        _showServerSettings = true;
+        _adminError = _adminStatus = null;
+        _adminConfig = null;
+        _confirmRestart = false;
+        _adminEdits.Clear();
+        try
+        {
+            using var res = await Http.SendAsync(ApiRequest(HttpMethod.Get, "/api/admin/config"));
+            if (!res.IsSuccessStatusCode)
+            {
+                _adminError = await ApiErrorAsync(res) ?? $"Cannot load settings ({(int)res.StatusCode})";
+                return;
+            }
+            var cfg = await res.Content.ReadFromJsonAsync<ApiAdminConfig>();
+            if (cfg == null) { _adminError = "Empty settings response"; return; }
+            _adminConfig = cfg.Settings;
+            _adminWritable = cfg.Writable;
+            _adminConfigPath = cfg.Path;
+            _adminHasRecording = cfg.Settings.TryGetProperty("recording", out var r)
+                && r.ValueKind == JsonValueKind.Object;
+        }
+        catch (Exception ex)
+        {
+            _adminError = ex.Message;
+        }
+    }
+
+    /// <summary>Current value of a dotted config path ("ui.trickleSpeed"), edit buffer first.</summary>
+    private string AdminValue(string path)
+    {
+        if (_adminEdits.TryGetValue(path, out var edited)) return edited;
+        if (_adminConfig is not { } cfg) return "";
+        JsonElement cur = cfg;
+        foreach (var part in path.Split('.'))
+        {
+            if (cur.ValueKind != JsonValueKind.Object || !cur.TryGetProperty(part, out var next))
+                return "";
+            cur = next;
+        }
+        return cur.ValueKind switch
+        {
+            JsonValueKind.String => cur.GetString() ?? "",
+            JsonValueKind.Number => cur.GetRawText(),
+            JsonValueKind.True => "true",
+            JsonValueKind.False => "false",
+            _ => "",
+        };
+    }
+
+    private bool AdminBool(string path) =>
+        _adminEdits.TryGetValue(path, out var e) ? e == "true" : AdminValue(path) == "true";
+
+    private RenderFragment AdminField(string label, string path, string type) => builder =>
+    {
+        builder.OpenElement(0, "label");
+        builder.AddAttribute(1, "class", "admin-field");
+        builder.OpenElement(2, "span");
+        builder.AddContent(3, label);
+        builder.CloseElement();
+        builder.OpenElement(4, "input");
+        builder.AddAttribute(5, "type", type);
+        builder.AddAttribute(6, "value", AdminValue(path));
+        builder.AddAttribute(7, "onchange",
+            EventCallback.Factory.Create<ChangeEventArgs>(this, e => _adminEdits[path] = e.Value?.ToString() ?? ""));
+        builder.CloseElement();
+        builder.CloseElement();
+    };
+
+    private RenderFragment AdminToggle(string label, string path) => builder =>
+    {
+        builder.OpenElement(0, "div");
+        builder.AddAttribute(1, "class", "control-row");
+        builder.OpenElement(2, "span");
+        builder.AddContent(3, label);
+        builder.CloseElement();
+        bool on = AdminBool(path);
+        builder.OpenElement(4, "button");
+        builder.AddAttribute(5, "class", $"chip {(on ? "" : "chip-off")}");
+        builder.AddAttribute(6, "onclick",
+            EventCallback.Factory.Create(this, () => _adminEdits[path] = (!on).ToString().ToLowerInvariant()));
+        builder.AddContent(7, on ? "on" : "off");
+        builder.CloseElement();
+        builder.CloseElement();
+    };
+
+    private async Task SaveServerSettingsAsync()
+    {
+        _adminError = _adminStatus = null;
+        var payload = new Dictionary<string, object?>();
+        var ui = new Dictionary<string, object?>();
+        var rec = new Dictionary<string, object?>();
+
+        object? Num(string p) => double.TryParse(AdminValue(p), out var d) ? d : null;
+        int? Int(string p) => int.TryParse(AdminValue(p), out var i) ? i : (int?)null;
+
+        foreach (var (path, _) in _adminEdits)
+        {
+            switch (path)
+            {
+                case "bind": payload["bind"] = AdminValue(path); break;
+                case "bindPort": payload["bindPort"] = Int(path); break;
+                case "webPort": payload["webPort"] = Int(path); break;
+                case "webBind": payload["webBind"] = AdminValue(path); break;
+                case "webUi": payload["webUi"] = AdminBool(path); break;
+                case "ui.trickleSpeed": ui["trickleSpeed"] = Num(path); break;
+                case "ui.stateDir": ui["stateDir"] = AdminValue(path); break;
+                case "ui.resetAdminPassword": ui["resetAdminPassword"] = AdminBool(path); break;
+                case "recording.path": rec["path"] = AdminValue(path); break;
+                case "recording.retentionDays": rec["retentionDays"] = Int(path); break;
+                case "recording.preSeconds": rec["preSeconds"] = Int(path); break;
+                case "recording.postSeconds": rec["postSeconds"] = Int(path); break;
+                case "recording.maxClipSeconds": rec["maxClipSeconds"] = Int(path); break;
+                case "recording.stream": rec["stream"] = AdminValue(path); break;
+                case "recording.segmentMinutes": rec["segmentMinutes"] = Int(path); break;
+                case "recording.continuousRetentionDays": rec["continuousRetentionDays"] = Int(path); break;
+            }
+        }
+        if (ui.Count > 0) payload["ui"] = ui;
+        if (rec.Count > 0) payload["recording"] = rec;
+        if (payload.Count == 0) { _adminStatus = "No changes to save."; return; }
+
+        try
+        {
+            var req = ApiRequest(HttpMethod.Put, "/api/admin/config");
+            req.Content = JsonContent.Create(payload);
+            using var res = await Http.SendAsync(req);
+            if (!res.IsSuccessStatusCode)
+            {
+                _adminError = await ApiErrorAsync(res) ?? $"Save failed ({(int)res.StatusCode})";
+                return;
+            }
+            _adminEdits.Clear();
+            await OpenServerSettingsAsync(); // reload the saved state
+            _adminStatus = "Saved. Restart the service to apply the changes.";
+        }
+        catch (Exception ex)
+        {
+            _adminError = ex.Message;
+        }
+    }
+
+    private async Task RestartServiceAsync()
+    {
+        _confirmRestart = false;
+        _adminStatus = null;
+        try
+        {
+            using var res = await Http.SendAsync(ApiRequest(HttpMethod.Post, "/api/admin/restart"));
+            _adminStatus = res.IsSuccessStatusCode
+                ? "Restarting… the service will be back in a few seconds; this page reconnects on its own."
+                : await ApiErrorAsync(res) ?? "Restart request failed.";
+        }
+        catch (Exception ex)
+        {
+            // Expected: the server may drop the connection as it shuts down.
+            _adminStatus = $"Restart requested ({ex.Message}). The service will be back shortly.";
+        }
+    }
+
     // ------------------------------------------------------------ review-strip filters
 
     /// <summary>The strip after the user's real-time filters (type + camera).</summary>
@@ -1153,6 +1455,12 @@
             var features = fres.IsSuccessStatusCode ? await fres.Content.ReadFromJsonAsync<ApiFeaturesInfo>() : null;
             _continuousSupported = features?.Continuous == true;
             if (features != null && features.TrickleSpeed > 0) _trickleSpeed = features.TrickleSpeed;
+            if (features != null)
+            {
+                _version = features.Version;
+                _latestVersion = features.LatestVersion;
+                if (!string.IsNullOrEmpty(features.RepoUrl)) _repoUrl = features.RepoUrl;
+            }
             if (!_continuousSupported && _panelTab == "recordings") _panelTab = "events";
         }
         catch
@@ -1187,7 +1495,18 @@
         }
     }
 
-    private void OpenEvent(ApiEvent ev) => _playEvent = ev;
+    private static readonly double[] PlaybackSpeeds = { 1, 2, 4, 8 };
+    private double _playSpeed = 1;
+
+    private static string FormatSpeed(double s) => s == 1 ? "1×" : $"{s:0}×";
+
+    private async Task SetPlaySpeedAsync(double s)
+    {
+        _playSpeed = s;
+        await JS.InvokeVoidAsync("neolink.setRate", "event-player-video", s);
+    }
+
+    private void OpenEvent(ApiEvent ev) { _playEvent = ev; _playSpeed = 1; }
 
     /// <summary>Closing the player counts as reviewing: the event leaves the top strip.</summary>
     private async Task ClosePlayerAsync()

--- a/src/Neolink.WebClient/Components/Pages/Timeline.razor
+++ b/src/Neolink.WebClient/Components/Pages/Timeline.razor
@@ -33,15 +33,7 @@
     {
         <div class="notice">
             Recording is not enabled on this server — add a "recording" section to the config
-            and switch cameras to Continuous (24/7) to use the timeline.
-        </div>
-    }
-    else if (!_continuous)
-    {
-        <div class="notice">
-            Continuous (24/7) recording is temporarily disabled in this build — the timeline
-            scrubs that footage and will return together with it. Detection events still record
-            and play from the 🕘 Events panel on the live view.
+            to use the timeline.
         </div>
     }
     else
@@ -55,7 +47,11 @@
                         title="@(_included.Contains(name) ? "Loaded — click to remove" : "Click to load this camera's footage")"
                         @onclick="() => ToggleCameraAsync(name)">@name</button>
             }
-            <span class="event-sub">— pick the cameras to scrub; nothing loads until selected</span>
+            <span class="event-sub">
+                @(_continuous
+                    ? "— pick the cameras to scrub; colored marks are events"
+                    : "— continuous recording is off, so only detection events (colored marks) play here")
+            </span>
         </div>
 
         @if (!Included.Any())
@@ -138,6 +134,9 @@
     private readonly List<ApiCamera> _cameras = new();
     private HashSet<string> _included = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, List<Seg>> _cov = new(StringComparer.OrdinalIgnoreCase);
+    // Event clips as playable segments — the fallback when there is no continuous
+    // footage under the cursor (or when continuous recording is off entirely).
+    private readonly Dictionary<string, List<Seg>> _eventSegs = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, List<Mark>> _marks = new(StringComparer.OrdinalIgnoreCase);
     private readonly HashSet<string> _noFootage = new(StringComparer.OrdinalIgnoreCase);
 
@@ -257,10 +256,12 @@
     private async Task LoadDayAsync()
     {
         _cov.Clear();
+        _eventSegs.Clear();
         _marks.Clear();
         _playing = false;
 
-        // Feature gates first: the timeline needs recording AND continuous footage.
+        // The timeline needs event recording; continuous footage is optional
+        // (event clips play as a fallback when it is off or has gaps).
         try
         {
             var features = await GetJsonAsync<ApiFeaturesInfo>("/api/features");
@@ -272,9 +273,9 @@
             _supported = false;
             return;
         }
-        if (!_supported || !_continuous) return;
+        if (!_supported) return;
 
-        // The events reply doubles as the day's colored lane marks.
+        // The events reply gives the day's colored lane marks AND playable event clips.
         try
         {
             var events = await GetJsonAsync<List<ApiEvent>>("/api/events?limit=1000");
@@ -288,10 +289,22 @@
                 var start = ev.Start.ToLocalTime();
                 if (start.Date != _date) continue;
                 double s = (start - _date).TotalSeconds;
-                double e = Math.Min(DaySeconds, s + Math.Max(ev.Duration.TotalSeconds, 1));
+                double dur = Math.Max(ev.Duration.TotalSeconds, 1);
+                double e = Math.Min(DaySeconds, s + dur);
                 if (!_marks.TryGetValue(ev.Camera, out var list))
                     _marks[ev.Camera] = list = new List<Mark>();
                 list.Add(new Mark(s, e, LabelColor(ev.Labels), $"{ev.Title} · {start:HH:mm:ss}"));
+
+                // The clip (full main-stream) is what plays; the sub-stream preview
+                // is a lighter fallback. Offset into the file = cursor − event start.
+                if (ev.HasClip || ev.HasPreview)
+                {
+                    var kind = ev.HasClip ? "clip" : "preview";
+                    if (!_eventSegs.TryGetValue(ev.Camera, out var segs))
+                        _eventSegs[ev.Camera] = segs = new List<Seg>();
+                    segs.Add(new Seg(s, dur,
+                        $"{Base}/api/events/{Uri.EscapeDataString(ev.Id)}/{kind}{TokenQuery('?')}"));
+                }
             }
         }
         catch
@@ -300,9 +313,12 @@
             return;
         }
 
-        // Coverage only for the cameras the user selected — this is the expensive part.
-        foreach (var cam in Included)
-            await LoadCoverageAsync(cam.Name);
+        // Continuous coverage only for the cameras the user selected (the expensive part).
+        if (_continuous)
+        {
+            foreach (var cam in Included)
+                await LoadCoverageAsync(cam.Name);
+        }
 
         // Land the cursor somewhere useful: near-now for today, else midday.
         _t = _date == DateTime.Today
@@ -422,14 +438,25 @@
         catch (ObjectDisposedException) { }
     }
 
+    /// <summary>The footage under the cursor for a camera: continuous first, then event clips.</summary>
+    private Seg? SegmentAt(string camera)
+    {
+        if (_cov.TryGetValue(camera, out var cont))
+        {
+            var hit = cont.FirstOrDefault(s => _t >= s.Start && _t < s.Start + s.Span);
+            if (hit != null) return hit;
+        }
+        if (_eventSegs.TryGetValue(camera, out var evs))
+            return evs.FirstOrDefault(s => _t >= s.Start && _t < s.Start + s.Span);
+        return null;
+    }
+
     /// <summary>Points every included camera's player at the footage under the cursor.</summary>
     private async Task SyncVideosAsync()
     {
         foreach (var cam in Included)
         {
-            var seg = _cov.TryGetValue(cam.Name, out var segs)
-                ? segs.FirstOrDefault(s => _t >= s.Start && _t < s.Start + s.Span)
-                : null;
+            var seg = SegmentAt(cam.Name);
             if (seg == null)
             {
                 _noFootage.Add(cam.Name);
@@ -462,7 +489,8 @@
         else
         {
             _included.Add(name);
-            await LoadCoverageAsync(name); // lazy: only now does this camera cost anything
+            if (_continuous)
+                await LoadCoverageAsync(name); // lazy: only now does this camera cost anything
         }
         await JS.InvokeVoidAsync("neolink.lsSet", PrefsKey,
             JsonSerializer.Serialize(new Prefs { Included = _included.ToList() }));

--- a/src/Neolink.WebClient/Models.cs
+++ b/src/Neolink.WebClient/Models.cs
@@ -43,7 +43,11 @@ public sealed record ApiEncodeProfile(string Type, uint Width, uint Height,
 public sealed record ApiStreamProfiles(List<ApiEncodeProfile> Profiles);
 
 /// <summary>Server capability flags (GET /api/features).</summary>
-public sealed record ApiFeaturesInfo(bool Events, bool Continuous, double TrickleSpeed = 4);
+public sealed record ApiFeaturesInfo(bool Events, bool Continuous, double TrickleSpeed = 4,
+    string? Version = null, string? LatestVersion = null, string? RepoUrl = null);
+
+/// <summary>GET /api/admin/config — the editable server settings.</summary>
+public sealed record ApiAdminConfig(string Path, bool Writable, JsonElement Settings);
 
 /// <summary>GET /api/auth/status — whether/how the UI must authenticate.</summary>
 public sealed record ApiAuthStatus(bool Enabled, bool SetupRequired, bool ResetAvailable,

--- a/src/Neolink.WebClient/wwwroot/css/app.css
+++ b/src/Neolink.WebClient/wwwroot/css/app.css
@@ -958,11 +958,15 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
 
 .tl-grid {
     flex: 1;
+    min-height: 0;
     display: grid; /* columns are set inline: fewer cameras = bigger tiles */
+    /* Rows share the available height so tiles fill the screen instead of a
+       single wide tile forcing its own 16:9 height (which zoomed on ultrawide). */
+    grid-auto-rows: minmax(140px, 1fr);
     gap: 8px;
     padding: 4px 12px 12px;
     overflow-y: auto;
-    align-content: start;
+    align-content: stretch;
 }
 
 .tl-tile {
@@ -971,11 +975,15 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
     border: 1px solid var(--line);
     border-radius: 8px;
     overflow: hidden;
+    min-height: 0;
 }
 
 .tl-tile video {
     width: 100%;
-    aspect-ratio: 16 / 9;
+    height: 100%;
+    /* contain, never stretch: letterbox/pillarbox the real feed (fixes the
+       zoomed, distorted look on wide screens and non-16:9 cameras). */
+    object-fit: contain;
     display: block;
     background: #000;
 }
@@ -1031,6 +1039,55 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
 }
 
 .sec-banner-actions .icon-btn { margin-left: auto; }
+
+/* New-version banner (same shape, accent colour) */
+.update-banner {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin: 4px 10px;
+    padding: 8px 10px;
+    border: 1px solid var(--accent);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.update-banner-text { font-size: 12px; color: var(--text); line-height: 1.35; }
+.update-banner a.chip { text-decoration: none; }
+
+/* Event player speed control */
+.player-speed {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 2px;
+}
+
+/* Admin server-settings fields */
+.admin-field {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    font-size: 13px;
+    padding: 3px 0;
+}
+
+.admin-field span { color: var(--muted); flex: 1; }
+
+.admin-field input {
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 4px 8px;
+    font-size: 13px;
+    width: 190px;
+    max-width: 48%;
+    outline: none;
+}
+
+.admin-field input:focus { border-color: var(--accent); }
 
 /* Strip filter row (under the events bar) */
 .strip-filter {

--- a/src/Neolink.WebClient/wwwroot/js/neolink.js
+++ b/src/Neolink.WebClient/wwwroot/js/neolink.js
@@ -310,6 +310,12 @@
             });
         },
 
+        // Set a video element's playback rate (event player speed control).
+        setRate(videoId, rate) {
+            const v = document.getElementById(videoId);
+            if (v) { v.defaultPlaybackRate = rate; v.playbackRate = rate; }
+        },
+
         // Review-strip vertical resizing: drag the handle at the bar's bottom edge.
         // The height is applied live in the DOM (no SignalR churn while dragging)
         // and reported to Blazor once on release for persistence.


### PR DESCRIPTION
Follow-up to #9. Two feature sets in one commit (they touch the same files).

## Admin & versioning (web UI)
- **Playback speed** in the event player: 1× / 2× / 4× / 8× chips (separate from the ambient strip previews' `ui.trickle_speed`).
- **Admin "Server settings" panel** edits most of `config.json` — network (ports/bind/serve-UI), web UI (trickle speed, state dir, reset-admin), recording (path/retention/pre-post/segment/etc). New `ConfigEditor` does a read-modify-write of the raw file: validates every candidate through the real config loader **before** an atomic replace that keeps a `.bak`, and preserves unknown fields plus the camera/RTSP-user lists (comments are not preserved — the UI says so). `GET/PUT /api/admin/config`, admin-gated.
- **Restart from the UI** (`POST /api/admin/restart`) triggers a graceful shutdown so the container/systemd restart policy applies saved config changes without touching Docker. `WebApi.RunAsync`'s long arg list folded into a `WebApiOptions` object.
- **New-version banner**: a daily best-effort `UpdateChecker` asks the GitHub releases/tags API whether a newer version exists (version string only, no code fetched); a dismissable sidebar banner links to the repo, with dismissal keyed by version so a future release re-surfaces it.

## Docker time zone
The `aspnet:10.0` base image ships no zoneinfo database, so `TZ` was silently ignored and every timestamp (event folders, clip names, the UI clock) ran in UTC. Now: `tzdata` is installed, `TZ` is documented in the Dockerfile / compose / README, and startup logs the resolved local time + signed offset so it's confirmable.

## Timeline fixes (reported)
- **Single-cam ultrawide feed was zoomed/stretched**: the tile forced its height from the full width via `aspect-ratio` with no `object-fit`. Grid rows now share the viewport height and the video uses `object-fit: contain` (letterboxed, never distorted). Verified fitting a 3440×1440 viewport.
- **Scrubbing onto an event played nothing** when continuous recording was off (or had a gap) — the timeline only played 24/7 footage. Event clips are now playable coverage (`clip.mp4`, or the sub-stream `preview.mp4` as a lighter fallback): continuous first, event clips as fallback. The timeline no longer requires continuous recording at all. Verified: scrubbing onto an event loaded its clip at the correct in-clip offset and cleared the "no footage" overlay.

## Reviewer notes
- 20/20 self-tests (adds config-editor read-modify-write with validation + backup).
- Verified live: player speed → 8× sets playbackRate; admin config read/write with valid+invalid edits (invalid rejected, file untouched, `.bak` written, camera list preserved); update banner render+dismiss (via a temporary stub, since the repo's current release is newest — stub removed); TZ startup log; ultrawide fit; event-clip playback on the timeline.
- Plain-HTTP caveat unchanged (session tokens on the LAN; TLS proxy for exposure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)