### PR TITLE
MQTT / Home Assistant integration; segment size cap; tile UX + scrollbar theming

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ the original Rust neolink are also accepted.
 | `web_bind` | = `bind` | Separate bind address for the web port |
 | `users` | *(none)* | **RTSP** Basic-auth users: `{ "name", "pass" }`. Omit for open access. Separate from web-UI accounts! |
 | `recording` | *(none)* | Event recording (see below). Omit to disable |
+| `mqtt` | *(none)* | MQTT / Home Assistant integration (see below). Omit to disable |
 | `ui` | *(defaults)* | Web-UI specific settings (see below) |
 
 ### Web-UI settings (`"ui": { ... }`)
@@ -325,7 +326,8 @@ config file (in Docker: the `/config` mount), so they survive restarts:
 | `post_seconds` | `8` | Quiet time after the last detection before the event closes |
 | `max_clip_seconds` | `120` | Hard cap per event; continued activity starts a new event |
 | `stream` | `auto` | Stream to record: `auto` (main if served), `mainStream`, `subStream` |
-| `segment_minutes` | `10` | Continuous recording: length of one segment file |
+| `segment_minutes` | `10` | Continuous recording: time limit for one segment file |
+| `max_segment_size_mb` | `256` | Continuous recording: size limit for one segment file — a new file starts at the next keyframe once the segment reaches this size *or* `segment_minutes`, whichever comes first (keeps high-bitrate streams from producing huge files) |
 | `continuous_retention_days` | = `retention_days` | Days to keep continuous footage (`0` = forever) |
 
 Everything is fragmented MP4 (H.264/H.265 passthrough, video-only) playable in
@@ -347,6 +349,75 @@ to start with events off (the UI switch can re-enable it).
 | `channel_id` | `0` | Channel when connecting through a Reolink NVR (0-based) |
 | `permitted_users` | all users | Restrict this camera's mounts to specific `users` |
 | `record` | `true` | Initial default for this camera's "Detection events" switch (changeable in the web UI) |
+
+## Home Assistant (MQTT)
+
+Add an `mqtt` section and Neolink connects to your broker and publishes
+[Home Assistant MQTT Discovery](https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery)
+config, so a **device per camera** appears automatically — no YAML in HA.
+
+**Lightweight by design — the camera does the heavy lifting.** Neolink runs no
+object detection of its own: it never decodes, transcodes, or analyses a single
+video frame for motion or AI. All of that already happens *on the camera*, whose
+dedicated silicon detects motion and classifies people, vehicles and animals in
+real time. Neolink simply **listens for the alarm messages the camera pushes**
+over the Baichuan connection (the same events that drive Reolink's own app) and
+relays them to Home Assistant as MQTT sensors. That means:
+
+- **No GPU, no Coral, no CPU-hungry inference** — unlike setups where a server
+  re-analyses every stream, Neolink adds essentially zero processing load. It
+  runs comfortably on a Raspberry Pi or a small NAS container.
+- **Event-driven, not polled** — sensors fire the instant the camera sees
+  something, with no scan interval and no per-frame work.
+- **AI is only as good as the camera** — person/vehicle/animal labels come from
+  the camera's firmware, so enable the detection types you want in the Reolink
+  app and Neolink surfaces exactly those.
+
+The trade-off is that detection quality and available classes are whatever your
+camera model provides (rather than a tunable server-side model like Frigate's);
+in exchange you get an integration light enough to leave running forever.
+
+```json
+"mqtt": {
+  "broker": "192.168.1.10",
+  "username": "neolink",
+  "password": "secret"
+}
+```
+
+| Option | Default | Description |
+|---|---|---|
+| `broker` | *required* | MQTT broker host (usually the Home Assistant / Mosquitto box) |
+| `port` | `1883` | Broker port (`8883` with `tls: true`) |
+| `username` / `password` | *(none)* | Broker credentials |
+| `client_id` | `neolink` | Client id (must be unique on the broker) |
+| `base_topic` | `neolink` | Root of the state/command topics |
+| `discovery` | `true` | Publish HA discovery config so entities appear automatically |
+| `discovery_prefix` | `homeassistant` | Must match HA's MQTT integration setting |
+| `keepalive` | `30` | Keep-alive interval (seconds) |
+| `tls` | `false` | Connect with TLS (certificates are not validated) |
+
+**Entities** created per camera, according to what it supports:
+
+| Entity | Type | Notes |
+|---|---|---|
+| Motion / Person / Vehicle / Animal | `binary_sensor` | From the camera's alarm pushes (AI labels need Smart Detection enabled in the Reolink app) |
+| Battery | `sensor` | Battery cameras; charge status + temperature as attributes |
+| Night vision | `select` | `auto` / `on` / `off` |
+| Floodlight | `light` | Cameras with a spotlight |
+| PIR sensor | `switch` | Enable/disable the PIR |
+| Reboot, Pan up/down/left/right | `button` | PTZ buttons on pan-tilt cameras |
+| Snapshot | `camera` | Latest JPEG, refreshed periodically (when the camera supports snapshots) |
+
+Availability is two-level: entities show **unavailable** when either the Neolink
+service (a Last-Will topic) or the individual camera goes offline. State and
+discovery messages are retained, so Home Assistant repopulates after a restart.
+Commands from HA (toggle the floodlight, reboot, nudge PTZ…) are executed on the
+camera over the same Baichuan connection. No external MQTT library is used —
+Neolink speaks MQTT 3.1.1 directly, keeping the zero-dependency build.
+
+> Plain MQTT (port 1883) is unencrypted. For a LAN broker that's typical; enable
+> `tls` (port 8883) if the broker is remote.
 
 ## Using with Frigate
 

--- a/src/Neolink.Server/Config/NeolinkConfig.cs
+++ b/src/Neolink.Server/Config/NeolinkConfig.cs
@@ -17,6 +17,8 @@ public sealed class NeolinkConfig
     public RecordingConfig? Recording { get; set; }
     /// <summary>Web-UI specific settings ("ui" section).</summary>
     public UiConfig Ui { get; set; } = new();
+    /// <summary>MQTT / Home Assistant integration ("mqtt" section); null = disabled.</summary>
+    public MqttConfig? Mqtt { get; set; }
     /// <summary>Recovery switch (legacy top-level spelling; "ui.reset_admin_password" preferred).</summary>
     public bool ResetAdminPassword { get; set; }
 
@@ -89,6 +91,9 @@ public sealed class NeolinkConfig
                     break;
                 case "ui":
                     ParseJsonUi(prop.Value, config);
+                    break;
+                case "mqtt":
+                    config.Mqtt = ParseJsonMqtt(prop.Value);
                     break;
                 case "users":
                     foreach (var u in prop.Value.EnumerateArray())
@@ -175,6 +180,7 @@ public sealed class NeolinkConfig
                 case "maxclipseconds": rec.MaxClipSeconds = prop.Value.GetInt32(); break;
                 case "stream": rec.Stream = prop.Value.GetString() ?? "auto"; break;
                 case "segmentminutes": rec.SegmentMinutes = prop.Value.GetInt32(); break;
+                case "maxsegmentsizemb": rec.MaxSegmentSizeMb = prop.Value.GetInt32(); break;
                 case "continuousretentiondays": rec.ContinuousRetentionDays = prop.Value.GetInt32(); break;
                 default:
                     Log.Warn($"Config: ignoring unknown recording option '{prop.Name}'");
@@ -183,6 +189,33 @@ public sealed class NeolinkConfig
         }
         rec.Path = path ?? throw new FormatException("\"recording\" needs a \"path\" (the storage directory)");
         return rec;
+    }
+
+    private static MqttConfig ParseJsonMqtt(JsonElement el)
+    {
+        var mqtt = new MqttConfig();
+        string? host = null;
+        foreach (var prop in el.EnumerateObject())
+        {
+            switch (Key(prop.Name))
+            {
+                case "broker" or "host" or "server": host = prop.Value.GetString(); break;
+                case "port": mqtt.Port = prop.Value.GetInt32(); break;
+                case "username" or "user": mqtt.Username = prop.Value.GetString(); break;
+                case "password" or "pass": mqtt.Password = prop.Value.GetString(); break;
+                case "clientid": mqtt.ClientId = prop.Value.GetString() ?? mqtt.ClientId; break;
+                case "basetopic" or "topic": mqtt.BaseTopic = prop.Value.GetString() ?? mqtt.BaseTopic; break;
+                case "discovery": mqtt.Discovery = prop.Value.GetBoolean(); break;
+                case "discoveryprefix": mqtt.DiscoveryPrefix = prop.Value.GetString() ?? mqtt.DiscoveryPrefix; break;
+                case "keepalive": mqtt.KeepAliveSeconds = prop.Value.GetInt32(); break;
+                case "tls" or "ssl": mqtt.Tls = prop.Value.GetBoolean(); break;
+                default:
+                    Log.Warn($"Config: ignoring unknown mqtt option '{prop.Name}'");
+                    break;
+            }
+        }
+        mqtt.Broker = host ?? throw new FormatException("\"mqtt\" needs a \"broker\" (the MQTT server host)");
+        return mqtt;
     }
 
     private static void ParseJsonUi(JsonElement el, NeolinkConfig config)
@@ -228,6 +261,24 @@ public sealed class NeolinkConfig
         if (MiniToml.GetString(root, "certificate") != null)
             WarnTls();
 
+        if (MiniToml.GetTable(root, "mqtt") is { } mqtt)
+        {
+            config.Mqtt = new MqttConfig
+            {
+                Broker = MiniToml.GetString(mqtt, "broker") ?? MiniToml.GetString(mqtt, "host")
+                    ?? throw new FormatException("[mqtt] needs a 'broker' (the MQTT server host)"),
+                Port = (int)(MiniToml.GetInt(mqtt, "port") ?? 1883),
+                Username = MiniToml.GetString(mqtt, "username"),
+                Password = MiniToml.GetString(mqtt, "password"),
+                ClientId = MiniToml.GetString(mqtt, "client_id") ?? "neolink",
+                BaseTopic = MiniToml.GetString(mqtt, "base_topic") ?? "neolink",
+                Discovery = MiniToml.GetBool(mqtt, "discovery") ?? true,
+                DiscoveryPrefix = MiniToml.GetString(mqtt, "discovery_prefix") ?? "homeassistant",
+                KeepAliveSeconds = (int)(MiniToml.GetInt(mqtt, "keepalive") ?? 30),
+                Tls = MiniToml.GetBool(mqtt, "tls") ?? false,
+            };
+        }
+
         if (MiniToml.GetTable(root, "ui") is { } ui)
         {
             if (MiniToml.GetBool(ui, "enabled") is { } en) config.WebUi = en;
@@ -250,6 +301,7 @@ public sealed class NeolinkConfig
                 MaxClipSeconds = (int)(MiniToml.GetInt(rec, "max_clip_seconds") ?? 120),
                 Stream = MiniToml.GetString(rec, "stream") ?? "auto",
                 SegmentMinutes = (int)(MiniToml.GetInt(rec, "segment_minutes") ?? 10),
+                MaxSegmentSizeMb = (int)(MiniToml.GetInt(rec, "max_segment_size_mb") ?? 256),
                 ContinuousRetentionDays = (int?)MiniToml.GetInt(rec, "continuous_retention_days"),
             };
         }
@@ -367,6 +419,8 @@ public sealed class NeolinkConfig
                 throw new FormatException("recording.stream must be auto, mainStream, subStream or externStream");
             if (Recording.SegmentMinutes is < 1 or > 120)
                 throw new FormatException("recording.segment_minutes must be 1..120");
+            if (Recording.MaxSegmentSizeMb is < 8 or > 8192)
+                throw new FormatException("recording.max_segment_size_mb must be 8..8192");
             if (Recording.ContinuousRetentionDays is < 0)
                 throw new FormatException("recording.continuous_retention_days must be >= 0 (0 = keep forever)");
         }
@@ -375,6 +429,18 @@ public sealed class NeolinkConfig
             throw new FormatException("ui.trickle_speed must be 0.25..16");
         if (Ui.StateDir is { Length: 0 })
             throw new FormatException("ui.state_dir must not be empty when set");
+
+        if (Mqtt != null)
+        {
+            if (string.IsNullOrWhiteSpace(Mqtt.Broker))
+                throw new FormatException("mqtt.broker must not be empty");
+            if (Mqtt.Port is < 1 or > 65535)
+                throw new FormatException($"Invalid mqtt.port {Mqtt.Port}");
+            if (Mqtt.KeepAliveSeconds is < 5 or > 3600)
+                throw new FormatException("mqtt.keepalive must be 5..3600");
+            if (string.IsNullOrWhiteSpace(Mqtt.BaseTopic))
+                throw new FormatException("mqtt.base_topic must not be empty");
+        }
     }
 
     private static (string host, int port) SplitHostPort(string address)
@@ -426,6 +492,27 @@ public sealed class UiConfig
     public double TrickleSpeed { get; set; } = 4;
 }
 
+/// <summary>MQTT / Home Assistant integration settings ("mqtt" in the config).</summary>
+public sealed class MqttConfig
+{
+    /// <summary>MQTT broker host (e.g. the Home Assistant / Mosquitto address).</summary>
+    public string Broker { get; set; } = "";
+    public int Port { get; set; } = 1883;
+    public string? Username { get; set; }
+    public string? Password { get; set; }
+    /// <summary>Client id presented to the broker (must be unique per connection).</summary>
+    public string ClientId { get; set; } = "neolink";
+    /// <summary>Root of all state/command topics.</summary>
+    public string BaseTopic { get; set; } = "neolink";
+    /// <summary>Publish Home Assistant MQTT-discovery config so entities appear automatically.</summary>
+    public bool Discovery { get; set; } = true;
+    /// <summary>Home Assistant's discovery prefix (matches its MQTT integration setting).</summary>
+    public string DiscoveryPrefix { get; set; } = "homeassistant";
+    public int KeepAliveSeconds { get; set; } = 30;
+    /// <summary>Connect with TLS (broker port is usually 8883). Certificates are not validated.</summary>
+    public bool Tls { get; set; }
+}
+
 /// <summary>Event recording settings ("recording" in the config).</summary>
 public sealed class RecordingConfig
 {
@@ -449,8 +536,10 @@ public sealed class RecordingConfig
     public int MaxClipSeconds { get; set; } = 120;
     /// <summary>Stream to record: "auto" (main if served, else first), or an explicit stream name.</summary>
     public string Stream { get; set; } = "auto";
-    /// <summary>Length of one continuous-recording segment file, in minutes.</summary>
+    /// <summary>Time limit for one continuous-recording segment file, in minutes.</summary>
     public int SegmentMinutes { get; set; } = 10;
+    /// <summary>Size cap for one continuous-recording segment file, in MB (rolls whichever limit hits first).</summary>
+    public int MaxSegmentSizeMb { get; set; } = 256;
     /// <summary>Days to keep continuous footage; null = same as RetentionDays.</summary>
     public int? ContinuousRetentionDays { get; set; }
 

--- a/src/Neolink.Server/Mqtt/HomeAssistantMqtt.cs
+++ b/src/Neolink.Server/Mqtt/HomeAssistantMqtt.cs
@@ -1,0 +1,538 @@
+using System.Text.Json;
+using System.Xml.Linq;
+using Neolink.Config;
+using Neolink.Protocol;
+using Neolink.Recording;
+using Neolink.Streaming;
+using Neolink.Web;
+
+namespace Neolink.Mqtt;
+
+/// <summary>
+/// Bridges Neolink cameras to Home Assistant over MQTT, following HA's MQTT
+/// Discovery convention so entities appear automatically.
+///
+/// Per camera it publishes (all retained, so HA repopulates after a restart):
+///   • binary_sensor: motion, person, vehicle, animal   (from the alarm pushes)
+///   • sensor:        battery                            (battery cameras)
+///   • switch:        PIR sensor                         (PIR cameras)
+///   • select:        night vision (auto/on/off)         (IR-capable cameras)
+///   • light:         floodlight                         (cameras with a spotlight)
+///   • button:        reboot, and PTZ steps              (per capability)
+///   • camera:        latest snapshot                    (when the camera supports it)
+///
+/// Availability is two-level (HA marks entities unavailable when either is off):
+/// a bridge-wide Last-Will topic and a per-camera online topic. Commands from HA
+/// arrive on ".../{entity}/set" and are executed through <see cref="ICameraControl"/>.
+/// </summary>
+public sealed class HomeAssistantMqtt
+{
+    private static readonly TimeSpan RefreshInterval = TimeSpan.FromSeconds(20);
+    /// <summary>How long a detection stays "on" after the last alarm push for it.</summary>
+    private static readonly TimeSpan MotionOffDelay = TimeSpan.FromSeconds(20);
+
+    internal static readonly string[] DetectionLabels = { "motion", "person", "vehicle", "animal" };
+
+    private readonly MqttConfig _cfg;
+    private readonly string _version;
+    private readonly MqttClient _client;
+    private readonly Dictionary<string, CameraBridge> _cameras = new(StringComparer.OrdinalIgnoreCase);
+    private readonly string _availabilityTopic;
+
+    public HomeAssistantMqtt(MqttConfig cfg, IReadOnlyList<WebCameraInfo> cameras, string version)
+    {
+        _cfg = cfg;
+        _version = version;
+        _availabilityTopic = $"{cfg.BaseTopic}/bridge/state";
+
+        _client = new MqttClient(new MqttClientOptions
+        {
+            Host = cfg.Broker,
+            Port = cfg.Port,
+            Username = cfg.Username,
+            Password = cfg.Password,
+            ClientId = cfg.ClientId,
+            KeepAliveSeconds = cfg.KeepAliveSeconds,
+            Tls = cfg.Tls,
+            WillTopic = _availabilityTopic,
+            WillPayload = "offline",
+            WillRetain = true,
+        });
+
+        foreach (var cam in cameras)
+            _cameras[Sanitize(cam.Name)] = new CameraBridge(cam, this);
+
+        _client.Connected += OnConnectedAsync;
+        _client.MessageReceived += OnMessage;
+    }
+
+    internal MqttConfig Config => _cfg;
+    internal string Version => _version;
+    internal string AvailabilityTopic => _availabilityTopic;
+
+    public async Task RunAsync(CancellationToken ct)
+    {
+        Log.Info($"MQTT: Home Assistant bridge enabled → {_cfg.Broker}:{_cfg.Port} " +
+                 $"(base topic '{_cfg.BaseTopic}'{(_cfg.Discovery ? ", discovery on" : "")})");
+        var refresh = Task.Run(() => RefreshLoopAsync(ct), CancellationToken.None);
+        try
+        {
+            await _client.RunAsync(ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            try { await refresh.ConfigureAwait(false); } catch { }
+        }
+    }
+
+    /// <summary>Feeds one camera's alarm push into its bridge (called from the camera connection).</summary>
+    public void OnMotion(string cameraName, MotionPush push)
+    {
+        if (_cameras.TryGetValue(Sanitize(cameraName), out var cam))
+            cam.OnMotion(push);
+    }
+
+    // ------------------------------------------------------------------ MQTT plumbing
+
+    internal Task PublishAsync(string topic, string payload, CancellationToken ct = default) =>
+        _client.PublishAsync(topic, payload, retain: true, ct);
+
+    internal Task PublishAsync(string topic, byte[] payload, CancellationToken ct = default) =>
+        _client.PublishAsync(topic, payload, retain: true, ct);
+
+    private async Task OnConnectedAsync()
+    {
+        await _client.PublishAsync(_availabilityTopic, "online", retain: true, CancellationToken.None)
+            .ConfigureAwait(false);
+        // One wildcard per camera captures every ".../{entity}/set" command.
+        var subs = _cameras.Values.Select(c => $"{_cfg.BaseTopic}/{c.Id}/+/set").ToList();
+        await _client.SubscribeAsync(subs, CancellationToken.None).ConfigureAwait(false);
+        foreach (var cam in _cameras.Values)
+            await cam.AnnounceAsync(CancellationToken.None).ConfigureAwait(false);
+    }
+
+    private void OnMessage(string topic, byte[] payload)
+    {
+        // topic = {base}/{camId}/{entity}/set
+        var prefix = _cfg.BaseTopic + "/";
+        if (!topic.StartsWith(prefix, StringComparison.Ordinal)) return;
+        var rest = topic[prefix.Length..].Split('/');
+        if (rest.Length != 3 || rest[2] != "set") return;
+        if (!_cameras.TryGetValue(rest[0], out var cam)) return;
+        _ = cam.HandleCommandAsync(rest[1], System.Text.Encoding.UTF8.GetString(payload));
+    }
+
+    private async Task RefreshLoopAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try { await Task.Delay(RefreshInterval, ct).ConfigureAwait(false); }
+            catch (OperationCanceledException) { return; }
+            if (!_client.IsConnected) continue;
+            foreach (var cam in _cameras.Values)
+            {
+                try { await cam.RefreshAsync(ct).ConfigureAwait(false); }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    Log.Debug($"MQTT: refresh for '{cam.Id}' failed: {Log.Flatten(ex)}");
+                }
+            }
+        }
+    }
+
+    internal static TimeSpan OffDelay => MotionOffDelay;
+
+    /// <summary>Camera name → a topic/id-safe token ([a-z0-9_]).</summary>
+    internal static string Sanitize(string name) =>
+        new(name.Select(c => char.IsAsciiLetterOrDigit(c) ? char.ToLowerInvariant(c) : '_').ToArray());
+}
+
+/// <summary>The Home Assistant surface of one camera: discovery, state and commands.</summary>
+internal sealed class CameraBridge
+{
+    private readonly WebCameraInfo _cam;
+    private readonly HomeAssistantMqtt _hub;
+    private readonly ICameraControl _control;
+    private readonly string _base;      // {baseTopic}/{id}
+    private readonly Dictionary<string, DateTime> _activeUntil = new();
+    private readonly HashSet<string> _sensorOn = new();
+
+    private bool _featuresAnnounced;
+    private bool _hasFloodlight, _hasIr, _hasSnapshot;
+    private string? _model;
+    private DateTime _lastSnapshot = DateTime.MinValue;
+    private bool _lastOnline;
+
+    public string Id { get; }
+
+    public CameraBridge(WebCameraInfo cam, HomeAssistantMqtt hub)
+    {
+        _cam = cam;
+        _hub = hub;
+        _control = cam.Control;
+        Id = HomeAssistantMqtt.Sanitize(cam.Name);
+        _base = $"{hub.Config.BaseTopic}/{Id}";
+    }
+
+    private string StateTopic(string entity) => $"{_base}/{entity}";
+    private string CommandTopic(string entity) => $"{_base}/{entity}/set";
+    private string AvailabilityTopic => $"{_base}/state";
+
+    // ------------------------------------------------------------------ discovery + announce
+
+    /// <summary>
+    /// (Re)publishes discovery for what is known so far. Called on every connect;
+    /// the feature entities are added once capabilities have been probed.
+    /// </summary>
+    public async Task AnnounceAsync(CancellationToken ct)
+    {
+        await PublishAvailabilityAsync(ct).ConfigureAwait(false);
+
+        // Detection sensors and reboot exist on every camera — announce immediately.
+        foreach (var label in HomeAssistantMqtt.DetectionLabels)
+            await AnnounceEntityAsync("binary_sensor", label, BinarySensorConfig(label), ct).ConfigureAwait(false);
+        await AnnounceEntityAsync("button", "reboot", ButtonConfig("Reboot", "reboot", "restart"), ct).ConfigureAwait(false);
+
+        // Publish current detection states so HA doesn't show "unknown".
+        foreach (var label in HomeAssistantMqtt.DetectionLabels)
+            await _hub.PublishAsync(StateTopic(label), _sensorOn.Contains(label) ? "ON" : "OFF", ct).ConfigureAwait(false);
+
+        if (_featuresAnnounced)
+            await AnnounceFeaturesAsync(ct).ConfigureAwait(false);
+    }
+
+    private async Task AnnounceFeaturesAsync(CancellationToken ct)
+    {
+        var caps = await TryGetCapabilitiesAsync(ct).ConfigureAwait(false);
+        if (caps?.Features is not { } f) return;
+
+        if (f.Battery)
+            await AnnounceEntityAsync("sensor", "battery", BatterySensorConfig(), ct).ConfigureAwait(false);
+        if (_hasIr)
+            await AnnounceEntityAsync("select", "ir", IrSelectConfig(), ct).ConfigureAwait(false);
+        if (_hasFloodlight)
+            await AnnounceEntityAsync("light", "floodlight", FloodlightConfig(), ct).ConfigureAwait(false);
+        if (f.Pir)
+            await AnnounceEntityAsync("switch", "pir", SwitchConfig("PIR sensor", "pir"), ct).ConfigureAwait(false);
+        if (f.Ptz)
+            foreach (var dir in new[] { "up", "down", "left", "right" })
+                await AnnounceEntityAsync("button", $"ptz_{dir}",
+                    ButtonConfig($"Pan {dir}", $"ptz_{dir}", null), ct).ConfigureAwait(false);
+        if (_hasSnapshot)
+            await AnnounceEntityAsync("camera", "snapshot", CameraConfig(), ct).ConfigureAwait(false);
+    }
+
+    private Task AnnounceEntityAsync(string component, string objectId, object config, CancellationToken ct)
+    {
+        if (!_hub.Config.Discovery) return Task.CompletedTask;
+        var topic = $"{_hub.Config.DiscoveryPrefix}/{component}/neolink_{Id}/{objectId}/config";
+        return _hub.PublishAsync(topic, JsonSerializer.Serialize(config), ct);
+    }
+
+    /// <summary>The device block shared by every entity so HA groups them under one device.</summary>
+    private object Device() => new
+    {
+        identifiers = new[] { $"neolink_{Id}" },
+        name = _cam.Name,
+        manufacturer = "Reolink (via Neolink.NET)",
+        model = string.IsNullOrEmpty(_model) ? "Baichuan camera" : _model,
+        sw_version = _hub.Version,
+    };
+
+    private object[] Availability() => new object[]
+    {
+        new { topic = _hub.AvailabilityTopic },   // bridge alive (Last Will)
+        new { topic = AvailabilityTopic },        // this camera online
+    };
+
+    private object BinarySensorConfig(string label) => new
+    {
+        name = label switch { "motion" => "Motion", "person" => "Person", "vehicle" => "Vehicle", "animal" => "Animal", _ => label },
+        unique_id = $"neolink_{Id}_{label}",
+        state_topic = StateTopic(label),
+        payload_on = "ON",
+        payload_off = "OFF",
+        device_class = "motion",
+        device = Device(),
+        availability = Availability(),
+        availability_mode = "all",
+    };
+
+    private object BatterySensorConfig() => new
+    {
+        name = "Battery",
+        unique_id = $"neolink_{Id}_battery",
+        state_topic = StateTopic("battery"),
+        json_attributes_topic = StateTopic("battery/attr"),
+        device_class = "battery",
+        unit_of_measurement = "%",
+        state_class = "measurement",
+        device = Device(),
+        availability = Availability(),
+        availability_mode = "all",
+    };
+
+    private object IrSelectConfig() => new
+    {
+        name = "Night vision",
+        unique_id = $"neolink_{Id}_ir",
+        state_topic = StateTopic("ir"),
+        command_topic = CommandTopic("ir"),
+        options = new[] { "auto", "on", "off" },
+        icon = "mdi:light-flood-down",
+        device = Device(),
+        availability = Availability(),
+        availability_mode = "all",
+    };
+
+    private object FloodlightConfig() => new
+    {
+        name = "Floodlight",
+        unique_id = $"neolink_{Id}_floodlight",
+        state_topic = StateTopic("floodlight"),
+        command_topic = CommandTopic("floodlight"),
+        payload_on = "ON",
+        payload_off = "OFF",
+        device = Device(),
+        availability = Availability(),
+        availability_mode = "all",
+    };
+
+    private object SwitchConfig(string name, string entity) => new
+    {
+        name,
+        unique_id = $"neolink_{Id}_{entity}",
+        state_topic = StateTopic(entity),
+        command_topic = CommandTopic(entity),
+        payload_on = "ON",
+        payload_off = "OFF",
+        device = Device(),
+        availability = Availability(),
+        availability_mode = "all",
+    };
+
+    private object ButtonConfig(string name, string entity, string? deviceClass) => new
+    {
+        name,
+        unique_id = $"neolink_{Id}_{entity}",
+        command_topic = CommandTopic(entity),
+        payload_press = "PRESS",
+        device_class = deviceClass,
+        device = Device(),
+        availability = Availability(),
+        availability_mode = "all",
+    };
+
+    private object CameraConfig() => new
+    {
+        name = "Snapshot",
+        unique_id = $"neolink_{Id}_snapshot",
+        topic = StateTopic("snapshot"),
+        image_encoding = "b64",
+        device = Device(),
+        availability = Availability(),
+        availability_mode = "all",
+    };
+
+    // ------------------------------------------------------------------ motion state
+
+    public void OnMotion(MotionPush push)
+    {
+        var now = DateTime.UtcNow;
+        var labels = EventRecorder.LabelsOf(push); // person/vehicle/animal/... or "motion"
+        if (push.Active)
+        {
+            _activeUntil["motion"] = now + HomeAssistantMqtt.OffDelay;
+            foreach (var l in labels)
+                if (Array.IndexOf(HomeAssistantMqtt.DetectionLabels, l) >= 0)
+                    _activeUntil[l] = now + HomeAssistantMqtt.OffDelay;
+        }
+        else
+        {
+            // All-clear: let the sensors fall to OFF shortly (a small grace avoids flapping).
+            var soon = now + TimeSpan.FromSeconds(3);
+            foreach (var l in HomeAssistantMqtt.DetectionLabels)
+                if (_activeUntil.TryGetValue(l, out var until) && until > soon)
+                    _activeUntil[l] = soon;
+        }
+        _ = PublishSensorEdgesAsync(CancellationToken.None);
+    }
+
+    /// <summary>Publishes ON/OFF only on transitions (edge-triggered), keeping traffic minimal.</summary>
+    private async Task PublishSensorEdgesAsync(CancellationToken ct)
+    {
+        var now = DateTime.UtcNow;
+        foreach (var label in HomeAssistantMqtt.DetectionLabels)
+        {
+            bool on = _activeUntil.TryGetValue(label, out var until) && until > now;
+            if (on && _sensorOn.Add(label))
+                await _hub.PublishAsync(StateTopic(label), "ON", ct).ConfigureAwait(false);
+            else if (!on && _sensorOn.Remove(label))
+                await _hub.PublishAsync(StateTopic(label), "OFF", ct).ConfigureAwait(false);
+        }
+    }
+
+    // ------------------------------------------------------------------ periodic refresh
+
+    public async Task RefreshAsync(CancellationToken ct)
+    {
+        await PublishSensorEdgesAsync(ct).ConfigureAwait(false); // time out stale detections
+        await PublishAvailabilityAsync(ct).ConfigureAwait(false);
+        if (!_control.Online) return;
+
+        // First time online: probe capabilities, then announce the feature entities.
+        if (!_featuresAnnounced)
+        {
+            var caps = await TryGetCapabilitiesAsync(ct).ConfigureAwait(false);
+            if (caps?.Features is { } f)
+            {
+                _model = caps.Version?.Model;
+                if (f.Led) await ProbeLedAsync(ct).ConfigureAwait(false);
+                _hasSnapshot = await ProbeSnapshotAsync(ct).ConfigureAwait(false);
+                _featuresAnnounced = true;
+                await AnnounceAsync(ct).ConfigureAwait(false);
+            }
+        }
+
+        var caps2 = await TryGetCapabilitiesAsync(ct).ConfigureAwait(false);
+        var feat = caps2?.Features;
+        if (feat?.Battery == true) await PublishBatteryAsync(ct).ConfigureAwait(false);
+        if (feat?.Led == true) await PublishLedAsync(ct).ConfigureAwait(false);
+        if (feat?.Pir == true) await PublishPirAsync(ct).ConfigureAwait(false);
+        if (_hasSnapshot && DateTime.UtcNow - _lastSnapshot > TimeSpan.FromMinutes(2))
+            await PublishSnapshotAsync(ct).ConfigureAwait(false);
+    }
+
+    private async Task PublishAvailabilityAsync(CancellationToken ct)
+    {
+        bool online = _control.Online;
+        if (online == _lastOnline && _lastSnapshot != DateTime.MinValue) { /* still publish periodically */ }
+        _lastOnline = online;
+        await _hub.PublishAsync(AvailabilityTopic, online ? "online" : "offline", ct).ConfigureAwait(false);
+    }
+
+    private async Task PublishBatteryAsync(CancellationToken ct)
+    {
+        var battery = await TryAsync(() => _control.GetBatteryInfoAsync(ct)).ConfigureAwait(false);
+        if (battery == null) return;
+        if (Num(battery, "batteryPercent") is { } pct)
+            await _hub.PublishAsync(StateTopic("battery"), pct.ToString(), ct).ConfigureAwait(false);
+        var attrs = new Dictionary<string, object?>
+        {
+            ["charge_status"] = Str(battery, "chargeStatus"),
+            ["temperature"] = Num(battery, "temperature"),
+        };
+        await _hub.PublishAsync(StateTopic("battery/attr"), JsonSerializer.Serialize(attrs), ct).ConfigureAwait(false);
+    }
+
+    private async Task PublishLedAsync(CancellationToken ct)
+    {
+        var led = await TryAsync(() => _control.GetLedStateAsync(ct)).ConfigureAwait(false);
+        if (led == null) return;
+        if (_hasIr && Str(led, "state") is { Length: > 0 } ir)
+            await _hub.PublishAsync(StateTopic("ir"), IrToHa(ir), ct).ConfigureAwait(false);
+        if (_hasFloodlight && Str(led, "lightState") is { Length: > 0 } fl)
+            await _hub.PublishAsync(StateTopic("floodlight"), fl == "open" ? "ON" : "OFF", ct).ConfigureAwait(false);
+    }
+
+    private async Task PublishPirAsync(CancellationToken ct)
+    {
+        var pir = await TryAsync(() => _control.GetPirStateAsync(ct)).ConfigureAwait(false);
+        if (pir == null) return;
+        await _hub.PublishAsync(StateTopic("pir"), Num(pir, "enable") == 1 ? "ON" : "OFF", ct).ConfigureAwait(false);
+    }
+
+    private async Task PublishSnapshotAsync(CancellationToken ct)
+    {
+        var jpeg = await TryAsync(() => _control.SnapshotAsync(ct)).ConfigureAwait(false);
+        if (jpeg is { Length: > 100 })
+        {
+            _lastSnapshot = DateTime.UtcNow;
+            // HA camera "image_encoding: b64" expects base64 text.
+            await _hub.PublishAsync(StateTopic("snapshot"), Convert.ToBase64String(jpeg), ct).ConfigureAwait(false);
+        }
+    }
+
+    private async Task ProbeLedAsync(CancellationToken ct)
+    {
+        var led = await TryAsync(() => _control.GetLedStateAsync(ct)).ConfigureAwait(false);
+        if (led == null) return;
+        _hasIr = Str(led, "state") is { Length: > 0 };
+        _hasFloodlight = Str(led, "lightState") is { Length: > 0 };
+    }
+
+    private async Task<bool> ProbeSnapshotAsync(CancellationToken ct)
+    {
+        var jpeg = await TryAsync(() => _control.SnapshotAsync(ct)).ConfigureAwait(false);
+        if (jpeg is not { Length: > 100 }) return false;
+        _lastSnapshot = DateTime.UtcNow;
+        await _hub.PublishAsync(StateTopic("snapshot"), Convert.ToBase64String(jpeg), ct).ConfigureAwait(false);
+        return true;
+    }
+
+    // ------------------------------------------------------------------ commands from HA
+
+    public async Task HandleCommandAsync(string entity, string payload)
+    {
+        var ct = CancellationToken.None;
+        try
+        {
+            switch (entity)
+            {
+                case "reboot" when payload == "PRESS":
+                    await _control.RebootAsync(ct).ConfigureAwait(false);
+                    break;
+                case "ir":
+                    await _control.SetLedStateAsync(HaToIr(payload), null, ct).ConfigureAwait(false);
+                    await PublishLedAsync(ct).ConfigureAwait(false);
+                    break;
+                case "floodlight":
+                    await _control.SetLedStateAsync(null, payload == "ON" ? "open" : "close", ct).ConfigureAwait(false);
+                    await PublishLedAsync(ct).ConfigureAwait(false);
+                    break;
+                case "pir":
+                    await _control.SetPirEnabledAsync(payload == "ON", ct).ConfigureAwait(false);
+                    await PublishPirAsync(ct).ConfigureAwait(false);
+                    break;
+                case "ptz_up" or "ptz_down" or "ptz_left" or "ptz_right" when payload == "PRESS":
+                    await PtzStepAsync(entity["ptz_".Length..], ct).ConfigureAwait(false);
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Warn($"MQTT: command '{entity}' for '{Id}' failed: {Log.Flatten(ex)}");
+        }
+    }
+
+    /// <summary>A momentary PTZ nudge: move for a short beat, then stop.</summary>
+    private async Task PtzStepAsync(string direction, CancellationToken ct)
+    {
+        await _control.PtzAsync(direction, 32f, ct).ConfigureAwait(false);
+        await Task.Delay(600, ct).ConfigureAwait(false);
+        await _control.PtzAsync("stop", 32f, ct).ConfigureAwait(false);
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private async Task<CameraCapabilities?> TryGetCapabilitiesAsync(CancellationToken ct)
+    {
+        if (!_control.Online) return null;
+        try { return await _control.GetCapabilitiesAsync(ct).ConfigureAwait(false); }
+        catch (Exception ex) when (ex is CameraOfflineException or CameraCommandException or TimeoutException) { return null; }
+    }
+
+    private static async Task<T?> TryAsync<T>(Func<Task<T?>> op) where T : class
+    {
+        try { return await op().ConfigureAwait(false); }
+        catch (Exception ex) when (ex is CameraOfflineException or CameraCommandException or TimeoutException
+                                    or System.IO.IOException) { return null; }
+    }
+
+    private static string IrToHa(string s) => s switch { "open" => "on", "close" => "off", _ => "auto" };
+    private static string HaToIr(string s) => s switch { "on" => "open", "off" => "close", _ => "auto" };
+
+    private static string? Str(XElement el, string name) => el.Element(name)?.Value.Trim() is { Length: > 0 } v ? v : null;
+    private static long? Num(XElement el, string name) =>
+        long.TryParse(el.Element(name)?.Value.Trim(), out var n) ? n : null;
+}

--- a/src/Neolink.Server/Mqtt/MqttClient.cs
+++ b/src/Neolink.Server/Mqtt/MqttClient.cs
@@ -1,0 +1,242 @@
+using System.Net.Security;
+using System.Net.Sockets;
+
+namespace Neolink.Mqtt;
+
+/// <summary>Connection options for <see cref="MqttClient"/> (a "last will" is required for HA availability).</summary>
+public sealed class MqttClientOptions
+{
+    public required string Host { get; init; }
+    public required int Port { get; init; }
+    public string? Username { get; init; }
+    public string? Password { get; init; }
+    public required string ClientId { get; init; }
+    public int KeepAliveSeconds { get; init; } = 30;
+    public bool Tls { get; init; }
+    public string? WillTopic { get; init; }
+    public string? WillPayload { get; init; }
+    public bool WillRetain { get; init; } = true;
+}
+
+/// <summary>
+/// A minimal, resilient MQTT 3.1.1 client: one background task owns the socket,
+/// runs the keep-alive ping loop and the read loop, and reconnects with backoff
+/// on any failure. Publishing and subscribing are thread-safe and simply no-op
+/// while disconnected — the owner republishes state on <see cref="Connected"/>.
+/// Only QoS 0 is used (sufficient, with retained state, for Home Assistant).
+/// </summary>
+public sealed class MqttClient
+{
+    private static readonly TimeSpan MinBackoff = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan MaxBackoff = TimeSpan.FromSeconds(30);
+
+    private readonly MqttClientOptions _opt;
+    private readonly SemaphoreSlim _writeGate = new(1, 1);
+    private volatile Stream? _stream;
+    private int _packetId;
+    private DateTime _lastRxUtc;
+
+    public MqttClient(MqttClientOptions options) => _opt = options;
+
+    /// <summary>Raised (on the read-loop thread) for every PUBLISH the broker delivers.</summary>
+    public event Action<string, byte[]>? MessageReceived;
+
+    /// <summary>Raised after each successful CONNACK — the owner (re)announces and subscribes here.</summary>
+    public event Func<Task>? Connected;
+
+    public bool IsConnected => _stream != null;
+
+    public async Task RunAsync(CancellationToken ct)
+    {
+        var backoff = MinBackoff;
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                await ConnectAndServeAsync(ct).ConfigureAwait(false);
+                backoff = MinBackoff; // a clean session end resets the backoff
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                Log.Warn($"MQTT: {_opt.Host}:{_opt.Port} — {Log.Flatten(ex)}; retrying in {backoff.TotalSeconds:0}s");
+            }
+            finally
+            {
+                _stream = null;
+            }
+            try { await Task.Delay(backoff, ct).ConfigureAwait(false); }
+            catch (OperationCanceledException) { return; }
+            backoff = TimeSpan.FromTicks(Math.Min(MaxBackoff.Ticks, backoff.Ticks * 2));
+        }
+    }
+
+    private async Task ConnectAndServeAsync(CancellationToken ct)
+    {
+        using var tcp = new TcpClient { NoDelay = true };
+        await tcp.ConnectAsync(_opt.Host, _opt.Port, ct).ConfigureAwait(false);
+        Stream stream = tcp.GetStream();
+        if (_opt.Tls)
+        {
+            var ssl = new SslStream(stream, leaveInnerStreamOpen: false,
+                userCertificateValidationCallback: (_, _, _, _) => true); // LAN brokers use self-signed certs
+            await ssl.AuthenticateAsClientAsync(_opt.Host).ConfigureAwait(false);
+            stream = ssl;
+        }
+
+        // CONNECT → CONNACK handshake.
+        var connect = MqttPacket.BuildConnect(_opt.ClientId, _opt.Username, _opt.Password,
+            (ushort)_opt.KeepAliveSeconds, _opt.WillTopic, _opt.WillPayload, _opt.WillRetain);
+        await stream.WriteAsync(connect, ct).ConfigureAwait(false);
+        await stream.FlushAsync(ct).ConfigureAwait(false);
+
+        var (type, body) = await ReadPacketAsync(stream, ct).ConfigureAwait(false);
+        if ((type & 0xF0) != MqttPacket.ConnAck)
+            throw new IOException($"expected CONNACK, got 0x{type:X2}");
+        if (body.Length < 2 || body[1] != 0x00)
+            throw new IOException($"broker refused the connection (CONNACK code {(body.Length >= 2 ? body[1] : -1)})");
+
+        _lastRxUtc = DateTime.UtcNow;
+        _stream = stream;
+        Log.Info($"MQTT: connected to {_opt.Host}:{_opt.Port} as '{_opt.ClientId}'");
+
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var ping = Task.Run(() => PingLoopAsync(stream, linked.Token), CancellationToken.None);
+        try
+        {
+            if (Connected != null)
+                await Connected.Invoke().ConfigureAwait(false);
+            await ReadLoopAsync(stream, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            linked.Cancel();
+            try { await ping.ConfigureAwait(false); } catch { }
+        }
+    }
+
+    // ------------------------------------------------------------------ publish / subscribe
+
+    public Task<bool> PublishAsync(string topic, string payload, bool retain, CancellationToken ct) =>
+        PublishAsync(topic, System.Text.Encoding.UTF8.GetBytes(payload), retain, ct);
+
+    public async Task<bool> PublishAsync(string topic, byte[] payload, bool retain, CancellationToken ct)
+    {
+        var stream = _stream;
+        if (stream == null) return false;
+        var packet = MqttPacket.BuildPublish(topic, payload, retain);
+        return await SendAsync(stream, packet, ct).ConfigureAwait(false);
+    }
+
+    public async Task<bool> SubscribeAsync(IReadOnlyList<string> topics, CancellationToken ct)
+    {
+        var stream = _stream;
+        if (stream == null || topics.Count == 0) return false;
+        var id = (ushort)(Interlocked.Increment(ref _packetId) & 0xFFFF);
+        var packet = MqttPacket.BuildSubscribe(id == 0 ? (ushort)1 : id, topics);
+        return await SendAsync(stream, packet, ct).ConfigureAwait(false);
+    }
+
+    private async Task<bool> SendAsync(Stream stream, byte[] packet, CancellationToken ct)
+    {
+        await _writeGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await stream.WriteAsync(packet, ct).ConfigureAwait(false);
+            await stream.FlushAsync(ct).ConfigureAwait(false);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException or SocketException)
+        {
+            _stream = null; // triggers a reconnect in RunAsync
+            return false;
+        }
+        finally
+        {
+            _writeGate.Release();
+        }
+    }
+
+    // ------------------------------------------------------------------ loops
+
+    private async Task ReadLoopAsync(Stream stream, CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            var (type, body) = await ReadPacketAsync(stream, ct).ConfigureAwait(false);
+            _lastRxUtc = DateTime.UtcNow;
+            switch (type & 0xF0)
+            {
+                case MqttPacket.Publish:
+                    var msg = MqttPacket.ParsePublish(type, body);
+                    try { MessageReceived?.Invoke(msg.Topic, msg.Payload); }
+                    catch (Exception ex) { Log.Warn($"MQTT: message handler for '{msg.Topic}' threw: {ex.Message}"); }
+                    break;
+                // PINGRESP / SUBACK / PUBACK: nothing to do beyond noting activity.
+            }
+        }
+    }
+
+    private async Task PingLoopAsync(Stream stream, CancellationToken ct)
+    {
+        var interval = TimeSpan.FromSeconds(Math.Max(5, _opt.KeepAliveSeconds * 0.75));
+        var deadline = TimeSpan.FromSeconds(_opt.KeepAliveSeconds * 2);
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                await Task.Delay(interval, ct).ConfigureAwait(false);
+                if (DateTime.UtcNow - _lastRxUtc > deadline)
+                {
+                    _stream = null;
+                    stream.Close(); // unblock the read loop → reconnect
+                    return;
+                }
+                await SendAsync(stream, MqttPacket.BuildPingReq(), ct).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException) { }
+    }
+
+    // ------------------------------------------------------------------ frame reader
+
+    /// <summary>Reads one control packet: its header byte and the "remaining length" body.</summary>
+    private static async Task<(byte type, byte[] body)> ReadPacketAsync(Stream stream, CancellationToken ct)
+    {
+        var one = new byte[1];
+        await ReadExactAsync(stream, one, ct).ConfigureAwait(false);
+        byte type = one[0];
+
+        // Remaining-length varint (up to 4 bytes).
+        int length = 0, mult = 1, count = 0;
+        byte digit;
+        do
+        {
+            await ReadExactAsync(stream, one, ct).ConfigureAwait(false);
+            digit = one[0];
+            length += (digit & 0x7F) * mult;
+            mult <<= 7;
+            if (++count > 4) throw new IOException("malformed MQTT remaining-length");
+        } while ((digit & 0x80) != 0);
+
+        if (length > 64 * 1024 * 1024) throw new IOException($"implausible MQTT packet length {length}");
+        var body = new byte[length];
+        if (length > 0) await ReadExactAsync(stream, body, ct).ConfigureAwait(false);
+        return (type, body);
+    }
+
+    private static async Task ReadExactAsync(Stream stream, byte[] buffer, CancellationToken ct)
+    {
+        int off = 0;
+        while (off < buffer.Length)
+        {
+            int n = await stream.ReadAsync(buffer.AsMemory(off), ct).ConfigureAwait(false);
+            if (n == 0) throw new IOException("MQTT connection closed by broker");
+            off += n;
+        }
+    }
+}

--- a/src/Neolink.Server/Mqtt/MqttPacket.cs
+++ b/src/Neolink.Server/Mqtt/MqttPacket.cs
@@ -1,0 +1,148 @@
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Neolink.Mqtt;
+
+/// <summary>
+/// MQTT 3.1.1 (protocol level 4) wire encoding — the small subset a publish/
+/// subscribe client needs. Kept dependency-free in keeping with the rest of the
+/// project (no external MQTT library). Only what Home Assistant needs is here:
+/// CONNECT, PUBLISH (QoS 0), SUBSCRIBE, PINGREQ, DISCONNECT, and parsing of the
+/// packets the broker sends back.
+/// </summary>
+internal static class MqttPacket
+{
+    // Control packet types (high nibble of the fixed-header byte).
+    public const byte Connect = 0x10;
+    public const byte ConnAck = 0x20;
+    public const byte Publish = 0x30;
+    public const byte PubAck = 0x40;
+    public const byte Subscribe = 0x82;   // reserved low bits must be 0b0010
+    public const byte SubAck = 0x90;
+    public const byte PingReq = 0xC0;
+    public const byte PingResp = 0xD0;
+    public const byte Disconnect = 0xE0;
+
+    // ------------------------------------------------------------------ encode
+
+    public static byte[] BuildConnect(string clientId, string? username, string? password,
+        ushort keepAlive, string? willTopic, string? willPayload, bool willRetain)
+    {
+        var vh = new List<byte>();
+        WriteString(vh, "MQTT");
+        vh.Add(4); // protocol level 4 = MQTT 3.1.1
+
+        byte flags = 0x02; // clean session
+        if (username != null) flags |= 0x80;
+        if (password != null) flags |= 0x40;
+        if (willTopic != null)
+        {
+            flags |= 0x04;                    // will flag
+            if (willRetain) flags |= 0x20;    // will retain (QoS 0)
+        }
+        vh.Add(flags);
+        vh.Add((byte)(keepAlive >> 8));
+        vh.Add((byte)(keepAlive & 0xFF));
+
+        var payload = new List<byte>();
+        WriteString(payload, clientId);
+        if (willTopic != null)
+        {
+            WriteString(payload, willTopic);
+            WriteBytes(payload, Encoding.UTF8.GetBytes(willPayload ?? ""));
+        }
+        if (username != null) WriteString(payload, username);
+        if (password != null) WriteString(payload, password);
+
+        return Assemble(Connect, vh, payload);
+    }
+
+    public static byte[] BuildPublish(string topic, ReadOnlySpan<byte> payload, bool retain)
+    {
+        var vh = new List<byte>();
+        WriteString(vh, topic); // QoS 0: no packet identifier
+        byte header = (byte)(Publish | (retain ? 0x01 : 0x00));
+        return Assemble(header, vh, payload);
+    }
+
+    public static byte[] BuildSubscribe(ushort packetId, IReadOnlyList<string> topics)
+    {
+        var vh = new List<byte> { (byte)(packetId >> 8), (byte)(packetId & 0xFF) };
+        var payload = new List<byte>();
+        foreach (var t in topics)
+        {
+            WriteString(payload, t);
+            payload.Add(0x00); // requested QoS 0
+        }
+        return Assemble(Subscribe, vh, payload);
+    }
+
+    public static byte[] BuildPingReq() => new byte[] { PingReq, 0x00 };
+    public static byte[] BuildDisconnect() => new byte[] { Disconnect, 0x00 };
+
+    // ------------------------------------------------------------------ decode
+
+    /// <summary>Parsed PUBLISH from the broker (QoS 0 handled; higher QoS ignored by the client).</summary>
+    public readonly record struct IncomingPublish(string Topic, byte[] Payload);
+
+    /// <summary>Splits a received PUBLISH body (after the fixed header) into topic + payload.</summary>
+    public static IncomingPublish ParsePublish(byte header, ReadOnlySpan<byte> body)
+    {
+        int qos = (header >> 1) & 0x03;
+        int topicLen = (body[0] << 8) | body[1];
+        var topic = Encoding.UTF8.GetString(body.Slice(2, topicLen));
+        int pos = 2 + topicLen;
+        if (qos > 0) pos += 2; // skip the packet identifier (we don't ack QoS>0)
+        return new IncomingPublish(topic, body[pos..].ToArray());
+    }
+
+    // ------------------------------------------------------------------ framing helpers
+
+    /// <summary>Encodes the "remaining length" variable-byte integer (1–4 bytes).</summary>
+    public static void WriteRemainingLength(List<byte> to, int value)
+    {
+        do
+        {
+            byte b = (byte)(value & 0x7F);
+            value >>= 7;
+            if (value > 0) b |= 0x80;
+            to.Add(b);
+        } while (value > 0);
+    }
+
+    private static byte[] Assemble(byte header, List<byte> variableHeader, ReadOnlySpan<byte> payload)
+    {
+        var frame = new List<byte>(variableHeader.Count + payload.Length + 5) { header };
+        WriteRemainingLength(frame, variableHeader.Count + payload.Length);
+        frame.AddRange(variableHeader);
+        var arr = new byte[frame.Count + payload.Length];
+        frame.CopyTo(arr);
+        payload.CopyTo(arr.AsSpan(frame.Count));
+        return arr;
+    }
+
+    private static byte[] Assemble(byte header, List<byte> variableHeader, List<byte> payload)
+    {
+        var frame = new List<byte>(variableHeader.Count + payload.Count + 5) { header };
+        WriteRemainingLength(frame, variableHeader.Count + payload.Count);
+        frame.AddRange(variableHeader);
+        frame.AddRange(payload);
+        return frame.ToArray();
+    }
+
+    private static void WriteString(List<byte> to, string s)
+    {
+        var bytes = Encoding.UTF8.GetBytes(s);
+        WriteBytes(to, bytes);
+    }
+
+    private static void WriteBytes(List<byte> to, byte[] bytes)
+    {
+        if (bytes.Length > 0xFFFF) throw new ArgumentException("MQTT field exceeds 65535 bytes");
+        to.Add((byte)(bytes.Length >> 8));
+        to.Add((byte)(bytes.Length & 0xFF));
+        to.AddRange(bytes);
+    }
+
+    internal static ushort ReadUInt16(ReadOnlySpan<byte> s) => BinaryPrimitives.ReadUInt16BigEndian(s);
+}

--- a/src/Neolink.Server/Program.cs
+++ b/src/Neolink.Server/Program.cs
@@ -1,5 +1,6 @@
 using Neolink;
 using Neolink.Config;
+using Neolink.Mqtt;
 using Neolink.Protocol;
 using Neolink.Recording;
 using Neolink.Rtsp;
@@ -112,6 +113,10 @@ var server = new RtspServer(users);
 var tasks = new List<Task>();
 var webCameras = new List<WebCameraInfo>();
 
+// MQTT / Home Assistant bridge is created after the cameras are built (below) so
+// it can reference their controls; declared here so motion wiring can reach it.
+HomeAssistantMqtt? mqtt = null;
+
 // Recording (detection events + continuous), when a storage path is configured.
 EventStore? eventStore = null;
 RecordingSettings? recordingSettings = null;
@@ -136,6 +141,10 @@ if (config.Recording is { } recCfg)
         eventStore = null;
     }
 }
+
+// Motion pushes fan out to the recorder and/or the MQTT bridge; wired after both
+// exist (the bridge needs the camera list, built below).
+var motionTargets = new List<(CameraService Primary, string Name, Action<MotionPush>? RecorderSink)>();
 
 foreach (var cam in config.Cameras)
 {
@@ -171,9 +180,11 @@ foreach (var cam in config.Cameras)
     // Stream encode settings are written via the camera's HTTP API when configured.
     var httpApi = cam.HttpAddress == null ? null
         : new ReolinkHttpApi(cam.HttpAddress, cam.Username, cam.Password, cam.ChannelId);
-    ICameraControl control = new CameraControl(primaryService
-        ?? throw new InvalidOperationException($"camera '{cam.Name}' has no streams"), httpApi);
+    var primary = primaryService
+        ?? throw new InvalidOperationException($"camera '{cam.Name}' has no streams");
+    ICameraControl control = new CameraControl(primary, httpApi);
     webCameras.Add(new WebCameraInfo(cam.Name, webStreams, control, permitted));
+    Action<MotionPush>? recorderSink = null;
 
     // Recording: alarm pushes ride the primary connection; event clips and
     // continuous segments are cut from the configured stream's hub (auto = main
@@ -199,7 +210,7 @@ foreach (var cam in config.Cameras)
             if (previewStream == recordStream) previewStream = null;
             var recorder = new EventRecorder(cam.Name, recordStream.Hub, control, eventStore,
                 config.Recording, recordingSettings, previewStream?.Hub);
-            primaryService.MotionSink = recorder.OnMotion;
+            recorderSink = recorder.OnMotion;
             tasks.Add(Task.Run(() => recorder.RunAsync(shutdown.Token)));
 
             // Continuous (24/7) recording is temporarily disabled — see
@@ -212,6 +223,28 @@ foreach (var cam in config.Cameras)
             }
         }
     }
+
+    motionTargets.Add((primary, cam.Name, recorderSink));
+}
+
+// MQTT / Home Assistant bridge (single connection for all cameras), then wire
+// motion: the camera's alarm push goes to the recorder and/or the bridge. The
+// alarm-push listener only runs when a MotionSink is set, so this also enables
+// motion for MQTT-only setups (recording off).
+if (config.Mqtt is { } mqttCfg)
+{
+    mqtt = new HomeAssistantMqtt(mqttCfg, webCameras, Version);
+    tasks.Add(Task.Run(() => mqtt.RunAsync(shutdown.Token)));
+}
+foreach (var (primary, name, recorderSink) in motionTargets)
+{
+    var bridge = mqtt;
+    if (recorderSink == null && bridge == null) continue;
+    primary.MotionSink = push =>
+    {
+        recorderSink?.Invoke(push);
+        bridge?.OnMotion(name, push);
+    };
 }
 
 // Web API (camera list + fMP4 live streams for browsers); guarded like the cameras.

--- a/src/Neolink.Server/Recording/ClipWriter.cs
+++ b/src/Neolink.Server/Recording/ClipWriter.cs
@@ -53,6 +53,7 @@ public sealed class ClipWriter : IDisposable
 
     // Shared with the writer thread.
     private long _queuedBytes;
+    private long _approxBytes; // cumulative bytes destined for the file (size-cap roll)
     private volatile bool _faulted;
 
     private readonly record struct QueueItem(byte[] Data, bool Keyframe, ulong DecodeTime);
@@ -61,6 +62,7 @@ public sealed class ClipWriter : IDisposable
     {
         _path = path;
         _codec = codec;
+        _approxBytes = init.Length; // the init segment is already on its way to disk
         var boxes = FindHeaderBoxes(init);
         new Thread(() => WriteLoop(init, boxes))
         {
@@ -79,6 +81,9 @@ public sealed class ClipWriter : IDisposable
     /// <summary>Seconds of video muxed so far (upper bound; pending frames included at nominal rate).</summary>
     public double DurationSeconds =>
         ((ulong)_decodeTime + (ulong)(_pending?.Count ?? 0) * NominalFrame) / (double)FMp4.Timescale;
+
+    /// <summary>Approximate size of the file so far in bytes (used to cap segment size).</summary>
+    public long ApproxBytes => Volatile.Read(ref _approxBytes);
 
     /// <summary>Prepares a clip file; null when codec params are not known yet. Never blocks on disk.</summary>
     public static ClipWriter? TryCreate(string path, IStreamHub hub)
@@ -171,6 +176,7 @@ public sealed class ClipWriter : IDisposable
         }
 
         Interlocked.Add(ref _queuedBytes, fragment.Length);
+        Interlocked.Add(ref _approxBytes, fragment.Length);
         try
         {
             _queue.Add(new QueueItem(fragment, keyframe, decodeTime));

--- a/src/Neolink.Server/Recording/ContinuousRecorder.cs
+++ b/src/Neolink.Server/Recording/ContinuousRecorder.cs
@@ -9,9 +9,11 @@ namespace Neolink.Recording;
 ///
 /// Toggleable at runtime (web UI → RecordingSettings): the hub subscription stays
 /// open either way, packets are simply discarded while the switch is off, so a
-/// toggle takes effect on the next frame. Segments roll at the first keyframe
-/// after SegmentMinutes, keeping every file independently playable. Day folders
-/// are pruned by the same retention task that expires events.
+/// toggle takes effect on the next frame. Segments roll at the first keyframe once
+/// they reach the time (SegmentMinutes) OR size (MaxSegmentSizeMb) limit, whichever
+/// comes first — the size cap keeps high-bitrate streams from producing enormous
+/// files. Every file is independently playable. Day folders are pruned by the same
+/// retention task that expires events.
 /// </summary>
 public sealed class ContinuousRecorder
 {
@@ -23,6 +25,7 @@ public sealed class ContinuousRecorder
     private readonly EventStore _store;
     private readonly RecordingSettings _settings;
     private readonly double _segmentSeconds;
+    private readonly long _maxSegmentBytes;
 
     public ContinuousRecorder(string camera, IStreamHub hub, EventStore store,
         RecordingSettings settings, RecordingConfig cfg)
@@ -32,6 +35,7 @@ public sealed class ContinuousRecorder
         _store = store;
         _settings = settings;
         _segmentSeconds = cfg.SegmentMinutes * 60.0;
+        _maxSegmentBytes = (long)cfg.MaxSegmentSizeMb * 1024 * 1024;
     }
 
     public async Task RunAsync(CancellationToken ct)
@@ -66,12 +70,15 @@ public sealed class ContinuousRecorder
                 if (!wasOn)
                 {
                     Log.Info($"{_camera}: continuous recording started " +
-                             $"({_segmentSeconds / 60:0}-minute segments)");
+                             $"(segments roll at {_segmentSeconds / 60:0} min or {_maxSegmentBytes / (1024 * 1024)} MB)");
                     wasOn = true;
                 }
 
-                // Roll to a new file at the first keyframe past the segment length.
-                if (writer != null && v.Keyframe && writer.DurationSeconds >= _segmentSeconds)
+                // Roll to a new file at the first keyframe once the segment reaches
+                // either limit — time OR size, whichever comes first (a size cap keeps
+                // high-bitrate main streams from producing enormous files).
+                if (writer != null && v.Keyframe
+                    && (writer.DurationSeconds >= _segmentSeconds || writer.ApproxBytes >= _maxSegmentBytes))
                 {
                     writer.Dispose();
                     writer = null;

--- a/src/Neolink.Server/SelfTest.cs
+++ b/src/Neolink.Server/SelfTest.cs
@@ -372,6 +372,43 @@ public static class SelfTest
             }
         });
 
+        Test("mqtt packet codec", () =>
+        {
+            // CONNECT: fixed header, remaining length, protocol name, level, flags.
+            var connect = Mqtt.MqttPacket.BuildConnect("neolink", "user", "pw", 30,
+                willTopic: "neolink/bridge/state", willPayload: "offline", willRetain: true);
+            AssertEq(connect[0], (byte)0x10); // CONNECT
+            // variable header protocol name "MQTT"
+            AssertEq(Encoding.ASCII.GetString(connect, 4, 4), "MQTT");
+            AssertEq(connect[8], (byte)4); // protocol level 3.1.1
+            byte flags = connect[9];
+            Assert((flags & 0x02) != 0, "clean session");
+            Assert((flags & 0x80) != 0, "username flag");
+            Assert((flags & 0x40) != 0, "password flag");
+            Assert((flags & 0x04) != 0, "will flag");
+            Assert((flags & 0x20) != 0, "will retain");
+
+            // PUBLISH round-trips through the incoming parser (topic + payload, QoS 0).
+            var pub = Mqtt.MqttPacket.BuildPublish("neolink/cam/motion", Encoding.UTF8.GetBytes("ON"), retain: true);
+            AssertEq(pub[0], (byte)0x31); // PUBLISH | retain
+            // Strip the fixed header + remaining-length byte to get the body the reader passes on.
+            var body = pub.AsSpan(2).ToArray();
+            var parsed = Mqtt.MqttPacket.ParsePublish(pub[0], body);
+            AssertEq(parsed.Topic, "neolink/cam/motion");
+            AssertEq(Encoding.UTF8.GetString(parsed.Payload), "ON");
+
+            // SUBSCRIBE has the reserved 0b0010 low bits and carries the packet id.
+            var sub = Mqtt.MqttPacket.BuildSubscribe(7, new[] { "neolink/cam/+/set" });
+            AssertEq(sub[0], (byte)0x82);
+
+            // Remaining-length varint encodes multi-byte lengths correctly (321 → 0xC1 0x02).
+            var rl = new List<byte>();
+            Mqtt.MqttPacket.WriteRemainingLength(rl, 321);
+            AssertEq(rl.Count, 2);
+            AssertEq(rl[0], (byte)0xC1);
+            AssertEq(rl[1], (byte)0x02);
+        });
+
         Test("config editor: read-modify-write with validation", () =>
         {
             var dir = Path.Combine(Path.GetTempPath(), $"neolink-selftest-{Guid.NewGuid():N}");
@@ -466,6 +503,7 @@ public static class SelfTest
                     writer.Add(new Streaming.HubVideo(index, Au(Nal(0x41, 25)), false, ts += 3000));
                 }
                 Assert(writer.DurationSeconds > 0.15, "all frames survive audio interleave");
+                Assert(writer.ApproxBytes > 0, "byte counter advances (drives the segment size cap)");
 
                 // A real drop (gap flag) resumes at the next keyframe.
                 writer.Add(new Streaming.HubVideo(index + 50, Au(Nal(0x41, 25)), false, ts += 3000), gap: true);

--- a/src/Neolink.Server/config.example.json
+++ b/src/Neolink.Server/config.example.json
@@ -43,8 +43,26 @@
   //   "post_seconds": 8,               // quiet time before an event closes
   //   "max_clip_seconds": 120,         // hard cap per event/clip
   //   "stream": "auto",                // which stream to record: auto|mainStream|subStream
-  //   "segment_minutes": 10,           // continuous recording: length of one file
+  //   "segment_minutes": 10,           // continuous recording: max length of one file
+  //   "max_segment_size_mb": 256,      // continuous recording: max size of one file (rolls at whichever hits first)
   //   "continuous_retention_days": 7   // continuous footage retention (default = retention_days)
+  // },
+
+  // Optional: publish to MQTT for Home Assistant (auto-discovery). Remove to disable.
+  // HA creates a device per camera with motion/person/vehicle/animal sensors,
+  // battery, night-vision, floodlight, PIR, reboot + PTZ buttons and a snapshot,
+  // depending on what each camera supports.
+  // "mqtt": {
+  //   "broker": "192.168.1.10",        // MQTT broker host (often the HA / Mosquitto box)
+  //   "port": 1883,                    // 8883 with "tls": true
+  //   "username": "neolink",
+  //   "password": "CHANGE-ME",
+  //   "client_id": "neolink",          // must be unique on the broker
+  //   "base_topic": "neolink",         // root of the state/command topics
+  //   "discovery": true,               // publish HA discovery config
+  //   "discovery_prefix": "homeassistant",  // must match HA's MQTT integration
+  //   "keepalive": 30,
+  //   "tls": false
   // },
 
   // Optional: password-protect the RTSP server. Remove entries for open access.

--- a/src/Neolink.WebClient/Components/Pages/Home.razor
+++ b/src/Neolink.WebClient/Components/Pages/Home.razor
@@ -263,6 +263,9 @@
                         @* no autoplay: the JS player starts playback once its jitter buffer is filled *@
                         <video id="vid-@index" muted playsinline></video>
                         <div class="tile-status">connecting…</div>
+                        <button class="tile-trash" title="Remove this tile"
+                                @onclick="() => CloseSlot(index)"
+                                @onclick:stopPropagation="true" @ondblclick:stopPropagation="true">🗑</button>
                         <div class="tile-bar" @onclick:stopPropagation="true" @ondblclick:stopPropagation="true">
                             <span class="tile-name">@slot.Camera</span>
                             @if (camera != null && camera.Streams.Count > 1)
@@ -1770,7 +1773,37 @@
 
     private void AddStream(ApiCamera cam, ApiStream stream)
     {
-        var slot = _slots.FirstOrDefault(s => s.Camera == null) ?? _slots[^1];
+        // Already on screen? Don't duplicate or clobber another tile — flash the
+        // existing tile red so the user can see where the camera already is.
+        int shown = _slots.FindIndex(s => s.Camera == cam.Name);
+        if (shown >= 0)
+        {
+            _ = JS.InvokeVoidAsync("neolink.flashTile", $"tile-{shown}");
+            _sidebarOpen = false;
+            return;
+        }
+
+        var slot = _slots.FirstOrDefault(s => s.Camera == null);
+        if (slot == null)
+        {
+            // No free tile: grow the layout by one rather than replacing a tile
+            // that already has content.
+            int grown = ClampCount(_mode, _count + 1);
+            if (grown > _count)
+            {
+                _count = grown;
+                EnsureSlots();
+                slot = _slots.FirstOrDefault(s => s.Camera == null);
+            }
+            if (slot == null)
+            {
+                // At the layout's max tiles: flash the last one instead of clobbering.
+                _ = JS.InvokeVoidAsync("neolink.flashTile", $"tile-{_slots.Count - 1}");
+                _sidebarOpen = false;
+                return;
+            }
+        }
+
         slot.Camera = cam.Name;
         slot.Kind = stream.Kind;
         slot.Path = stream.Path;

--- a/src/Neolink.WebClient/wwwroot/css/app.css
+++ b/src/Neolink.WebClient/wwwroot/css/app.css
@@ -364,6 +364,40 @@ html, body {
 
 .tile:hover .tile-bar { opacity: 1; }
 
+/* Per-tile delete: a trashcan on the tile itself (top-right), subtle until hover */
+.tile-trash {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    z-index: 3;
+    border: none;
+    background: rgba(0, 0, 0, 0.5);
+    color: #fff;
+    font-size: 14px;
+    line-height: 1;
+    width: 28px;
+    height: 28px;
+    border-radius: 7px;
+    cursor: pointer;
+    opacity: 0.35;
+    transition: opacity 0.15s ease, background 0.15s ease;
+}
+
+.tile:hover .tile-trash { opacity: 0.9; }
+
+.tile-trash:hover {
+    opacity: 1;
+    background: var(--err);
+}
+
+/* Flash a tile red when its camera is picked again (already on screen) */
+.tile-flash { animation: tile-flash 0.9s ease-in-out; }
+
+@keyframes tile-flash {
+    0%, 33%, 66% { box-shadow: inset 0 0 0 3px var(--err); }
+    16%, 50%, 100% { box-shadow: inset 0 0 0 3px transparent; }
+}
+
 .tile-name {
     font-weight: 600;
     font-size: 13px;
@@ -399,9 +433,20 @@ html, body {
 .fs-toggle::before { content: "⤢"; }
 body.is-fullscreen .fs-toggle::before { content: "⇲"; }
 
-::-webkit-scrollbar { width: 10px; }
-::-webkit-scrollbar-thumb { background: var(--line); border-radius: 5px; }
-::-webkit-scrollbar-track { background: transparent; }
+/* Themed scrollbars. WebKit/Blink needs both width (vertical bars) AND height
+   (horizontal bars, e.g. the event strip) or the horizontal one falls back to
+   the chunky default. Firefox uses the inherited scrollbar-color/-width below. */
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-thumb {
+    background: var(--line);
+    border-radius: 5px;
+    border: 2px solid transparent;
+    background-clip: padding-box;
+}
+::-webkit-scrollbar-thumb:hover { background: var(--muted); }
+::-webkit-scrollbar-track,
+::-webkit-scrollbar-corner { background: transparent; }
+:root { scrollbar-color: var(--line) transparent; scrollbar-width: thin; }
 
 /* ---------- responsive ---------- */
 .menu-btn { display: none; }
@@ -462,6 +507,7 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
     .grid.mode-free { overflow: auto; }
 
     .tile-bar { opacity: 1; } /* no hover on touch: keep controls visible */
+    .tile-trash { opacity: 0.85; }
 }
 
 /* ---------- camera settings dialog ---------- */

--- a/src/Neolink.WebClient/wwwroot/js/neolink.js
+++ b/src/Neolink.WebClient/wwwroot/js/neolink.js
@@ -300,6 +300,17 @@
     window.neolink = {
         freeInit,
 
+        // Briefly flash a tile's border red — used when a camera the user picked
+        // is already on screen (so we don't duplicate or clobber another tile).
+        flashTile(id) {
+            const el = document.getElementById(id);
+            if (!el) return;
+            el.classList.remove('tile-flash');
+            void el.offsetWidth; // reflow so a repeat click restarts the animation
+            el.classList.add('tile-flash');
+            setTimeout(() => el.classList.remove('tile-flash'), 950);
+        },
+
         // Ambient event previews (review strip): ensure real muting, fast-forward
         // playback rate and looped playback. Idempotent, called per render.
         trickle(speed) {


### PR DESCRIPTION
Three commits.

## 1. MQTT / Home Assistant integration (`Mqtt/`)
Add an `mqtt` section and Neolink publishes Home Assistant MQTT Discovery, so a **device per camera** appears automatically.
- **Hand-rolled MQTT 3.1.1 client** — no NuGet, matching the zero-dependency build. `MqttPacket` (wire codec) + `MqttClient` (owns the socket, keep-alive ping loop, read loop, auto-reconnect with backoff, Last-Will, optional TLS).
- **`HomeAssistantMqtt` bridge** publishes discovery per capability: `binary_sensor` (motion/person/vehicle/animal), `sensor` (battery), `select` (night vision), `light` (floodlight), `switch` (PIR), `button` (reboot + PTZ), `camera` (snapshot). Two-level availability (bridge Last-Will + per-camera online, `availability_mode: all`), retained state/discovery, commands executed over Baichuan.
- **Lightweight**: no server-side detection — the camera's own AI does the work; Neolink relays the pushes (no GPU/Coral/inference, event-driven).

## 2. Continuous segment size cap
Segments rolled only on time; high-bitrate streams made enormous files. New **`max_segment_size_mb`** (default 256): a new file starts at the next keyframe once the segment reaches the size **or** time limit.

## 3. Tile UX + scrollbar theming
- **Flash instead of clobber**: picking a camera already on screen flashes its tile red rather than overwriting another tile.
- **Grow instead of replace**: with no free tile, the layout grows by one instead of replacing content (flashes the last tile at the layout max).
- **Per-tile trashcan** (top-right) to remove a tile, alongside the hover bar; visible on touch.
- **Themed scrollbars**: the global rule only set `width`, so the event strip's horizontal scrollbar used the chunky default — added `height`, a hover thumb, and Firefox theming via inherited `scrollbar-color/-width`.

## Reviewer notes
- 21/21 self-tests (MQTT packet codec, clip-writer byte counter).
- MQTT verified end-to-end against a stub broker (CONNECT/CONNACK, retained availability, discovery JSON with correct device/availability blocks, command subscription). Tile flash / grow / trash and the scrollbar theming verified in a live browser session.
- Segment size cap couldn't be functionally tested in the sandbox (fake camera has no feed); byte counter is self-tested, roll is a simple time-OR-size condition (can overshoot by up to one GOP).
- Zero-dependency single-binary build preserved (no MQTT library).

🤖 Generated with [Claude Code](https://claude.com/claude-code)