### PR TITLE
Fast-forward event previews to fix decode freeze at 2×/4×

### DIFF
--- a/src/Neolink.WebClient/Components/Pages/Home.razor
+++ b/src/Neolink.WebClient/Components/Pages/Home.razor
@@ -643,15 +643,21 @@
             </div>
             @if (_playEvent.HasClip)
             {
-                @* @key forces a fresh <video> when navigating between events *@
-                <video id="event-player-video" controls autoplay playsinline @key="_playEvent.Id"
-                       src="@EventArtifactUrl(_playEvent, "clip")"></video>
+                @* @key forces a fresh <video> when navigating between events.
+                   The source is chosen by speed (JS owns it, preserving position):
+                   full clip at 1×, low-res sub-stream preview when fast-forwarding
+                   so the decoder doesn't stall on 2K/4K (esp. H.265) frames. *@
+                <video id="event-player-video" controls autoplay playsinline @key="_playEvent.Id"></video>
                 <div class="player-speed">
                     <span class="tool-label">SPEED</span>
                     @foreach (var s in PlaybackSpeeds)
                     {
                         <button class="chip @(_playSpeed == s ? "chip-active" : "")"
                                 @onclick="() => SetPlaySpeedAsync(s)">@FormatSpeed(s)</button>
+                    }
+                    @if (_playSpeed > 1 && _playEvent.HasPreview)
+                    {
+                        <span class="event-sub">· preview quality while fast-forwarding</span>
                     }
                 </div>
             }
@@ -799,9 +805,10 @@
             _selfRef ??= DotNetObjectReference.Create(this);
             await JS.InvokeVoidAsync("neolink.stripResizeInit", "events-bar", _selfRef);
         }
-        // Keep a chosen playback rate across the <video>'s reloads/renders.
-        if (_playEvent is { HasClip: true } && _playSpeed != 1)
-            await JS.InvokeVoidAsync("neolink.setRate", "event-player-video", _playSpeed);
+        // Drive the event player from JS: pick the source for the current speed,
+        // preserve position across a clip↔preview swap, and apply the rate.
+        if (_playEvent is { HasClip: true })
+            await JS.InvokeVoidAsync("neolink.eventPlayer", "event-player-video", PlayerUrl, _playSpeed);
     }
 
     /// <summary>Called from JS when the strip's resize-handle drag ends.</summary>
@@ -1500,10 +1507,16 @@
 
     private static string FormatSpeed(double s) => s == 1 ? "1×" : $"{s:0}×";
 
+    /// <summary>Full clip at 1×; the light sub-stream preview when fast-forwarding (if it exists).</summary>
+    private string PlayerUrl => _playEvent == null ? "" :
+        (_playSpeed > 1 && _playEvent.HasPreview)
+            ? EventArtifactUrl(_playEvent, "preview")
+            : EventArtifactUrl(_playEvent, "clip");
+
     private async Task SetPlaySpeedAsync(double s)
     {
         _playSpeed = s;
-        await JS.InvokeVoidAsync("neolink.setRate", "event-player-video", s);
+        await JS.InvokeVoidAsync("neolink.eventPlayer", "event-player-video", PlayerUrl, s);
     }
 
     private void OpenEvent(ApiEvent ev) { _playEvent = ev; _playSpeed = 1; }

--- a/src/Neolink.WebClient/wwwroot/js/neolink.js
+++ b/src/Neolink.WebClient/wwwroot/js/neolink.js
@@ -310,10 +310,29 @@
             });
         },
 
-        // Set a video element's playback rate (event player speed control).
-        setRate(videoId, rate) {
+        // Drives the event player: points the <video> at `url` (full clip at 1×,
+        // low-res preview when fast-forwarding), preserving the current position
+        // across a source swap, and applies the playback rate. Idempotent — a
+        // same-url call only updates the rate. Fast-forwarding the light preview
+        // avoids the decoder stall that froze 2K/4K (H.265) clips at 2×/4×.
+        eventPlayer(videoId, url, rate) {
             const v = document.getElementById(videoId);
-            if (v) { v.defaultPlaybackRate = rate; v.playbackRate = rate; }
+            if (!v || !url) return;
+            if (v.dataset.evUrl !== url) {
+                const at = (v.currentTime && isFinite(v.currentTime)) ? v.currentTime : 0;
+                v.dataset.evUrl = url;
+                v.src = url;
+                const onMeta = () => {
+                    v.removeEventListener('loadedmetadata', onMeta);
+                    try { if (at > 0 && at < v.duration) v.currentTime = at; } catch { }
+                    v.defaultPlaybackRate = v.playbackRate = rate;
+                    v.play().catch(() => { });
+                };
+                v.addEventListener('loadedmetadata', onMeta);
+                try { v.load(); } catch { }
+            } else {
+                v.defaultPlaybackRate = v.playbackRate = rate;
+            }
         },
 
         // Review-strip vertical resizing: drag the handle at the bar's bottom edge.


### PR DESCRIPTION
Follow-up to #10. Small, focused fix.

## Problem
Speeding an event clip to 2× or 4× froze playback. The player was fast-forwarding the **full main-stream `clip.mp4`** (2K/4K, frequently H.265), and the browser's video decoder — especially hardware H.265 — can't sustain that throughput at speed, so it stalls on a frame. 1× barely keeps up, which is why only the higher speeds froze.

## Fix
Do what NLEs do for fast review: **fast-forward the lightweight sub-stream `preview.mp4`** (H.264, low-res), which decodes trivially at 8×.
- 1× plays the full-quality clip; 2×/4×/8× swap to the preview (when the event has one), with a “preview quality while fast-forwarding” note so the drop is clearly intentional.
- A new JS `eventPlayer` helper owns the source: it **preserves playback position** across the clip↔preview swap (captures `currentTime`, restores after load) and applies the rate. Switching among 2×/4×/8× only changes the rate — no reload.
- Events with no sub-stream preview fall back to the full clip (unchanged behaviour).

## Reviewer notes
- Verified in the browser: 1× → `/clip`, 4× → `/preview` at rate 4 with the note, back-to-1× → `/clip`, 2× stays on `/preview` (rate-only change); console clean.
- The actual decode-at-speed can't be exercised in the sandbox (seeded clip is a stub), only the source-selection/rate/position logic — the preview swap is what removes the decode bottleneck on real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)