### PR TITLE
Monitor/Logs pages: circuit fetches use loopback behind a reverse proxy

### DIFF
--- a/src/Neolink.WebClient/Components/Pages/Logs.razor
+++ b/src/Neolink.WebClient/Components/Pages/Logs.razor
@@ -2,6 +2,7 @@
 @using System.Text.Json
 @inject HttpClient Http
 @inject IJSRuntime JS
+@inject LocalApiInfo Local
 @implements IAsyncDisposable
 
 @* Full-page live tail of the server log (admin only). The lines are appended
@@ -58,6 +59,7 @@
     private static readonly string[] LogLevelChips = { "DBG", "INF", "WRN", "ERR" };
 
     private string _server = "";
+    private string _origin = "";
     private string? _token;
     private bool _checked;      // auth status fetched (before that, render nothing judgmental)
     private bool _authEnabled;
@@ -73,6 +75,8 @@
             if (_admin && !_attached)
             {
                 _attached = true;
+                // This URL is fetched by the BROWSER (neolink.js), not the circuit —
+                // it keeps the page origin so it flows through any reverse proxy.
                 var url = $"{_server.TrimEnd('/')}/api/system/logs" +
                           (string.IsNullOrEmpty(_token) ? "" : $"?token={Uri.EscapeDataString(_token)}");
                 await JS.InvokeVoidAsync("neolink.logsAttach", "logs-view", url);
@@ -94,12 +98,13 @@
             }
         }
         catch { }
+        try { _origin = await JS.InvokeAsync<string>("neolink.defaultServer"); } catch { }
         if (string.IsNullOrWhiteSpace(_server))
-            _server = await JS.InvokeAsync<string>("neolink.defaultServer");
+            _server = _origin;
 
         try
         {
-            var req = new HttpRequestMessage(HttpMethod.Get, $"{_server.TrimEnd('/')}/api/auth/status");
+            var req = new HttpRequestMessage(HttpMethod.Get, $"{ApiBase}/api/auth/status");
             if (!string.IsNullOrEmpty(_token))
                 req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _token);
             using var res = await Http.SendAsync(req);
@@ -114,6 +119,14 @@
         _checked = true;
         StateHasChanged();
     }
+
+    /// <summary>Where the auth-status fetch goes. It runs SERVER-side (Blazor circuit),
+    /// so when the configured server is the page's own origin it uses loopback
+    /// instead of dialing back out through a reverse proxy's public URL.</summary>
+    private string ApiBase => _origin.Length > 0
+        && string.Equals(_server.TrimEnd('/'), _origin.TrimEnd('/'), StringComparison.OrdinalIgnoreCase)
+        ? Local.BaseUrl.TrimEnd('/')
+        : _server.TrimEnd('/');
 
     private void ToggleLevel(string lvl)
     {

--- a/src/Neolink.WebClient/Components/Pages/Monitor.razor
+++ b/src/Neolink.WebClient/Components/Pages/Monitor.razor
@@ -3,6 +3,7 @@
 @using System.Text.Json
 @inject HttpClient Http
 @inject IJSRuntime JS
+@inject LocalApiInfo Local
 @implements IAsyncDisposable
 
 @* Live resource monitor: the backend (Neolink.Server process + storage disk)
@@ -181,6 +182,7 @@
     private static readonly (string Label, int Sec)[] Windows = { ("5m", 300), ("15m", 900), ("1h", 3600) };
 
     private string _server = "";
+    private string _origin = "";
     private string? _token;
     private string? _error;
     private bool _supported = true;
@@ -202,6 +204,14 @@
 
     private ApiSystemSample? Last => _samples.Count > 0 ? _samples[^1] : null;
 
+    /// <summary>Where this page's fetches go. They run SERVER-side (Blazor circuit),
+    /// so when the configured server is the page's own origin they use loopback
+    /// instead of dialing back out through a reverse proxy's public URL.</summary>
+    private string ApiBase => _origin.Length > 0
+        && string.Equals(_server.TrimEnd('/'), _origin.TrimEnd('/'), StringComparison.OrdinalIgnoreCase)
+        ? Local.BaseUrl.TrimEnd('/')
+        : _server.TrimEnd('/');
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (!firstRender) return;
@@ -220,8 +230,9 @@
             }
         }
         catch { }
+        try { _origin = await JS.InvokeAsync<string>("neolink.defaultServer"); } catch { }
         if (string.IsNullOrWhiteSpace(_server))
-            _server = await JS.InvokeAsync<string>("neolink.defaultServer");
+            _server = _origin;
 
         await JS.InvokeVoidAsync("neolink.perfStart");
         _perfStarted = true;
@@ -257,7 +268,7 @@
         try
         {
             long after = Last?.T ?? 0;
-            var req = new HttpRequestMessage(HttpMethod.Get, $"{_server.TrimEnd('/')}/api/system/stats?after={after}");
+            var req = new HttpRequestMessage(HttpMethod.Get, $"{ApiBase}/api/system/stats?after={after}");
             if (!string.IsNullOrEmpty(_token))
                 req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _token);
             using var res = await Http.SendAsync(req);
@@ -282,7 +293,7 @@
         }
         catch (Exception ex)
         {
-            _error = _samples.Count == 0 ? $"Cannot reach {_server}: {ex.Message}" : _error;
+            _error = _samples.Count == 0 ? $"Cannot reach {ApiBase}: {ex.Message}" : _error;
         }
     }
 
@@ -290,7 +301,7 @@
     {
         try
         {
-            var req = new HttpRequestMessage(HttpMethod.Get, $"{_server.TrimEnd('/')}/api/auth/status");
+            var req = new HttpRequestMessage(HttpMethod.Get, $"{ApiBase}/api/auth/status");
             if (!string.IsNullOrEmpty(_token))
                 req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _token);
             using var res = await Http.SendAsync(req);


### PR DESCRIPTION
## What

Fixes the system monitor (and the logs page) failing behind HAProxy with:

> Cannot reach https://neolink.example: The SSL connection could not be established, see inner exception.

The reverse-proxy fix (circuits call loopback, not the public URL) covered **Home** and **Timeline** but missed **Monitor** and **Logs**. Their fetches run server-side on the Blazor circuit, so behind a reverse proxy they dialed the proxy's public `https://` URL from inside the server and died on the internal TLS cert.

## How

Same pattern as Timeline — both pages inject `LocalApiInfo` and resolve an `ApiBase`:

- when the configured server equals the page origin, circuit fetches go to the server's own loopback address
- a genuinely remote server address is used as-is

Applied to Monitor's `/api/system/stats` poll + `/api/auth/status` check, and Logs' `/api/auth/status` check.

**Deliberately not changed:** the logs page's live-tail URL (`/api/system/logs`) stays on the page origin — that request is made by the **browser** (`neolink.js` `logsAttach`), so it must flow through the proxy. There's now a comment on it so a future change doesn't "fix" it.

Also: Monitor's "Cannot reach …" message now names the address actually dialed, so the next failure report points at the real target.

## Verification

- Ran the server and loaded `/monitor` both ways: server configured as a non-origin address (direct branch) and as the origin default (loopback branch) — all 11 stat tiles rendered live in both, no error, uptime ticking
- `/logs` rendered its post-auth-check notice, proving its circuit fetch completed
- Swept the client for other direct `_server` fetches: CameraPanel already receives the resolved base from Home; the remaining uses are browser-side media URLs that are correct as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)