### PR TITLE
CI merge gate: web-API contract self-tests + GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: ci
+
+# Merge gate: every pull request (and every push to main) must build cleanly
+# and pass the built-in self-test suite (`neolink.net selftest` — protocol
+# codecs, config, recording, auth, MQTT, and the live web-API contract test).
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Build (warnings are errors)
+        run: dotnet build src/Neolink.Server/Neolink.Server.csproj -c Release -warnaserror -nologo
+
+      - name: Self-tests
+        run: dotnet src/Neolink.Server/bin/Release/net10.0/neolink.net.dll selftest

--- a/src/Neolink.Server/SelfTest.cs
+++ b/src/Neolink.Server/SelfTest.cs
@@ -578,6 +578,148 @@ public static class SelfTest
             }
         });
 
+        Test("loopback base for blazor circuits (reverse-proxy fix)", () =>
+        {
+            // Wildcard binds are not dialable — the circuit's own-server calls
+            // must go to plain loopback; a concrete bind address is used as-is.
+            AssertEq(Web.WebApi.LoopbackBase("0.0.0.0", 8655), "http://127.0.0.1:8655");
+            AssertEq(Web.WebApi.LoopbackBase("::", 8655), "http://127.0.0.1:8655");
+            AssertEq(Web.WebApi.LoopbackBase("[::]", 8655), "http://127.0.0.1:8655");
+            AssertEq(Web.WebApi.LoopbackBase("*", 8655), "http://127.0.0.1:8655");
+            AssertEq(Web.WebApi.LoopbackBase("192.168.1.10", 9000), "http://192.168.1.10:9000");
+        });
+
+        Test("update checker: release tag comparison", () =>
+        {
+            var chk = new Web.UpdateChecker("0.6.0");
+            Assert(chk.IsNewer("v0.7.0"), "newer tag detected");
+            Assert(chk.IsNewer("V1.0"), "capital V and two-part version accepted");
+            Assert(!chk.IsNewer("v0.6.0"), "same version is not an update");
+            Assert(!chk.IsNewer("0.5.9"), "older version is not an update");
+            Assert(!chk.IsNewer("not-a-version"), "junk tag ignored");
+        });
+
+        Test("web api: auth gate, token transports, endpoint contracts", () =>
+        {
+            // Boots the real HTTP API on an ephemeral loopback port (UI disabled)
+            // and exercises the contracts the web client binds to. This is the
+            // seam merges keep touching: the auth middleware and the JSON shapes.
+            var dir = Path.Combine(Path.GetTempPath(), $"neolink-selftest-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(dir);
+            using var cts = new CancellationTokenSource();
+            Task? server = null;
+            try
+            {
+                int port = FreeTcpPort();
+                var hub = new Streaming.StreamHub("apicam");
+                var cam = new Web.WebCameraInfo("apicam",
+                    new List<Web.WebStreamInfo> { new("mainStream", "/apicam/mainStream", hub) },
+                    new StubCameraControl("apicam"), PermittedUsers: null);
+                server = Web.WebApi.RunAsync(new Web.WebApiOptions
+                {
+                    BindAddr = "127.0.0.1",
+                    Port = port,
+                    WebUi = false,
+                    Cameras = new[] { cam },
+                    Users = new Dictionary<string, string>(),
+                    RtspPort = 8654,
+                    Events = new Recording.EventStore(Path.Combine(dir, "recordings")),
+                    RecordingSettings = new Recording.RecordingSettings(dir),
+                    UserStore = new Web.UserStore(dir),
+                    Version = "0.0.0-selftest",
+                    ConfigPath = Path.Combine(dir, "config.json"),
+                    RestartRequested = () => { },
+                }, cts.Token);
+
+                using var http = new HttpClient
+                {
+                    BaseAddress = new Uri($"http://127.0.0.1:{port}"),
+                    Timeout = TimeSpan.FromSeconds(10),
+                };
+
+                // Wait for Kestrel to accept; surface a startup crash immediately.
+                System.Text.Json.JsonElement features = default;
+                var deadline = DateTime.UtcNow.AddSeconds(15);
+                while (true)
+                {
+                    if (server.IsCompleted) server.GetAwaiter().GetResult();
+                    try { features = GetJson(http, "/api/features"); break; }
+                    catch when (DateTime.UtcNow < deadline) { Thread.Sleep(100); }
+                }
+
+                // Feature discovery — what ApiFeaturesInfo binds to.
+                Assert(features.GetProperty("events").GetBoolean(), "events feature on (store wired)");
+                AssertEq(features.GetProperty("version").GetString()!, "0.0.0-selftest");
+                Assert(features.TryGetProperty("trickleSpeed", out _), "trickleSpeed exposed");
+                AssertEq(features.GetProperty("repoUrl").GetString()!, Web.UpdateChecker.RepoUrl);
+
+                // Camera list — what ApiCamera/ApiStream bind to; open while no accounts exist.
+                var cams = GetJson(http, "/api/cameras");
+                AssertEq(cams.GetArrayLength(), 1);
+                AssertEq(cams[0].GetProperty("name").GetString()!, "apicam");
+                var stream = cams[0].GetProperty("streams")[0];
+                AssertEq(stream.GetProperty("kind").GetString()!, "mainStream");
+                AssertEq(stream.GetProperty("path").GetString()!, "/apicam/mainStream");
+                AssertEq(stream.GetProperty("rtspPort").GetInt32(), 8654);
+
+                // CORS preflight short-circuits (the web client may be served from anywhere).
+                using (var preflight = http.Send(new HttpRequestMessage(HttpMethod.Options, "/api/cameras")))
+                {
+                    AssertEq((int)preflight.StatusCode, 204);
+                    AssertEq(preflight.Headers.GetValues("Access-Control-Allow-Origin").First(), "*");
+                }
+
+                // First account = the admin; creating it turns authentication ON.
+                var setup = PostJson(http, "/api/auth/setup",
+                    """{"username":"admin","password":"correct horse"}""");
+                var token = setup.GetProperty("token").GetString()!;
+                Assert(setup.GetProperty("admin").GetBoolean(), "first account is the admin");
+                using (var again = PostRaw(http, "/api/auth/setup", """{"username":"x","password":"yyyyyyyy"}"""))
+                    AssertEq((int)again.StatusCode, 409); // setup is one-shot
+
+                // The gate: every /api route except the auth handshake now needs a session.
+                AssertEq((int)http.GetAsync("/api/cameras").Result.StatusCode, 401);
+                AssertEq((int)http.GetAsync("/api/features").Result.StatusCode, 401);
+                AssertEq((int)http.GetAsync("/api/auth/status").Result.StatusCode, 200);
+
+                // Both token transports authenticate: Bearer header (component fetches)
+                // and ?token= (media elements + the stream WebSocket, where headers can't go).
+                using (var req = new HttpRequestMessage(HttpMethod.Get, "/api/cameras"))
+                {
+                    req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+                    using var res = http.Send(req);
+                    AssertEq((int)res.StatusCode, 200);
+                }
+                var tokenQ = $"?token={Uri.EscapeDataString(token)}";
+                AssertEq((int)http.GetAsync($"/api/cameras{tokenQ}").Result.StatusCode, 200);
+                AssertEq((int)http.GetAsync($"/api/cameras{tokenQ}x").Result.StatusCode, 401); // tampered
+
+                // Login: wrong password rejected (401), right one issues a token.
+                using (var bad = PostRaw(http, "/api/auth/login", """{"username":"admin","password":"wrong horse"}"""))
+                    AssertEq((int)bad.StatusCode, 401);
+                var login = PostJson(http, "/api/auth/login", """{"username":"admin","password":"correct horse"}""");
+                Assert(login.GetProperty("token").GetString()!.Length > 20, "login issues a token");
+
+                // Per-camera recording switches round-trip through the API.
+                using (var req = new HttpRequestMessage(HttpMethod.Post, $"/api/cameras/apicam/recording{tokenQ}")
+                       { Content = new StringContent("""{"events":true}""", Encoding.UTF8, "application/json") })
+                using (var res = http.Send(req))
+                    AssertEq((int)res.StatusCode, 200);
+                var rec = GetJson(http, $"/api/cameras/apicam/recording{tokenQ}");
+                Assert(rec.GetProperty("events").GetBoolean(), "recording switch persisted via API");
+                Assert(rec.TryGetProperty("continuous", out _), "continuous switch exposed");
+
+                // Recorded-events listing responds (empty store).
+                AssertEq(GetJson(http, $"/api/events{tokenQ}").GetArrayLength(), 0);
+            }
+            finally
+            {
+                cts.Cancel();
+                try { server?.Wait(TimeSpan.FromSeconds(15)); } catch { }
+                try { Directory.Delete(dir, recursive: true); } catch { }
+            }
+        });
+
         if (rustRepoPath != null)
         {
             var bcSamples = Path.Combine(rustRepoPath, "crates", "core", "src", "bc", "samples");
@@ -727,6 +869,61 @@ public static class SelfTest
     }
 
     // ------------------------------------------------------------- helpers
+
+    private static int FreeTcpPort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static System.Text.Json.JsonElement GetJson(HttpClient http, string path)
+    {
+        using var res = http.GetAsync(path).GetAwaiter().GetResult();
+        res.EnsureSuccessStatusCode();
+        return System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(
+            res.Content.ReadAsStringAsync().GetAwaiter().GetResult());
+    }
+
+    private static HttpResponseMessage PostRaw(HttpClient http, string path, string json) =>
+        http.PostAsync(path, new StringContent(json, Encoding.UTF8, "application/json"))
+            .GetAwaiter().GetResult();
+
+    private static System.Text.Json.JsonElement PostJson(HttpClient http, string path, string json)
+    {
+        using var res = PostRaw(http, path, json);
+        res.EnsureSuccessStatusCode();
+        return System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(
+            res.Content.ReadAsStringAsync().GetAwaiter().GetResult());
+    }
+
+    /// <summary>An always-online camera that supports nothing — the API test only
+    /// needs a control surface to exist, not to do anything.</summary>
+    private sealed class StubCameraControl(string name) : Streaming.ICameraControl
+    {
+        public string CameraName => name;
+        public bool Online => true;
+        public bool CanSetStreamSettings => false;
+        public Task<Streaming.CameraCapabilities> GetCapabilitiesAsync(CancellationToken ct) =>
+            throw new NotSupportedException();
+        public Task<Bc.Xml.StreamInfoListXml?> GetStreamInfoAsync(CancellationToken ct) =>
+            Task.FromResult<Bc.Xml.StreamInfoListXml?>(null);
+        public Task SetStreamSettingsAsync(string stream, uint? width, uint? height,
+            uint? framerate, uint? bitrate, CancellationToken ct) => throw new NotSupportedException();
+        public Task<System.Xml.Linq.XElement?> GetBatteryInfoAsync(CancellationToken ct) =>
+            Task.FromResult<System.Xml.Linq.XElement?>(null);
+        public Task<byte[]?> SnapshotAsync(CancellationToken ct) => Task.FromResult<byte[]?>(null);
+        public Task<System.Xml.Linq.XElement?> GetLedStateAsync(CancellationToken ct) =>
+            Task.FromResult<System.Xml.Linq.XElement?>(null);
+        public Task SetLedStateAsync(string? state, string? lightState, CancellationToken ct) => Task.CompletedTask;
+        public Task<System.Xml.Linq.XElement?> GetPirStateAsync(CancellationToken ct) =>
+            Task.FromResult<System.Xml.Linq.XElement?>(null);
+        public Task SetPirEnabledAsync(bool enabled, CancellationToken ct) => Task.CompletedTask;
+        public Task PtzAsync(string command, float speed, CancellationToken ct) => Task.CompletedTask;
+        public Task RebootAsync(CancellationToken ct) => Task.CompletedTask;
+    }
 
     private static BcContext NewContext()
     {

--- a/src/Neolink.Server/Web/UpdateChecker.cs
+++ b/src/Neolink.Server/Web/UpdateChecker.cs
@@ -55,13 +55,17 @@ public sealed class UpdateChecker
         var tag = await FetchTagAsync(http, ct).ConfigureAwait(false);
         if (tag == null) return;
 
-        if (System.Version.TryParse(tag.TrimStart('v', 'V'), out var latest) && latest > _current)
+        if (IsNewer(tag))
         {
             if (_latest != tag)
                 Log.Info($"Update available: {tag} (running {_current}) — {RepoUrl}");
             _latest = tag;
         }
     }
+
+    /// <summary>True when the tag (with or without a leading v) parses and is strictly newer than the running version.</summary>
+    internal bool IsNewer(string tag) =>
+        System.Version.TryParse(tag.TrimStart('v', 'V'), out var latest) && latest > _current;
 
     private static async Task<string?> FetchTagAsync(HttpClient http, CancellationToken ct)
     {

--- a/src/Neolink.Server/Web/WebApi.cs
+++ b/src/Neolink.Server/Web/WebApi.cs
@@ -122,8 +122,7 @@ public static class WebApi
             builder.Services.AddSingleton(_ => new HttpClient { Timeout = TimeSpan.FromSeconds(5) });
             // Circuits must talk to THIS server via loopback, never back out through
             // a reverse proxy's public URL (TLS/hairpin failures behind HAProxy etc.).
-            var loopbackHost = bindAddr is "0.0.0.0" or "::" or "[::]" or "*" ? "127.0.0.1" : bindAddr;
-            builder.Services.AddSingleton(new Neolink.WebClient.LocalApiInfo($"http://{loopbackHost}:{port}"));
+            builder.Services.AddSingleton(new Neolink.WebClient.LocalApiInfo(LoopbackBase(bindAddr, port)));
         }
         var app = builder.Build();
 
@@ -962,6 +961,14 @@ public static class WebApi
         Log.Info($"  API:    http://{displayHost}:{port}/api/cameras" + (webUi ? "" : " (web UI disabled)"));
         await using var reg = ct.Register(() => app.Lifetime.StopApplication());
         await app.RunAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>The base URL the server's own Blazor circuits use to reach the API:
+    /// wildcard binds map to plain loopback, a concrete bind address is used as-is.</summary>
+    internal static string LoopbackBase(string bindAddr, int port)
+    {
+        var host = bindAddr is "0.0.0.0" or "::" or "[::]" or "*" ? "127.0.0.1" : bindAddr;
+        return $"http://{host}:{port}";
     }
 
     private static IStreamHub? FindHub(IReadOnlyList<WebCameraInfo> cameras, string? path)


### PR DESCRIPTION
## What

Adds a CI **merge gate** so a bad merge can't land silently, plus new self-tests covering the seams merges keep touching.

### GitHub Actions workflow (`.github/workflows/ci.yml`)
Runs on every pull request and every push to `main`:
1. `dotnet build -c Release -warnaserror` — warnings fail the check
2. `neolink.net.dll selftest` — any failing test exits non-zero and fails the check

(The existing `docker` workflow only runs *after* a merge lands; this one gates it.)

### New self-tests (21 → 24)

- **`web api: auth gate, token transports, endpoint contracts`** — boots the real HTTP API in-process on an ephemeral loopback port (UI disabled, stub camera, temp stores) and verifies over actual HTTP:
  - `/api/features` + `/api/cameras` JSON shapes — the exact fields the web client's `ApiFeaturesInfo`/`ApiCamera` records bind to (client/server contract drift is the classic silent merge casualty)
  - the auth gate: once an account exists, **every** `/api` route returns 401 without a session; only `/api/auth/*` stays public
  - both token transports (`Bearer` header and `?token=` for media elements/WS); tampered tokens rejected
  - one-shot setup (409 on second attempt), login (401 wrong / token right), per-camera recording switches POST→GET round-trip, CORS preflight
- **`loopback base for blazor circuits`** — locks in the reverse-proxy fix: wildcard binds (`0.0.0.0`, `::`, `[::]`, `*`) map to `127.0.0.1`; concrete addresses pass through
- **`update checker: release tag comparison`** — `v`-prefix handling, strictly-newer semantics, junk tags ignored

### Testability extractions (no behavior change)
- loopback URL builder → `WebApi.LoopbackBase(bindAddr, port)`
- tag comparison → `UpdateChecker.IsNewer(tag)`

Both are now called by the original code paths.

## Verification

- Release build clean with `-warnaserror` (0 warnings)
- `24 passed, 0 failed` on three consecutive runs (the exact commands CI executes)
- The API test adds ~0.5 s (starts/stops a real Kestrel server); full suite still runs in ~2 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)