### PR TITLE
Show signed-in user in the sidebar; lock all video when signed out

### DIFF
--- a/src/Neolink.WebClient/Components/Pages/Home.razor
+++ b/src/Neolink.WebClient/Components/Pages/Home.razor
@@ -114,7 +114,23 @@
             </div>
         }
 
-        <div class="sidebar-foot">Neolink.NET web client</div>
+        <div class="sidebar-foot">
+            @if (_authUser != null)
+            {
+                <div class="sidebar-user">
+                    <span class="sidebar-user-id" title="Signed in as @_authUser">
+                        <span class="sidebar-user-icon">@(_authAdmin ? "🛡" : "👤")</span>
+                        <span class="sidebar-user-name">@_authUser</span>
+                        <span class="sidebar-user-role">@(_authAdmin ? "admin" : "user")</span>
+                    </span>
+                    <button class="chip chip-off sidebar-signout" title="Sign out" @onclick="LogoutAsync">Sign out</button>
+                </div>
+            }
+            else
+            {
+                <span>Neolink.NET web client</span>
+            }
+        </div>
     </aside>
 
     <main class="stage">
@@ -1902,12 +1918,20 @@
         return $"{baseUrl}/api/stream?path={Uri.EscapeDataString(slot.Path)}{TokenQuery('&')}";
     }
 
+    /// <summary>
+    /// Sign-in is required but not satisfied. While locked, NO stream is attached —
+    /// belt-and-braces with the server, which already rejects the stream WebSocket
+    /// (and every /api call) without a valid session token.
+    /// </summary>
+    private bool Locked => _authEnabled && _authUser == null;
+
     private async Task ReconcilePlayersAsync()
     {
         int upper = Math.Max(_slots.Count, _attached.Count == 0 ? 0 : _attached.Keys.Max() + 1);
         for (int i = 0; i < upper; i++)
         {
-            string? desired = i < _slots.Count ? WsUrl(_slots[i]) : null;
+            // Locked: force every tile to detach — a signed-out user sees no video.
+            string? desired = (!Locked && i < _slots.Count) ? WsUrl(_slots[i]) : null;
             _attached.TryGetValue(i, out var current);
             if (desired == current) continue;
 

--- a/src/Neolink.WebClient/wwwroot/css/app.css
+++ b/src/Neolink.WebClient/wwwroot/css/app.css
@@ -184,6 +184,48 @@ html, body {
     padding-top: 10px;
 }
 
+/* Signed-in user + sign-out, pinned at the sidebar bottom */
+.sidebar-user {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    border-top: 1px solid var(--line);
+    padding-top: 10px;
+    text-align: left;
+}
+
+.sidebar-user-id {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+    flex: 1;
+}
+
+.sidebar-user-icon { font-size: 14px; flex: 0 0 auto; }
+
+.sidebar-user-name {
+    color: var(--text);
+    font-size: 13px;
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.sidebar-user-role {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--muted);
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    padding: 1px 7px;
+    flex: 0 0 auto;
+}
+
+.sidebar-signout { flex: 0 0 auto; }
+
 /* ---------- stage ---------- */
 .stage {
     flex: 1;


### PR DESCRIPTION
## Sidebar footer: user, role, sign-out
The bottom of the sidebar (previously the static "Neolink.NET web client") now shows the signed-in account when authentication is on: a 🛡/👤 icon, the username, an admin/user role pill, and a **Sign out** button. It falls back to the original text when auth is disabled.

## No camera viewable while signed out (the important one)
Enforced on three layers:
1. **Server (the real gate)** — the auth middleware already rejects the live-stream WebSocket *and* every `/api` call without a valid session token. Verified live: `/api/stream` without a token is **rejected**, `/api/cameras` returns **401**. (The WS token rides as `?token=` since browsers can't set headers on a WebSocket.)
2. **Client lock (defense-in-depth)** — a new `Locked` gate makes `ReconcilePlayersAsync` detach every tile and attach nothing while sign-in is required but unsatisfied, so a signed-out session never opens a stream. Logging out immediately tears down any live tile.
3. **UI overlay** — the opaque login screen already covers the stage while locked.

## Reviewer notes
- Verified end-to-end in the browser: no token → WS rejected + `/api/cameras` 401; sign in → footer shows the user, video plays; sign out → login overlay returns, token cleared, footer reverts, and the tile `<video>` detaches (no live stream). Log back in → normal viewing restored.
- Sign-out is now in two places (the new footer button + the existing ⚙ server-settings panel); both call the same `LogoutAsync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)