### PR TITLE
Web UI: AAC audio end to end, digital zoom, strip drag-scroll, Esc closes pop-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ The cameras are unmodified and no Reolink NVR is required.
 **Web UI (optional, built in)**
 - Live video in the browser via **fMP4 over WebSocket + Media Source Extensions** —
   ~1 s latency, no plugins, no ffmpeg
+- **Live audio** for cameras with AAC sound: streams start muted (browser autoplay
+  rules), a speaker button on the tile/quick-view unmutes; event clips and 24/7
+  recordings carry the audio track too. ADPCM-only cameras play audio via RTSP only
+  (browsers can't decode raw PCM in MP4)
 - Camera wall with five layout modes: **Grid** (1–16 tiles), **Focus** (hero + thumbnail
   strip, click to promote), **Mosaic** (classic CCTV wall), **Theater** (one camera,
   center stage), **Free** (draggable, resizable floating windows)

--- a/src/Neolink.Server/Media/FMp4.cs
+++ b/src/Neolink.Server/Media/FMp4.cs
@@ -7,15 +7,25 @@ using System.Text;
 namespace Neolink.Media;
 
 /// <summary>
-/// Minimal fragmented-MP4 (fMP4/CMAF-style) muxer for live H.264/H.265 video,
-/// suitable for browser Media Source Extensions. One video track, one sample
-/// per fragment (lowest latency). Timescale is the RTP video clock (90 kHz).
+/// Minimal fragmented-MP4 (fMP4/CMAF-style) muxer for live H.264/H.265 video
+/// plus optional AAC audio, suitable for browser Media Source Extensions.
+/// Track 1 is video (timescale = the RTP video clock, 90 kHz), track 2 — when
+/// the camera has AAC audio — runs on the audio sample rate. One sample per
+/// fragment (lowest latency). ADPCM cameras get no MP4 audio track: browsers
+/// can't play raw PCM via MSE, so their audio is RTSP-only.
 /// </summary>
 public static class FMp4
 {
     public const uint Timescale = 90_000;
+    public const uint AudioTrackId = 2;
+    /// <summary>An AAC access unit is always exactly 1024 samples.</summary>
+    public const uint AacSamplesPerAu = 1024;
 
     // ------------------------------------------------------------------ public API
+
+    /// <summary>MSE codec string for an AAC track, e.g. mp4a.40.2 (AAC-LC).</summary>
+    public static string AacCodecString(byte[] audioSpecificConfig) =>
+        $"mp4a.40.{(audioSpecificConfig.Length > 0 ? audioSpecificConfig[0] >> 3 : 2)}";
 
     /// <summary>MIME codec string for MSE, e.g. avc1.64001F or hvc1.1.6.L153.B0.</summary>
     public static string CodecString(VideoCodec codec, byte[] sps)
@@ -36,10 +46,16 @@ public static class FMp4
         return $"hvc1.{profileIdc}.{reversed:X}.{(highTier ? 'H' : 'L')}{level}.B0";
     }
 
-    /// <summary>Builds ftyp + moov (the MSE initialization segment).</summary>
-    public static byte[] BuildInit(VideoCodec codec, byte[] sps, byte[] pps, byte[]? vps, uint width, uint height)
+    /// <summary>
+    /// Builds ftyp + moov (the MSE initialization segment). When
+    /// <paramref name="aacConfig"/> is given, a second (AAC audio) track is
+    /// declared with the audio sample rate as its timescale.
+    /// </summary>
+    public static byte[] BuildInit(VideoCodec codec, byte[] sps, byte[] pps, byte[]? vps, uint width, uint height,
+        byte[]? aacConfig = null, int aacRate = 0, int aacChannels = 0)
     {
         var w = new Mp4Writer();
+        bool audio = aacConfig != null && aacRate > 0;
 
         using (w.Box("ftyp"))
         {
@@ -60,7 +76,7 @@ public static class FMp4
                 w.U16(0); w.U32(0); w.U32(0);
                 WriteIdentityMatrix(w);
                 for (int i = 0; i < 6; i++) w.U32(0); // pre_defined
-                w.U32(2);              // next_track_ID
+                w.U32(audio ? 3u : 2u); // next_track_ID
             }
 
             using (w.Box("trak"))
@@ -124,22 +140,39 @@ public static class FMp4
                 }
             }
 
+            if (audio)
+                WriteAudioTrak(w, aacConfig!, aacRate, aacChannels);
+
             using (w.Box("mvex"))
-            using (w.FullBox("trex", 0, 0))
             {
-                w.U32(1);            // track ID
-                w.U32(1);            // default sample description index
-                w.U32(0);            // default sample duration
-                w.U32(0);            // default sample size
-                w.U32(0x01010000);   // default flags: non-sync sample
+                using (w.FullBox("trex", 0, 0))
+                {
+                    w.U32(1);            // track ID
+                    w.U32(1);            // default sample description index
+                    w.U32(0);            // default sample duration
+                    w.U32(0);            // default sample size
+                    w.U32(0x01010000);   // default flags: non-sync sample
+                }
+                if (audio)
+                {
+                    using (w.FullBox("trex", 0, 0))
+                    {
+                        w.U32(AudioTrackId);
+                        w.U32(1);
+                        w.U32(0);
+                        w.U32(0);
+                        w.U32(0x02000000); // default flags: sync sample (all AAC AUs are)
+                    }
+                }
             }
         }
 
         return w.ToArray();
     }
 
-    /// <summary>Builds one moof + mdat fragment containing a single video sample.</summary>
-    public static byte[] BuildFragment(uint sequence, ulong decodeTime, uint duration, byte[] sample, bool keyframe)
+    /// <summary>Builds one moof + mdat fragment containing a single sample (video or audio).</summary>
+    public static byte[] BuildFragment(uint sequence, ulong decodeTime, uint duration, byte[] sample, bool keyframe,
+        uint trackId = 1)
     {
         var w = new Mp4Writer();
         int trunDataOffsetPos;
@@ -152,7 +185,7 @@ public static class FMp4
             using (w.Box("traf"))
             {
                 using (w.FullBox("tfhd", 0, 0x020000)) // default-base-is-moof
-                    w.U32(1);                          // track ID
+                    w.U32(trackId);
                 using (w.FullBox("tfdt", 1, 0))
                     w.U64(decodeTime);
                 // trun flags: data-offset | first-sample-flags | sample-duration | sample-size
@@ -281,6 +314,117 @@ public static class FMp4
             pos += 4 + nal.Length;
         }
         return result;
+    }
+
+    // ------------------------------------------------------------------ audio track
+
+    private static void WriteAudioTrak(Mp4Writer w, byte[] asc, int rate, int channels)
+    {
+        using (w.Box("trak"))
+        {
+            using (w.FullBox("tkhd", 0, 7)) // enabled | in movie | in preview
+            {
+                w.U32(0); w.U32(0);   // times
+                w.U32(AudioTrackId);
+                w.U32(0);             // reserved
+                w.U32(0);             // duration
+                w.U32(0); w.U32(0);   // reserved
+                w.U16(0); w.U16(0);   // layer, alternate group
+                w.U16(0x0100);        // volume 1.0 (audio track)
+                w.U16(0);             // reserved
+                WriteIdentityMatrix(w);
+                w.U32(0); w.U32(0);   // width/height (audio = 0)
+            }
+
+            using (w.Box("mdia"))
+            {
+                using (w.FullBox("mdhd", 0, 0))
+                {
+                    w.U32(0); w.U32(0);
+                    w.U32((uint)rate);  // timescale = sample rate
+                    w.U32(0);           // duration
+                    w.U16(0x55C4);      // language "und"
+                    w.U16(0);
+                }
+                using (w.FullBox("hdlr", 0, 0))
+                {
+                    w.U32(0);
+                    w.Tag("soun");
+                    w.U32(0); w.U32(0); w.U32(0);
+                    w.Bytes(Encoding.ASCII.GetBytes("Neolink.NET Audio\0"));
+                }
+                using (w.Box("minf"))
+                {
+                    using (w.FullBox("smhd", 0, 0))
+                    {
+                        w.U16(0); // balance
+                        w.U16(0);
+                    }
+                    using (w.Box("dinf"))
+                    using (w.FullBox("dref", 0, 0))
+                    {
+                        w.U32(1);
+                        using (w.FullBox("url ", 0, 1)) { } // self-contained
+                    }
+                    using (w.Box("stbl"))
+                    {
+                        using (w.FullBox("stsd", 0, 0))
+                        {
+                            w.U32(1);
+                            WriteAudioSampleEntry(w, asc, rate, channels);
+                        }
+                        using (w.FullBox("stts", 0, 0)) w.U32(0);
+                        using (w.FullBox("stsc", 0, 0)) w.U32(0);
+                        using (w.FullBox("stsz", 0, 0)) { w.U32(0); w.U32(0); }
+                        using (w.FullBox("stco", 0, 0)) w.U32(0);
+                    }
+                }
+            }
+        }
+    }
+
+    private static void WriteAudioSampleEntry(Mp4Writer w, byte[] asc, int rate, int channels)
+    {
+        using (w.Box("mp4a"))
+        {
+            for (int i = 0; i < 6; i++) w.U8(0);   // reserved
+            w.U16(1);                              // data reference index
+            w.U32(0); w.U32(0);                    // reserved
+            w.U16((ushort)Math.Max(channels, 1));
+            w.U16(16);                             // sample size (bits)
+            w.U16(0); w.U16(0);                    // pre_defined, reserved
+            w.U32((uint)rate << 16);               // sample rate, 16.16 fixed point
+
+            // esds: the MPEG-4 descriptor chain that carries the
+            // AudioSpecificConfig — decoders refuse mp4a without it.
+            using (w.FullBox("esds", 0, 0))
+            {
+                int dsiLen = asc.Length;
+                int dcdLen = 13 + 2 + dsiLen;      // DecoderConfig + nested DSI
+                int esLen = 3 + 2 + dcdLen + 3;    // ES header + DCD + SLConfig
+
+                w.U8(0x03);                        // ES_Descriptor
+                w.U8((byte)esLen);
+                w.U16((ushort)AudioTrackId);       // ES_ID
+                w.U8(0);                           // flags
+
+                w.U8(0x04);                        // DecoderConfigDescriptor
+                w.U8((byte)dcdLen);
+                w.U8(0x40);                        // objectTypeIndication: MPEG-4 Audio
+                w.U8(0x15);                        // streamType audio (0x05<<2 | 1)
+                w.U8(0); w.U16(0);                 // bufferSizeDB (24-bit)
+                w.U32(0);                          // maxBitrate (unknown)
+                w.U32(0);                          // avgBitrate (unknown)
+
+                w.U8(0x05);                        // DecoderSpecificInfo
+                w.U8((byte)dsiLen);
+                w.Bytes(asc);
+
+                w.U8(0x06);                        // SLConfigDescriptor
+                w.U8(1);
+                w.U8(0x02);                        // MP4 predefined
+            }
+        }
     }
 
     // ------------------------------------------------------------------ codec boxes

--- a/src/Neolink.Server/Recording/ClipWriter.cs
+++ b/src/Neolink.Server/Recording/ClipWriter.cs
@@ -10,11 +10,12 @@ using Neolink.Streaming;
 namespace Neolink.Recording;
 
 /// <summary>
-/// Writes hub video packets into a fragmented-MP4 file (playable by browsers and
+/// Writes hub media packets into a fragmented-MP4 file (playable by browsers and
 /// ffmpeg alike). Same pacing trick as the live web player: a camera buffer's true
 /// duration is only known when the NEXT buffer arrives (RTP delta), so one buffer
 /// is held back and its measured delta spread evenly across its frames.
-/// Video-only by design — detection clips don't need the audio track.
+/// AAC audio is recorded as track 2 when the camera has it; ADPCM cameras record
+/// video-only (raw PCM in MP4 is unplayable in browsers).
 ///
 /// Disk I/O is fully decoupled from the caller: fragments are muxed on the
 /// caller's thread but written by a dedicated background thread (below-normal
@@ -54,6 +55,12 @@ public sealed class ClipWriter : IDisposable
     private int _dropped;
     private bool _disposed;
 
+    // Audio (AAC track 2) mux state — same producer thread.
+    private readonly int _audioRate; // 0 = no audio track in this file
+    private long _audioDecodeTime;   // sample-rate ticks; Volatile.Read on the writer thread
+    private uint _prevAudioTs;
+    private bool _haveAudioTs;
+
     // Shared with the writer thread.
     private long _queuedBytes;
     private long _approxBytes; // cumulative bytes destined for the file (size-cap roll)
@@ -61,10 +68,11 @@ public sealed class ClipWriter : IDisposable
 
     private readonly record struct QueueItem(byte[] Data, bool Keyframe, ulong DecodeTime);
 
-    private ClipWriter(string path, VideoCodec codec, byte[] init)
+    private ClipWriter(string path, VideoCodec codec, byte[] init, int audioRate)
     {
         _path = path;
         _codec = codec;
+        _audioRate = audioRate;
         _approxBytes = init.Length; // the init segment is already on its way to disk
         var boxes = FindHeaderBoxes(init);
         new Thread(() => WriteLoop(init, boxes))
@@ -96,8 +104,10 @@ public sealed class ClipWriter : IDisposable
         var pps = hub.Pps;
         if (codec == null || sps == null || pps == null)
             return null;
-        var init = FMp4.BuildInit(codec.Value, sps, pps, hub.Vps, hub.Width, hub.Height);
-        return new ClipWriter(path, codec.Value, init);
+        var audio = hub.Audio is { IsAac: true, AudioSpecificConfig: not null } a ? a : null;
+        var init = FMp4.BuildInit(codec.Value, sps, pps, hub.Vps, hub.Width, hub.Height,
+            audio?.AudioSpecificConfig, audio?.SampleRate ?? 0, audio?.Channels ?? 0);
+        return new ClipWriter(path, codec.Value, init, audio?.SampleRate ?? 0);
     }
 
     /// <summary>
@@ -135,6 +145,27 @@ public sealed class ClipWriter : IDisposable
         var aus = FMp4.SplitAccessUnits(_codec, v.AnnexB);
         if (aus.Count > 0)
             _pending = aus;
+    }
+
+    /// <summary>
+    /// Feeds one AAC access unit (hub order, same producer thread as
+    /// <see cref="Add"/>). Ignored while the clip still waits for its first video
+    /// keyframe, so both tracks start on the same instant. The decode-time advance
+    /// comes from the RTP delta: dropped packets shift the timeline instead of
+    /// desyncing it.
+    /// </summary>
+    public void AddAudio(HubAudioAac aac)
+    {
+        if (_audioRate == 0 || _waitKeyframe) return;
+        if (_haveAudioTs)
+        {
+            uint d = unchecked(aac.RtpTs - _prevAudioTs);
+            _audioDecodeTime += (d > 0 && d < 30u * (uint)_audioRate) ? d : FMp4.AacSamplesPerAu;
+        }
+        _prevAudioTs = aac.RtpTs;
+        _haveAudioTs = true;
+        Enqueue(FMp4.BuildFragment(_sequence++, (ulong)_audioDecodeTime, FMp4.AacSamplesPerAu, aac.Au,
+            keyframe: true, trackId: FMp4.AudioTrackId), keyframe: false, 0);
     }
 
     private void FlushPending(uint totalDuration)
@@ -206,7 +237,7 @@ public sealed class ClipWriter : IDisposable
 
     // ------------------------------------------------------------------ writer thread
 
-    private void WriteLoop(byte[] init, Dictionary<string, int> boxes)
+    private void WriteLoop(byte[] init, Dictionary<string, List<int>> boxes)
     {
         FileStream? file = null;
         bool failed = false;
@@ -265,17 +296,26 @@ public sealed class ClipWriter : IDisposable
     }
 
     /// <summary>Backfills the total duration into the init-segment headers.</summary>
-    private void PatchDurations(FileStream file, Dictionary<string, int> boxes)
+    private void PatchDurations(FileStream file, Dictionary<string, List<int>> boxes)
     {
         ulong decodeTime = (ulong)Volatile.Read(ref _decodeTime);
         if (decodeTime == 0) return;
-        // mvhd/tkhd run on the movie timescale (1000 = ms), mdhd on the media
-        // timescale (90 kHz). All are version-0 boxes, i.e. 32-bit durations.
+        // mvhd/tkhd run on the movie timescale (1000 = ms); each mdhd runs on its
+        // own media timescale (track 1: 90 kHz, track 2: the audio sample rate).
+        // All are version-0 boxes, i.e. 32-bit durations. Tracks appear in the
+        // init in ID order, so the box lists line up: [0]=video, [1]=audio.
         uint ms = (uint)Math.Min(uint.MaxValue, decodeTime * 1000 / FMp4.Timescale);
         uint ticks = (uint)Math.Min(uint.MaxValue, decodeTime);
-        if (boxes.TryGetValue("mvhd", out var mvhd)) WriteU32At(file, mvhd + 24, ms);
-        if (boxes.TryGetValue("tkhd", out var tkhd)) WriteU32At(file, tkhd + 28, ms);
-        if (boxes.TryGetValue("mdhd", out var mdhd)) WriteU32At(file, mdhd + 24, ticks);
+        if (boxes.TryGetValue("mvhd", out var mvhd)) WriteU32At(file, mvhd[0] + 24, ms);
+        if (boxes.TryGetValue("tkhd", out var tkhds))
+            foreach (var tkhd in tkhds) WriteU32At(file, tkhd + 28, ms);
+        if (boxes.TryGetValue("mdhd", out var mdhds))
+        {
+            WriteU32At(file, mdhds[0] + 24, ticks);
+            if (mdhds.Count > 1)
+                WriteU32At(file, mdhds[1] + 24,
+                    (uint)Math.Min(uint.MaxValue, (ulong)Volatile.Read(ref _audioDecodeTime) + FMp4.AacSamplesPerAu));
+        }
         file.Seek(0, SeekOrigin.End);
     }
 
@@ -329,10 +369,11 @@ public sealed class ClipWriter : IDisposable
         file.Write(buf);
     }
 
-    /// <summary>Absolute offsets of the duration-carrying boxes inside the init segment.</summary>
-    private static Dictionary<string, int> FindHeaderBoxes(byte[] init)
+    /// <summary>Absolute offsets of the duration-carrying boxes inside the init
+    /// segment, in file order (one tkhd/mdhd per track).</summary>
+    private static Dictionary<string, List<int>> FindHeaderBoxes(byte[] init)
     {
-        var found = new Dictionary<string, int>();
+        var found = new Dictionary<string, List<int>>();
         Walk(0, init.Length);
         return found;
 
@@ -343,7 +384,8 @@ public sealed class ClipWriter : IDisposable
                 uint size = BinaryPrimitives.ReadUInt32BigEndian(init.AsSpan(pos));
                 if (size < 8 || pos + size > (uint)end) return;
                 var type = Encoding.ASCII.GetString(init, pos + 4, 4);
-                if (type is "mvhd" or "tkhd" or "mdhd") found[type] = pos;
+                if (type is "mvhd" or "tkhd" or "mdhd")
+                    (found.TryGetValue(type, out var list) ? list : found[type] = new()).Add(pos);
                 if (type is "moov" or "trak" or "mdia") Walk(pos + 8, pos + (int)size);
                 pos += (int)size;
             }

--- a/src/Neolink.Server/Recording/ContinuousRecorder.cs
+++ b/src/Neolink.Server/Recording/ContinuousRecorder.cs
@@ -97,6 +97,14 @@ public sealed class ContinuousRecorder
                 // Hub indices are global across video and audio — see EventRecorder.
                 bool gap = lastIndex >= 0 && packet.Index != lastIndex + 1;
                 lastIndex = packet.Index;
+
+                // AAC audio rides into the open segment; everything that decides the
+                // segment's lifecycle (on/off, roll, create) stays video-driven.
+                if (packet is HubAudioAac aac)
+                {
+                    writer?.AddAudio(aac);
+                    continue;
+                }
                 if (packet is not HubVideo v) continue;
 
                 bool on = _settings.Get(_camera).Continuous;

--- a/src/Neolink.Server/Recording/EventRecorder.cs
+++ b/src/Neolink.Server/Recording/EventRecorder.cs
@@ -44,8 +44,8 @@ public sealed class EventRecorder
     // records the sub stream into preview.mp4 alongside the full clip — that's
     // what the review strip's ambient players use, keeping client decode cheap.
     private readonly object _mediaGate = new();
-    private readonly List<(HubVideo Video, bool Gap)> _preroll = new();
-    private readonly List<(HubVideo Video, bool Gap)> _previewPreroll = new();
+    private readonly List<(HubPacket Packet, bool Gap)> _preroll = new();
+    private readonly List<(HubPacket Packet, bool Gap)> _previewPreroll = new();
     private ClipWriter? _writer;
     private ClipWriter? _previewWriter;
     /// <summary>The hub the record pump is subscribed to RIGHT NOW — clips must
@@ -145,12 +145,13 @@ public sealed class EventRecorder
 
                         bool gap = lastIndex >= 0 && packet.Index != lastIndex + 1;
                         lastIndex = packet.Index;
-                        if (packet is not HubVideo v) continue;
+                        if (packet is not HubVideo and not HubAudioAac) continue;
                         lock (_mediaGate)
                         {
                             if (_writer != null)
                             {
-                                _writer.Add(v, gap);
+                                if (packet is HubVideo v) _writer.Add(v, gap);
+                                else _writer.AddAudio((HubAudioAac)packet);
                                 if (_writer.Faulted)
                                 {
                                     Log.Warn($"{_camera}: clip writer failed; event continues without further video");
@@ -160,8 +161,8 @@ public sealed class EventRecorder
                             }
                             else
                             {
-                                _preroll.Add((v, gap));
-                                TrimPreroll(_preroll);
+                                _preroll.Add((packet, gap));
+                                if (packet is HubVideo) TrimPreroll(_preroll);
                             }
                         }
                     }
@@ -202,7 +203,7 @@ public sealed class EventRecorder
                 bool gap = lastIndex >= 0 && packet.Index != lastIndex + 1;
                 lastIndex = packet.Index;
 
-                if (packet is not HubVideo v) continue;
+                if (packet is not HubVideo and not HubAudioAac) continue;
                 lock (_mediaGate)
                 {
                     var writer = preview ? _previewWriter : _writer;
@@ -210,7 +211,8 @@ public sealed class EventRecorder
                     {
                         // Add never blocks on disk (background writer thread); a dead
                         // disk surfaces as Faulted and the event continues clip-less.
-                        writer.Add(v, gap);
+                        if (packet is HubVideo v) writer.Add(v, gap);
+                        else writer.AddAudio((HubAudioAac)packet);
                         if (writer.Faulted)
                         {
                             Log.Warn($"{_camera}: {(preview ? "preview" : "clip")} writer failed; " +
@@ -223,8 +225,8 @@ public sealed class EventRecorder
                     else
                     {
                         var buffer = preview ? _previewPreroll : _preroll;
-                        buffer.Add((v, gap));
-                        TrimPreroll(buffer);
+                        buffer.Add((packet, gap));
+                        if (packet is HubVideo) TrimPreroll(buffer);
                     }
                 }
             }
@@ -239,17 +241,18 @@ public sealed class EventRecorder
     /// <summary>
     /// Keeps a pre-roll spanning at least PreSeconds while starting on a keyframe
     /// (a clip must begin decodable): drop everything before the latest keyframe
-    /// that still preserves the wanted span.
+    /// that still preserves the wanted span. Only called right after a VIDEO
+    /// packet was appended; interleaved audio is trimmed along with its video.
     /// </summary>
-    private void TrimPreroll(List<(HubVideo Video, bool Gap)> buffer)
+    private void TrimPreroll(List<(HubPacket Packet, bool Gap)> buffer)
     {
         uint want = (uint)_cfg.PreSeconds * FMp4.Timescale;
-        uint last = buffer[^1].Video.RtpTs;
+        uint last = ((HubVideo)buffer[^1].Packet).RtpTs;
         int cut = -1;
         for (int i = buffer.Count - 1; i >= 0; i--)
         {
-            if (!buffer[i].Video.Keyframe) continue;
-            if (unchecked(last - buffer[i].Video.RtpTs) >= want)
+            if (buffer[i].Packet is not HubVideo { Keyframe: true } kv) continue;
+            if (unchecked(last - kv.RtpTs) >= want)
             {
                 cut = i;
                 break;
@@ -258,8 +261,8 @@ public sealed class EventRecorder
         if (cut > 0)
             buffer.RemoveRange(0, cut);
         // Safety valve for streams with pathological keyframe intervals.
-        if (buffer.Count > 4096)
-            buffer.RemoveRange(0, buffer.Count - 4096);
+        if (buffer.Count > 8192)
+            buffer.RemoveRange(0, buffer.Count - 8192);
     }
 
     // ------------------------------------------------------------------ event lifecycle
@@ -381,8 +384,13 @@ public sealed class EventRecorder
                 }
                 else
                 {
-                    foreach (var (v, gap) in _preroll)
-                        _writer.Add(v, gap);
+                    // Audio before the first keyframe is ignored by the writer,
+                    // so both tracks start on the same instant.
+                    foreach (var (p, gap) in _preroll)
+                    {
+                        if (p is HubVideo v) _writer.Add(v, gap);
+                        else if (p is HubAudioAac a) _writer.AddAudio(a);
+                    }
                     _preroll.Clear();
                 }
             }
@@ -401,8 +409,11 @@ public sealed class EventRecorder
                     _previewWriter = ClipWriter.TryCreate(Path.Combine(_store.EventDir(rec), "preview.mp4"), _previewHub);
                     if (_previewWriter != null)
                     {
-                        foreach (var (v, gap) in _previewPreroll)
-                            _previewWriter.Add(v, gap);
+                        foreach (var (p, gap) in _previewPreroll)
+                        {
+                            if (p is HubVideo v) _previewWriter.Add(v, gap);
+                            else if (p is HubAudioAac a) _previewWriter.AddAudio(a);
+                        }
                         _previewPreroll.Clear();
                     }
                 }

--- a/src/Neolink.Server/SelfTest.cs
+++ b/src/Neolink.Server/SelfTest.cs
@@ -578,6 +578,89 @@ public static class SelfTest
             }
         });
 
+        Test("clip writer muxes an AAC audio track", () =>
+        {
+            var dir = Path.Combine(Path.GetTempPath(), $"neolink-selftest-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(dir);
+            try
+            {
+                var hub = new Streaming.StreamHub("audiotest");
+                byte[] Nal(byte type, int len)
+                {
+                    var nal = new byte[len];
+                    Array.Fill(nal, (byte)0xAA);
+                    nal[0] = type;
+                    nal[1] = 0x80;
+                    return nal;
+                }
+                byte[] Au(params byte[][] nals)
+                {
+                    var ms = new MemoryStream();
+                    foreach (var n in nals)
+                    {
+                        ms.Write(new byte[] { 0, 0, 0, 1 });
+                        ms.Write(n);
+                    }
+                    return ms.ToArray();
+                }
+                var sps = new byte[] { 0x67, 0x42, 0xE0, 0x1F, 0xA0 };
+                var pps = new byte[] { 0x68, 0xCE, 0x38, 0x80 };
+                hub.PublishVideo(new VideoFrame(VideoCodec.H264, Keyframe: true, Microseconds: 0, UnixTime: null,
+                    Au(sps, pps, Nal(0x65, 40))));
+
+                // One ADTS frame: syncword, MPEG-4/no-CRC, AAC-LC, 16 kHz, mono,
+                // frame length 39 (7-byte header + 32-byte payload).
+                var adts = new byte[39];
+                adts[0] = 0xFF; adts[1] = 0xF1; adts[2] = 0x60; adts[3] = 0x40; adts[4] = 0x04; adts[5] = 0xE0;
+                hub.PublishAac(new AacFrame(adts));
+                Assert(hub.Audio is { IsAac: true, SampleRate: 16000, Channels: 1 }, "hub learned the AAC track");
+                AssertEq(FMp4.AacCodecString(hub.Audio!.AudioSpecificConfig!), "mp4a.40.2");
+
+                var path = Path.Combine(dir, "clip.mp4");
+                var writer = Recording.ClipWriter.TryCreate(path, hub);
+                Assert(writer != null, "writer created");
+                // Audio before the first video keyframe is skipped (track alignment).
+                writer!.AddAudio(new Streaming.HubAudioAac(0, new byte[32], 500));
+                writer.Add(new Streaming.HubVideo(1, Au(Nal(0x65, 40)), true, 1000));
+                writer.AddAudio(new Streaming.HubAudioAac(2, new byte[32], 5000));
+                writer.AddAudio(new Streaming.HubAudioAac(3, new byte[32], 5000 + 1024));
+                writer.Add(new Streaming.HubVideo(4, Au(Nal(0x41, 25)), false, 4000));
+                writer.Dispose();
+                Assert(writer.Completion.Wait(TimeSpan.FromSeconds(10)), "writer finalizes");
+                Assert(!writer.Faulted, "no write faults");
+
+                var bytes = File.ReadAllBytes(path);
+                var text = Encoding.ASCII.GetString(bytes);
+                Assert(text.Contains("mp4a"), "AAC sample entry present");
+                Assert(text.Contains("soun"), "audio handler present");
+                Assert(text.Contains("esds"), "decoder config present");
+
+                static List<int> IndicesOf(string haystack, string needle)
+                {
+                    var list = new List<int>();
+                    for (int i = haystack.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+                         i = haystack.IndexOf(needle, i + 1, StringComparison.Ordinal))
+                        list.Add(i);
+                    return list;
+                }
+                AssertEq(IndicesOf(text, "tkhd").Count, 2);
+                AssertEq(IndicesOf(text, "trex").Count, 2);
+
+                // Both media headers carry a real duration after finalization —
+                // video in 90 kHz ticks, audio in sample-rate ticks (2 AUs = 2048).
+                var mdhds = IndicesOf(text, "mdhd");
+                AssertEq(mdhds.Count, 2);
+                uint DurAt(int mdhd) => System.Buffers.Binary.BinaryPrimitives.ReadUInt32BigEndian(
+                    bytes.AsSpan(mdhd + 20));
+                Assert(DurAt(mdhds[0]) > 0, "video mdhd duration patched");
+                AssertEq(DurAt(mdhds[1]), 2048u);
+            }
+            finally
+            {
+                try { Directory.Delete(dir, recursive: true); } catch { }
+            }
+        });
+
         Test("loopback base for blazor circuits (reverse-proxy fix)", () =>
         {
             // Wildcard binds are not dialable — the circuit's own-server calls

--- a/src/Neolink.Server/Web/WebApi.cs
+++ b/src/Neolink.Server/Web/WebApi.cs
@@ -1104,18 +1104,27 @@ public static class WebApi
             return;
         }
 
+        // AAC audio rides along as MP4 track 2. ADPCM cameras stay video-only in
+        // the browser (MSE can't play raw PCM) — their audio is RTSP-only.
+        var audio = hub.Audio is { IsAac: true, AudioSpecificConfig: not null } a ? a : null;
+
         string codecString = FMp4.CodecString(codec, sps);
+        string mimeCodecs = audio != null
+            ? $"{codecString}, {FMp4.AacCodecString(audio.AudioSpecificConfig!)}"
+            : codecString;
         var meta = JsonSerializer.Serialize(new
         {
             type = "init",
             codec = codecString,
-            mime = $"video/mp4; codecs=\"{codecString}\"",
+            mime = $"video/mp4; codecs=\"{mimeCodecs}\"",
             width = hub.Width,
             height = hub.Height,
+            audio = audio != null,
         });
         await ws.SendAsync(Encoding.UTF8.GetBytes(meta), WebSocketMessageType.Text, true, ct).ConfigureAwait(false);
 
-        var init = FMp4.BuildInit(codec, sps, pps, hub.Vps, hub.Width, hub.Height);
+        var init = FMp4.BuildInit(codec, sps, pps, hub.Vps, hub.Width, hub.Height,
+            audio?.AudioSpecificConfig, audio?.SampleRate ?? 0, audio?.Channels ?? 0);
         await ws.SendAsync(init, WebSocketMessageType.Binary, true, ct).ConfigureAwait(false);
 
         var (subId, reader) = hub.Subscribe(viewer: true);
@@ -1136,17 +1145,31 @@ public static class WebApi
             uint sequence = 1;
             List<(byte[] Sample, bool Keyframe)>? pending = null;
 
+            // Audio fragments accumulate here and ship inside the next video batch:
+            // sending each ~21ms AAC frame as its own WebSocket message would wreck
+            // the client's delivery-cadence measurement (its jitter buffer sizing).
+            var audioFrags = new List<byte[]>();
+            ulong audioDt = 0;
+            uint prevAudioTs = 0;
+            bool haveAudioTs = false;
+
             async Task FlushPendingAsync(uint totalDuration)
             {
-                if (pending == null || pending.Count == 0) { pending = null; return; }
-                uint per = Math.Clamp(totalDuration / (uint)pending.Count, 900u, 45_000u); // 10..500ms per frame
+                if ((pending == null || pending.Count == 0) && audioFrags.Count == 0) { pending = null; return; }
                 using var batch = new MemoryStream();
-                foreach (var (sample, key) in pending)
+                if (pending is { Count: > 0 })
                 {
-                    batch.Write(FMp4.BuildFragment(sequence++, decodeTime, per, sample, key));
-                    decodeTime += per;
+                    uint per = Math.Clamp(totalDuration / (uint)pending.Count, 900u, 45_000u); // 10..500ms per frame
+                    foreach (var (sample, key) in pending)
+                    {
+                        batch.Write(FMp4.BuildFragment(sequence++, decodeTime, per, sample, key));
+                        decodeTime += per;
+                    }
                 }
                 pending = null;
+                foreach (var frag in audioFrags)
+                    batch.Write(frag);
+                audioFrags.Clear();
                 // Send straight from the stream's buffer — copying it per batch would
                 // double the allocation on the per-frame hot path, per viewer.
                 var payload = new ArraySegment<byte>(batch.GetBuffer(), 0, (int)batch.Length);
@@ -1160,6 +1183,24 @@ public static class WebApi
                 // video packet look like a drop (which would discard all P-frames).
                 bool gap = lastIndex >= 0 && packet.Index != lastIndex + 1;
                 lastIndex = packet.Index;
+
+                // Audio: fixed 1024-sample AUs; the decode-time advance comes from the
+                // RTP delta so hub drops shift the timeline instead of desyncing it.
+                // Held until the first video keyframe so both tracks start together.
+                if (packet is HubAudioAac aac && audio != null)
+                {
+                    if (waitKeyframe) continue;
+                    if (haveAudioTs)
+                    {
+                        uint d = unchecked(aac.RtpTs - prevAudioTs);
+                        audioDt += (d > 0 && d < 30u * (uint)audio.SampleRate) ? d : FMp4.AacSamplesPerAu;
+                    }
+                    prevAudioTs = aac.RtpTs;
+                    haveAudioTs = true;
+                    audioFrags.Add(FMp4.BuildFragment(sequence++, audioDt, FMp4.AacSamplesPerAu, aac.Au,
+                        keyframe: true, trackId: FMp4.AudioTrackId));
+                    continue;
+                }
 
                 if (packet is not HubVideo v) continue;
                 if (gap)

--- a/src/Neolink.WebClient/Components/Pages/Home.razor
+++ b/src/Neolink.WebClient/Components/Pages/Home.razor
@@ -362,7 +362,9 @@
                 var slot = _slots[index];
                 var camera = slot.Camera == null ? null : _cameras.FirstOrDefault(c => c.Name == slot.Camera);
 
-                <div class="tile @(index == 0 && (_mode is "focus" or "mosaic") ? "hero" : "")"
+                @* theater = the maximized/solo view: digital zoom is available there
+                   (and in browser fullscreen, where JS checks the fullscreen element) *@
+                <div class="tile @(index == 0 && (_mode is "focus" or "mosaic") ? "hero" : "") @(_mode == "theater" ? "zoom-on" : "")"
                      id="tile-@index" data-slot="@index" style="@TileStyle(index)" @key="index"
                      @ondblclick="() => ToggleMaximize(index)"
                      @onclick="() => OnTileClick(index)">
@@ -401,6 +403,8 @@
                                 </select>
                             }
                             <span class="tile-spacer"></span>
+                            @* JS-owned (neolink.audioInit): shown only when the stream has audio *@
+                            <button type="button" class="icon-btn" data-audio-toggle style="display:none">🔇</button>
                             <button class="icon-btn" title="@(_backup != null && _mode == "theater" ? "Restore view" : "Maximize")"
                                     @onclick="() => ToggleMaximize(index)">@(_backup != null && _mode == "theater" ? "❐" : "⛶")</button>
                             @* glyph comes from CSS so it can follow browser fullscreen state *@
@@ -408,6 +412,7 @@
                                     @onclick="() => FullscreenAsync(index)"></button>
                             <button class="icon-btn" title="Remove" @onclick="() => CloseSlot(index)">✕</button>
                         </div>
+                        @ZoomHud
                     }
                 </div>
             }
@@ -442,13 +447,16 @@
                         }
                     </select>
                 }
+                @* JS-owned (neolink.audioInit): shown only when the stream has audio *@
+                <button type="button" class="icon-btn" data-audio-toggle style="display:none">🔇</button>
                 <button class="icon-btn fs-toggle" title="Browser fullscreen (click again to exit)"
                         @onclick="QuickFullscreenAsync"></button>
                 <button class="icon-btn" title="Close" @onclick="CloseQuickView">✕</button>
             </div>
-            <div class="quick-view-media" id="quick-view-media">
+            <div class="quick-view-media zoom-on" id="quick-view-media">
                 <video id="vid-quick" muted playsinline></video>
                 <div class="tile-status">connecting…</div>
+                @ZoomHud
             </div>
         </div>
     }
@@ -922,6 +930,13 @@
         await ReconcilePlayersAsync();
         if (_mode == "free")
             await JS.InvokeVoidAsync("neolink.freeInit", "stage-grid");
+        // Digital zoom (theater/fullscreen/quick view). Re-invoked per render so
+        // zoom resets when a surface stops being zoomable (e.g. un-maximized).
+        await JS.InvokeVoidAsync("neolink.zoomInit");
+        // Speaker toggles: re-sync glyphs/visibility after every render.
+        await JS.InvokeVoidAsync("neolink.audioInit");
+        // Esc closes the event player / quick view pop-ups.
+        await JS.InvokeVoidAsync("neolink.escInit");
         // Blazor's `muted` attribute only sets defaultMuted on dynamically created
         // elements, which blocks autoplay — the helper mutes for real and plays.
         if (_eventsSupported && _events.Any(e => !e.Reviewed))
@@ -1996,6 +2011,15 @@
         _slots[index].Clear();
         _ = SaveAsync();
     }
+
+    // Digital-zoom HUD: JS (neolink.zoomInit) owns the clicks and the badge —
+    // no Blazor handlers, so wheel/drag/click stay off the circuit entirely.
+    private RenderFragment ZoomHud => @<div class="zoom-hud" @onclick:stopPropagation="true" @ondblclick:stopPropagation="true">
+        <button type="button" class="icon-btn zoom-btn" data-zoom="in" title="Zoom in (or mouse-wheel up on the video)">＋</button>
+        <span class="zoom-badge" data-zoom-badge>100%</span>
+        <button type="button" class="icon-btn zoom-btn" data-zoom="out" title="Zoom out (or mouse-wheel down)">−</button>
+        <button type="button" class="icon-btn zoom-btn zoom-reset" data-zoom="reset" title="Restore 1:1 (or double-click the video)">1:1</button>
+    </div>;
 
     private void OnTileClick(int index)
     {

--- a/src/Neolink.WebClient/wwwroot/css/app.css
+++ b/src/Neolink.WebClient/wwwroot/css/app.css
@@ -844,6 +844,15 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
     flex: 1;
     min-width: 0;
     padding: 2px 0;
+    cursor: grab; /* the strip pans with a mouse drag (cards override with pointer) */
+}
+
+/* While drag-panning: grabbing cursor everywhere and no accidental text/image
+   selection on the cards flying past (JS toggles the class). */
+.events-bar-scroll.strip-dragging,
+.events-bar-scroll.strip-dragging * {
+    cursor: grabbing !important;
+    user-select: none;
 }
 
 /* Edge scroll arrows: near full height of the strip, gradient fade into the
@@ -1233,6 +1242,59 @@ body.is-fullscreen .fs-toggle::before { content: "⇲"; }
     object-fit: contain;
     background: #000;
 }
+
+/* ---------- digital zoom (theater/maximized tiles, fullscreen, quick view) ---------- */
+
+/* Vertical glass pill hugging the right edge; appears while hovering a
+   zoomable surface and stays pinned while zoomed. JS (zoomInit) owns all
+   state — wheel zooms at the cursor, drag pans, double-click restores 1:1. */
+.zoom-hud {
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 6;
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    padding: 8px 5px;
+    background: color-mix(in srgb, var(--panel) 82%, transparent);
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    backdrop-filter: blur(6px);
+}
+
+.zoom-on:hover .zoom-hud,
+.zoom-on.zoomed .zoom-hud,
+.tile:fullscreen:hover .zoom-hud,
+.tile:fullscreen.zoomed .zoom-hud {
+    display: flex;
+}
+
+.zoom-badge {
+    font-size: 10px;
+    font-weight: 700;
+    min-width: 34px;
+    text-align: center;
+    color: var(--muted);
+    user-select: none;
+}
+
+.zoomed .zoom-badge { color: var(--accent); }
+
+.zoom-btn { font-size: 14px; }
+
+.zoom-reset {
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+}
+
+/* While zoomed the frame pans with a drag */
+.zoomed video { cursor: grab; }
+.zoom-panning video { cursor: grabbing; }
+.zoom-panning { user-select: none; }
 
 /* ------------------------------------------------------------ timeline page */
 

--- a/src/Neolink.WebClient/wwwroot/js/neolink.js
+++ b/src/Neolink.WebClient/wwwroot/js/neolink.js
@@ -87,6 +87,11 @@
                 return;
             }
             this.setStatus('connecting…');
+            // Tell the UI whether this stream carries audio — the speaker toggle
+            // only shows for cameras that actually have some.
+            if (meta.audio) this.video.dataset.audio = '1';
+            else delete this.video.dataset.audio;
+            window.neolink.audioSync();
             this.ms = new MediaSource();
             this.video.src = URL.createObjectURL(this.ms);
             this.ms.addEventListener('sourceopen', () => {
@@ -372,7 +377,223 @@
             const page = (dir) => scroll.scrollBy({ left: dir * scroll.clientWidth * 0.8, behavior: 'smooth' });
             wrap.querySelector('.strip-nav-left')?.addEventListener('click', () => page(-1));
             wrap.querySelector('.strip-nav-right')?.addEventListener('click', () => page(1));
+
+            // Swipe/drag panning (mouse only): press anywhere on the strip and drag
+            // to scroll it. Touch is left alone — the browser already pans natively.
+            // A real drag (>5px) swallows the click on release so the card under
+            // the cursor doesn't open, but a plain click still plays its event.
+            const drag = { active: false, moved: false, startX: 0, startLeft: 0 };
+            scroll.addEventListener('pointerdown', (e) => {
+                if (e.pointerType !== 'mouse' || e.button !== 0) return;
+                drag.active = true;
+                drag.moved = false;
+                drag.startX = e.clientX;
+                drag.startLeft = scroll.scrollLeft;
+            });
+            scroll.addEventListener('pointermove', (e) => {
+                if (!drag.active) return;
+                const dx = e.clientX - drag.startX;
+                if (!drag.moved) {
+                    if (Math.abs(dx) < 5) return; // still just a (wobbly) click
+                    drag.moved = true;
+                    scroll.classList.add('strip-dragging');
+                    try { scroll.setPointerCapture(e.pointerId); } catch { }
+                }
+                scroll.scrollLeft = drag.startLeft - dx;
+            });
+            const dragEnd = (e) => {
+                if (!drag.active) return;
+                drag.active = false;
+                scroll.classList.remove('strip-dragging');
+                try { scroll.releasePointerCapture(e.pointerId); } catch { }
+            };
+            scroll.addEventListener('pointerup', dragEnd);
+            scroll.addEventListener('pointercancel', dragEnd);
+            scroll.addEventListener('click', (e) => {
+                if (!drag.moved) return;
+                drag.moved = false; // this click ends the pan, nothing more
+                e.stopPropagation();
+                e.preventDefault();
+            }, { capture: true });
+            // Thumbnails are draggable by default; that would hijack the pan.
+            scroll.addEventListener('dragstart', (e) => e.preventDefault());
+
             update();
+        },
+
+        // Esc dismisses the top-most pop-up (event player / quick view). The key
+        // routes through the dialog's own Close button, so every Blazor-side
+        // close effect (mark-reviewed on close, player teardown) runs exactly
+        // as if it was clicked.
+        escInit() {
+            if (document.body.dataset.escInit) return;
+            document.body.dataset.escInit = '1';
+            document.addEventListener('keydown', (e) => {
+                if (e.key !== 'Escape') return;
+                const dialogs = document.querySelectorAll('.event-player, .quick-view');
+                const btn = dialogs.length
+                    ? dialogs[dialogs.length - 1].querySelector('.icon-btn[title="Close"]')
+                    : null;
+                if (btn) {
+                    e.preventDefault();
+                    btn.click();
+                }
+            });
+        },
+
+        // Live-audio mute toggles: cameras with AAC audio expose a speaker button
+        // (tile bar / quick view). Videos start muted so autoplay always works;
+        // clicking the toggle is the user gesture that lets sound through. JS owns
+        // the state — audioSync re-stamps the glyphs after every Blazor render.
+        audioInit() {
+            if (!document.body.dataset.audioInit) {
+                document.body.dataset.audioInit = '1';
+                document.addEventListener('click', (e) => {
+                    const btn = e.target instanceof Element ? e.target.closest('[data-audio-toggle]') : null;
+                    if (!btn) return;
+                    e.preventDefault();
+                    e.stopPropagation(); // the tile underneath must not react
+                    const video = btn.closest('.tile, .quick-view')?.querySelector('video');
+                    if (!video) return;
+                    video.muted = !video.muted;
+                    if (!video.muted) video.volume = 1;
+                    this.audioSync();
+                }, { capture: true });
+            }
+            this.audioSync();
+        },
+
+        audioSync() {
+            document.querySelectorAll('[data-audio-toggle]').forEach(btn => {
+                const video = btn.closest('.tile, .quick-view')?.querySelector('video');
+                const has = !!(video && video.dataset.audio);
+                btn.style.display = has ? '' : 'none';
+                if (!has) return;
+                btn.textContent = video.muted ? '🔇' : '🔊';
+                btn.title = video.muted ? 'Unmute — this camera has audio' : 'Mute';
+            });
+        },
+
+        // Digital zoom on live video (theater/maximized tiles, browser fullscreen,
+        // and the quick-view pop-up): the mouse wheel zooms around the cursor so
+        // the spot under it stays put, dragging pans while zoomed, the HUD pill
+        // steps in/out and restores 1:1, and a double-click snaps back to 1:1.
+        // All state lives DOM-side — nothing touches the Blazor circuit.
+        zoomInit() {
+            if (document.body.dataset.zoomInit) { this._zoomSweep?.(); return; }
+            document.body.dataset.zoomInit = '1';
+
+            const MAXZ = 8, STEP = 1.25;
+            const states = new WeakMap();  // container -> { z, tx, ty }
+            const zoomedBoxes = new Set(); // containers currently zoomed in (class
+                                           // alone won't do: Blazor re-renders clobber it)
+            const boxOf = (t) => (t instanceof Element ? t : null)?.closest?.('.tile, .quick-view-media');
+            const eligible = (box) => !!box && !!box.querySelector('video') &&
+                (box.classList.contains('zoom-on') || box === document.fullscreenElement);
+            const stOf = (box) => {
+                let s = states.get(box);
+                if (!s) { s = { z: 1, tx: 0, ty: 0 }; states.set(box, s); }
+                return s;
+            };
+
+            // Clamp the pan so the frame always covers the container, then paint.
+            const apply = (box) => {
+                const st = stOf(box);
+                const v = box.querySelector('video');
+                if (!v) return;
+                st.z = Math.min(MAXZ, Math.max(1, st.z));
+                st.tx = Math.min(0, Math.max(box.clientWidth * (1 - st.z), st.tx));
+                st.ty = Math.min(0, Math.max(box.clientHeight * (1 - st.z), st.ty));
+                if (st.z <= 1.001) {
+                    st.z = 1; st.tx = 0; st.ty = 0;
+                    v.style.transform = '';
+                } else {
+                    v.style.transformOrigin = '0 0';
+                    v.style.transform = `translate(${st.tx}px, ${st.ty}px) scale(${st.z})`;
+                }
+                box.classList.toggle('zoomed', st.z > 1);
+                if (st.z > 1) zoomedBoxes.add(box); else zoomedBoxes.delete(box);
+                const badge = box.querySelector('[data-zoom-badge]');
+                if (badge) badge.textContent = Math.round(st.z * 100) + '%';
+            };
+            // Rescale keeping the container point (px,py) fixed on screen.
+            const zoomAt = (box, factor, px, py) => {
+                const st = stOf(box);
+                const z0 = st.z;
+                st.z = Math.min(MAXZ, Math.max(1, z0 * factor));
+                const k = st.z / z0;
+                st.tx = px - k * (px - st.tx);
+                st.ty = py - k * (py - st.ty);
+                apply(box);
+            };
+            const reset = (box) => { const st = stOf(box); st.z = 1; st.tx = 0; st.ty = 0; apply(box); };
+            // Layout changed under us (unmaximized, left fullscreen): back to 1:1.
+            this._zoomSweep = () => [...zoomedBoxes]
+                .forEach(b => { if (!b.isConnected || !eligible(b)) reset(b); });
+
+            document.addEventListener('wheel', (e) => {
+                const box = boxOf(e.target);
+                if (!eligible(box)) return;
+                e.preventDefault(); // the wheel is zoom here, never page scroll
+                const r = box.getBoundingClientRect();
+                zoomAt(box, e.deltaY < 0 ? STEP : 1 / STEP, e.clientX - r.left, e.clientY - r.top);
+            }, { passive: false, capture: true });
+
+            // HUD buttons — capture phase so the tile underneath never sees the click.
+            document.addEventListener('click', (e) => {
+                const btn = e.target instanceof Element ? e.target.closest('[data-zoom]') : null;
+                if (!btn) return;
+                const box = boxOf(btn);
+                if (!box) return;
+                e.preventDefault();
+                e.stopPropagation();
+                if (btn.dataset.zoom === 'reset') reset(box);
+                else zoomAt(box, btn.dataset.zoom === 'in' ? STEP : 1 / STEP,
+                    box.clientWidth / 2, box.clientHeight / 2);
+            }, { capture: true });
+
+            // Drag pans while zoomed; the click on release is swallowed so the
+            // tile doesn't react to it.
+            const pan = { box: null, moved: false, x: 0, y: 0 };
+            document.addEventListener('pointerdown', (e) => {
+                const box = boxOf(e.target);
+                if (!eligible(box) || stOf(box).z <= 1) return;
+                if (e.target.closest('.tile-bar, .zoom-hud, button, select')) return;
+                pan.box = box; pan.moved = false; pan.x = e.clientX; pan.y = e.clientY;
+            }, { capture: true });
+            document.addEventListener('pointermove', (e) => {
+                if (!pan.box) return;
+                const dx = e.clientX - pan.x, dy = e.clientY - pan.y;
+                if (!pan.moved && Math.hypot(dx, dy) < 4) return; // still just a click
+                pan.moved = true;
+                pan.box.classList.add('zoom-panning');
+                const st = stOf(pan.box);
+                st.tx += dx; st.ty += dy;
+                pan.x = e.clientX; pan.y = e.clientY;
+                apply(pan.box);
+            }, { capture: true });
+            const panEnd = () => { pan.box?.classList.remove('zoom-panning'); pan.box = null; };
+            document.addEventListener('pointerup', panEnd, { capture: true });
+            document.addEventListener('pointercancel', panEnd, { capture: true });
+            document.addEventListener('click', (e) => {
+                if (!pan.moved) return;
+                pan.moved = false; // the pan is over; this click is not a tile click
+                e.stopPropagation();
+                e.preventDefault();
+            }, { capture: true });
+
+            // Double-click zoomed video: back to 1:1 (swallowed so the tile's own
+            // double-click — maximize/restore — only fires from an unzoomed state).
+            document.addEventListener('dblclick', (e) => {
+                const box = boxOf(e.target);
+                if (!box || stOf(box).z <= 1) return;
+                e.stopPropagation();
+                e.preventDefault();
+                reset(box);
+            }, { capture: true });
+
+            document.addEventListener('fullscreenchange', () => setTimeout(this._zoomSweep, 0));
+            this._zoomSweep();
         },
 
         // Review-strip vertical resizing: drag the handle at the bar's bottom edge.


### PR DESCRIPTION
Four UI/media features from this session, one branch.

## 🔊 Audio — live feeds and recordings (the big one)

**Why everything was silent:** the hand-rolled fMP4 muxer only ever wrote a video track. Live MSE streams, event clips and 24/7 recordings genuinely had no audio, so every volume control was correctly greyed out — even though the hub has carried the camera's AAC all along (RTSP had it).

- `FMp4` now declares an **AAC track 2** (`mp4a` + `esds` built from the ADTS-derived AudioSpecificConfig) and emits track-aware fragments
- **Live WS streams** carry audio; AAC frames batch into the existing video flushes so the client's delivery-cadence measurement (jitter-buffer sizing) is undisturbed; decode time advances by RTP delta so drops shift the timeline instead of desyncing A/V
- **Recordings**: event clips (pre-roll included), sub-stream previews and continuous segments all record the audio track; the file finalizer patches both tracks' durations
- **UI**: a speaker toggle 🔇/🔊 on tile bars and the quick view — only visible when the stream actually has audio; clicking it is the user gesture browsers require to unmute autoplaying video. The event player's native volume control works on clips recorded from now on
- **Caveats**: footage recorded before this change stays silent (no track to enable); ADPCM-only cameras keep audio on RTSP only — browsers can't play raw PCM in MP4, and a zero-dependency AAC encoder isn't realistic

## 🔍 Digital zoom (maximized/theater tiles, fullscreen, quick view)

- Mouse wheel zooms **around the cursor** (1×–8×), drag pans with edge clamping
- Frosted-glass HUD pill: ＋ / live % badge / − / **1:1** restore; double-click snaps back to 1:1 (and only a second double-click un-maximizes)
- Auto-resets when a surface stops being zoomable; inert on plain grid tiles

## 🖱 Review-strip drag-scroll

Press-and-drag pans the strip 1:1 (grab/grabbing cursors); touch keeps native momentum scrolling; a real drag swallows the release-click so the card under the cursor doesn't open. Thumbnails' native HTML5 drag is suppressed.

## ⎋ Esc closes pop-ups

Esc dismisses the event player and quick view by routing through their own Close buttons, so close side effects (mark-reviewed on close) run unchanged.

All interaction state is JS-owned (`neolink.js`) — wheel ticks, pans and toggles never touch the Blazor circuit.

## Verification

- Self-tests: **25 passed** (new test asserts the two-track clip structure and per-track patched durations); Release build clean with `-warnaserror`
- A `ClipWriter`-generated A/V file was validated against **Chrome's own MP4 demuxer** via MSE append: both tracks parsed, 2.9 s buffered, AAC timing exact (64 ms/AU @ 16 kHz). A first attempt failed for an instructive reason: the *synthetic test SPS* yields a 0×0 video config which MSE rejects — real cameras publish dimensions out of band, and the generator now does too
- Zoom/drag/Esc all exercised in the running app (synthetic events, offline camera); **audible live audio needs real camera hardware** — please try the speaker button and a fresh event clip on your setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)