### PR TITLE
Reverse-proxy fix: circuits call loopback, not the public URL; strip scroll chevrons

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,27 @@ to start with events off (the UI switch can re-enable it).
 | `permitted_users` | all users | Restrict this camera's mounts to specific `users` |
 | `record` | `true` | Initial default for this camera's "Detection events" switch (changeable in the web UI) |
 
+## Behind a reverse proxy (HAProxy / nginx / Caddy)
+
+The web UI works behind a TLS-terminating reverse proxy (e.g. HAProxy on
+OPNsense) pointing at `web_port`. Two things matter:
+
+- **WebSocket upgrade** must be allowed for `/_blazor` (the UI's interactive
+  circuit) and `/api/stream` (live video). Most proxies pass the `Upgrade`
+  header by default; in HAProxy make sure the backend has a generous
+  `timeout tunnel` (e.g. `1h`) so long-lived streams aren't cut.
+- **The container never needs to reach its own public URL.** The UI runs on
+  Blazor Server, so its API calls execute *inside* the container; when the
+  configured server address is the page's own origin, those calls
+  automatically short-circuit to loopback instead of going back out through
+  the proxy — no hairpin NAT, split DNS, or internal-CA trust required.
+  (Symptom of the old behaviour: the page loads but the camera list shows
+  "Cannot reach https://… The SSL connection could not be established".)
+
+Only the browser-facing traffic (the page, the live-video WebSocket, event
+clips/thumbnails) traverses the proxy, so your TLS certificate only needs to
+be valid for the browser.
+
 ## Home Assistant (MQTT)
 
 Add an `mqtt` section and Neolink connects to your broker and publishes

--- a/src/Neolink.Server/Web/WebApi.cs
+++ b/src/Neolink.Server/Web/WebApi.cs
@@ -106,6 +106,10 @@ public static class WebApi
             builder.Services.AddRazorComponents().AddInteractiveServerComponents();
             // The UI's camera-list fetches run server-side (Blazor Server circuits)
             builder.Services.AddSingleton(_ => new HttpClient { Timeout = TimeSpan.FromSeconds(5) });
+            // Circuits must talk to THIS server via loopback, never back out through
+            // a reverse proxy's public URL (TLS/hairpin failures behind HAProxy etc.).
+            var loopbackHost = bindAddr is "0.0.0.0" or "::" or "[::]" or "*" ? "127.0.0.1" : bindAddr;
+            builder.Services.AddSingleton(new Neolink.WebClient.LocalApiInfo($"http://{loopbackHost}:{port}"));
         }
         var app = builder.Build();
 

--- a/src/Neolink.WebClient/Components/Pages/Home.razor
+++ b/src/Neolink.WebClient/Components/Pages/Home.razor
@@ -2,6 +2,7 @@
 @using System.Text.Json
 @inject HttpClient Http
 @inject IJSRuntime JS
+@inject LocalApiInfo Local
 @implements IAsyncDisposable
 
 <div class="shell">
@@ -142,6 +143,11 @@
                 <span class="events-bar-count" title="Unreviewed events (after filters)">⚡ @StripEvents.Count()</span>
                 <button class="icon-btn strip-filter-btn @(_showStripFilter || _hiddenTypes.Count > 0 || _hiddenCams.Count > 0 ? "active" : "")"
                         title="Filter which events appear here" @onclick="() => _showStripFilter = !_showStripFilter">⚟</button>
+                @* Edge chevrons make the strip's scrollability obvious; JS owns their
+                   clicks/visibility so paging is smooth and off the Blazor circuit. *@
+                <div class="strip-scroll-wrap" id="strip-scroll-wrap">
+                    <button type="button" class="strip-nav strip-nav-left strip-nav-hidden"
+                            title="Scroll to earlier events" aria-label="Scroll left">❮</button>
                 <div class="events-bar-scroll">
                     @if (!StripEvents.Any())
                     {
@@ -186,6 +192,9 @@
                             </div>
                         </div>
                     }
+                </div>
+                    <button type="button" class="strip-nav strip-nav-right strip-nav-hidden"
+                            title="Scroll to older events" aria-label="Scroll right">❯</button>
                 </div>
                 <button class="chip events-clear" title="Dismiss all events" @onclick="DismissAllAsync">Clear all</button>
                 <div class="strip-resize" title="Drag to resize the event strip"></div>
@@ -309,7 +318,7 @@
 
     @if (_panelCamera != null)
     {
-        <CameraPanel Server="@_server" CameraName="@_panelCamera"
+        <CameraPanel Server="@ApiBase" CameraName="@_panelCamera"
                      Camera="_cameras.FirstOrDefault(c => c.Name == _panelCamera)"
                      User="@_user" Pass="@_pass" Token="@_authToken"
                      OnClose="() => _panelCamera = null" />
@@ -823,6 +832,7 @@
             await JS.InvokeVoidAsync("neolink.trickle", _trickleSpeed);
             _selfRef ??= DotNetObjectReference.Create(this);
             await JS.InvokeVoidAsync("neolink.stripResizeInit", "events-bar", _selfRef);
+            await JS.InvokeVoidAsync("neolink.stripNavInit", "strip-scroll-wrap");
         }
         // Drive the event player from JS: pick the source for the current speed,
         // preserve position across a clip↔preview swap, and apply the rate.
@@ -880,8 +890,9 @@
             await SaveAsync();
         }
 
+        try { _origin = await JS.InvokeAsync<string>("neolink.defaultServer"); } catch { }
         if (string.IsNullOrWhiteSpace(_server))
-            _server = await JS.InvokeAsync<string>("neolink.defaultServer");
+            _server = _origin;
 
         // Session + one-time flags
         try
@@ -951,9 +962,29 @@
 
     // ------------------------------------------------------------ authentication
 
+    private string _origin = "";
+
+    /// <summary>
+    /// Where SERVER-side fetches go. Blazor circuits run in this very process, so
+    /// when the configured server is the page's own origin, calls go to loopback
+    /// instead of back out through a reverse proxy's public URL (which the host
+    /// often can't reach, or rejects for its internal TLS cert). A genuinely
+    /// remote server address is used as-is. Browser-side URLs (video WS, media
+    /// elements) intentionally keep <see cref="_server"/> so they traverse the proxy.
+    /// </summary>
+    private string ResolveApi(string server)
+    {
+        var s = server.TrimEnd('/');
+        return _origin.Length > 0 && string.Equals(s, _origin.TrimEnd('/'), StringComparison.OrdinalIgnoreCase)
+            ? Local.BaseUrl.TrimEnd('/')
+            : s;
+    }
+
+    private string ApiBase => ResolveApi(_server);
+
     private HttpRequestMessage ApiRequest(HttpMethod method, string path)
     {
-        var req = new HttpRequestMessage(method, $"{_server.TrimEnd('/')}{path}");
+        var req = new HttpRequestMessage(method, $"{ApiBase}{path}");
         if (!string.IsNullOrEmpty(_authToken))
             req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _authToken);
         return req;
@@ -1409,7 +1440,7 @@
         if (string.IsNullOrWhiteSpace(server)) return false;
         try
         {
-            var req = new HttpRequestMessage(HttpMethod.Get, $"{server.TrimEnd('/')}/api/cameras");
+            var req = new HttpRequestMessage(HttpMethod.Get, $"{ResolveApi(server)}/api/cameras");
             if (!string.IsNullOrEmpty(_authToken))
                 req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _authToken);
             using var res = await Http.SendAsync(req);
@@ -1592,7 +1623,7 @@
         try
         {
             var req = new HttpRequestMessage(HttpMethod.Post,
-                $"{_server.TrimEnd('/')}/api/events/{Uri.EscapeDataString(ev.Id)}/review");
+                $"{ApiBase}/api/events/{Uri.EscapeDataString(ev.Id)}/review");
             if (!string.IsNullOrEmpty(_authToken))
             {
                 req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _authToken);

--- a/src/Neolink.WebClient/Components/Pages/Timeline.razor
+++ b/src/Neolink.WebClient/Components/Pages/Timeline.razor
@@ -2,6 +2,7 @@
 @using System.Text.Json
 @inject HttpClient Http
 @inject IJSRuntime JS
+@inject LocalApiInfo Local
 @implements IAsyncDisposable
 
 @* NVR-style timeline: pick a day, scrub the lanes, and every included camera
@@ -175,8 +176,9 @@
                 }
             }
             catch { }
+            try { _origin = await JS.InvokeAsync<string>("neolink.defaultServer"); } catch { }
             if (string.IsNullOrWhiteSpace(_server))
-                _server = await JS.InvokeAsync<string>("neolink.defaultServer");
+                _server = _origin;
 
             try
             {
@@ -214,7 +216,19 @@
 
     // ------------------------------------------------------------ data
 
+    /// <summary>Base for BROWSER-side URLs (the segment videos) — goes through any reverse proxy.</summary>
     private string Base => _server.TrimEnd('/');
+
+    /// <summary>
+    /// Base for SERVER-side fetches: the circuit runs in this process, so its own
+    /// origin resolves to loopback instead of looping out through a reverse proxy.
+    /// </summary>
+    private string ApiBase =>
+        _origin.Length > 0 && string.Equals(Base, _origin.TrimEnd('/'), StringComparison.OrdinalIgnoreCase)
+            ? Local.BaseUrl.TrimEnd('/')
+            : Base;
+
+    private string _origin = "";
 
     private string TokenQuery(char sep) =>
         string.IsNullOrEmpty(_token) ? "" : $"{sep}token={Uri.EscapeDataString(_token)}";
@@ -222,7 +236,7 @@
     /// <summary>Authenticated GET; null on failure (401 also sets the sign-in notice).</summary>
     private async Task<T?> GetJsonAsync<T>(string path)
     {
-        var req = new HttpRequestMessage(HttpMethod.Get, $"{Base}{path}");
+        var req = new HttpRequestMessage(HttpMethod.Get, $"{ApiBase}{path}");
         if (!string.IsNullOrEmpty(_token))
             req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _token);
         using var res = await Http.SendAsync(req);

--- a/src/Neolink.WebClient/Models.cs
+++ b/src/Neolink.WebClient/Models.cs
@@ -42,6 +42,15 @@ public sealed record ApiEncodeProfile(string Type, uint Width, uint Height,
 /// <summary>GET /api/cameras/{name}/streaminfo — the encode profiles of each stream.</summary>
 public sealed record ApiStreamProfiles(List<ApiEncodeProfile> Profiles);
 
+/// <summary>
+/// The server's own loopback API address, injected by the host. Blazor circuits
+/// run SERVER-side: their HTTP calls must not go out through a reverse proxy's
+/// public URL (TLS/hairpin problems) when the target is this very server — they
+/// use this instead. Browser-side URLs (video WS, media elements) keep the page
+/// origin so they DO flow through the proxy.
+/// </summary>
+public sealed record LocalApiInfo(string BaseUrl);
+
 /// <summary>Server capability flags (GET /api/features).</summary>
 public sealed record ApiFeaturesInfo(bool Events, bool Continuous, double TrickleSpeed = 4,
     string? Version = null, string? LatestVersion = null, string? RepoUrl = null);

--- a/src/Neolink.WebClient/wwwroot/css/app.css
+++ b/src/Neolink.WebClient/wwwroot/css/app.css
@@ -707,6 +707,14 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
     font-weight: 600;
 }
 
+/* Hosts the card list plus the edge chevrons that page it */
+.strip-scroll-wrap {
+    position: relative;
+    display: flex;
+    flex: 1;
+    min-width: 0;
+}
+
 .events-bar-scroll {
     display: flex;
     align-items: stretch;
@@ -715,7 +723,47 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
     overflow-y: hidden;
     scrollbar-width: thin;
     flex: 1;
+    min-width: 0;
     padding: 2px 0;
+    scroll-behavior: smooth;
+}
+
+/* Edge chevrons: a gradient fade into the panel colour with a centered arrow,
+   shown only while there is content to scroll toward that side. */
+.strip-nav {
+    position: absolute;
+    top: 2px;
+    bottom: 12px; /* keep clear of the resize handle / scrollbar */
+    width: 44px;
+    z-index: 4;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    color: var(--text);
+    font-size: 16px;
+    display: flex;
+    align-items: center;
+    transition: opacity 0.18s ease;
+}
+
+.strip-nav-left {
+    left: 0;
+    justify-content: flex-start;
+    background: linear-gradient(to right, var(--panel) 30%, transparent);
+}
+
+.strip-nav-right {
+    right: 0;
+    justify-content: flex-end;
+    background: linear-gradient(to left, var(--panel) 30%, transparent);
+}
+
+.strip-nav { text-shadow: 0 1px 3px #000; }
+.strip-nav:hover { color: var(--accent); font-size: 18px; }
+
+.strip-nav-hidden {
+    opacity: 0;
+    pointer-events: none;
 }
 
 .event-card {

--- a/src/Neolink.WebClient/wwwroot/js/neolink.js
+++ b/src/Neolink.WebClient/wwwroot/js/neolink.js
@@ -300,6 +300,36 @@
     window.neolink = {
         freeInit,
 
+        // Review-strip edge chevrons: page the card list left/right with smooth
+        // scrolling and show each arrow only while there is content that way.
+        // Idempotent — called per render so visibility tracks card changes too.
+        stripNavInit(wrapId) {
+            const wrap = document.getElementById(wrapId);
+            if (!wrap) return;
+            const scroll = wrap.querySelector('.events-bar-scroll');
+            const left = wrap.querySelector('.strip-nav-left');
+            const right = wrap.querySelector('.strip-nav-right');
+            if (!scroll || !left || !right) return;
+
+            const sync = () => {
+                const max = scroll.scrollWidth - scroll.clientWidth;
+                const overflow = max > 4;
+                left.classList.toggle('strip-nav-hidden', !overflow || scroll.scrollLeft <= 4);
+                right.classList.toggle('strip-nav-hidden', !overflow || scroll.scrollLeft >= max - 4);
+            };
+
+            if (!wrap.dataset.navInit) {
+                wrap.dataset.navInit = '1';
+                const page = (dir) =>
+                    scroll.scrollBy({ left: dir * Math.max(180, scroll.clientWidth * 0.8), behavior: 'smooth' });
+                left.addEventListener('click', () => page(-1));
+                right.addEventListener('click', () => page(1));
+                scroll.addEventListener('scroll', sync, { passive: true });
+                new ResizeObserver(sync).observe(scroll);
+            }
+            sync();
+        },
+
         // Briefly flash a tile's border red — used when a camera the user picked
         // is already on screen (so we don't duplicate or clobber another tile).
         flashTile(id) {


### PR DESCRIPTION
## Fix: broken behind a TLS reverse proxy (HAProxy on OPNsense report)
The UI is **Blazor Server**: its API fetches run *inside* the container, not in the browser. With the Server API set to the page origin (the default), fronting the UI with a TLS proxy made the container dial back out to the proxy's public URL — which fails on the internal CA ("The SSL connection could not be established") or hairpin NAT. The page loaded but the camera list showed the SSL error.

**Fix — separate the paths**: the host injects its loopback address (`LocalApiInfo`, registered with the Blazor services), and both pages resolve their server-side fetch base through it:
- Own-origin addresses short-circuit to `http://127.0.0.1:{web_port}` (or the bind IP when bound to a specific interface) — the container never needs to reach its public URL.
- A genuinely remote Server API address is used as-is (pointing the UI at another Neolink instance still works).
- **Browser-side URLs deliberately keep the origin** — the live-video WebSocket, event clips/previews/thumbnails and recording segments load from the browser and must traverse the proxy with its certificate.

README gains a **"Behind a reverse proxy"** section: WebSocket upgrade needed for `/_blazor` + `/api/stream`, HAProxy `timeout tunnel` guidance, and the loopback behaviour.

## Review strip: edge scroll chevrons
❮ / ❯ buttons at both ends of the detection-card list make its scrollability obvious: each arrow shows only while there is content to scroll toward that side (scroll events + ResizeObserver + per-render sync), clicking pages by ~80% of the visible width with smooth scrolling, drawn over a gradient fade into the panel colour. All click/scroll handling stays in JS — no SignalR round-trips.

## Reviewer notes
- 21/21 self-tests.
- Verified in the browser: with the origin-matching default, cameras/events/auth all flow through the loopback path; chevron visibility verified correct at start/middle/end scroll positions with 9 real event cards. The smooth-scroll animation itself couldn't be observed in the hidden preview tab (rAF-throttled) — standard APIs, worth a glance on a real screen.
- The reporter's HAProxy setup needs no config change after this — the SSL error disappears because the container stops dialling its own public URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)