### PR TITLE
Maximize fills the stage in every layout; browser fullscreen also switches to main

### DIFF
--- a/src/Neolink.WebClient/Components/Pages/Home.razor
+++ b/src/Neolink.WebClient/Components/Pages/Home.razor
@@ -2357,8 +2357,61 @@
         _ = SaveAsync();
     }
 
-    private async Task FullscreenAsync(int index) =>
+    // Browser fullscreen gets the same treatment as maximize: a sub-stream card
+    // switches to the camera's main stream while fullscreen, reverted on exit.
+    // Exit can happen without us (Esc, browser UI), so JS watches fullscreenchange
+    // and calls OnFullscreenExit.
+    private int? _fsIndex;
+    private string? _fsPrevKind;
+    private string? _fsPrevPath;
+    private string? _fsPrevCamera;
+
+    private async Task FullscreenAsync(int index)
+    {
+        // Entering only — the same button while fullscreen exits (JS toggles), and
+        // a maximized tile already runs its main stream.
+        if (_fsIndex == null && _maxIndex != index)
+        {
+            var slot = _slots[index];
+            var cam = _cameras.FirstOrDefault(c => c.Name == slot.Camera);
+            var main = cam?.Streams.FirstOrDefault(s => s.Kind == "mainStream");
+            if (main != null && slot.Kind != main.Kind)
+            {
+                _fsIndex = index;
+                _fsPrevKind = slot.Kind;
+                _fsPrevPath = slot.Path;
+                _fsPrevCamera = slot.Camera;
+                slot.Kind = main.Kind;
+                slot.Path = main.Path;
+                _ = SaveAsync();
+            }
+        }
+        _selfRef ??= DotNetObjectReference.Create(this);
+        await JS.InvokeVoidAsync("neolink.fsWatch", _selfRef);
         await JS.InvokeVoidAsync("neolink.fullscreen", $"tile-{index}");
+    }
+
+    /// <summary>Called from JS whenever browser fullscreen ends, however it ends.</summary>
+    [JSInvokable]
+    public async Task OnFullscreenExit()
+    {
+        if (_fsIndex is not int i) return;
+        var slot = _slots.ElementAtOrDefault(i);
+        // Same rule as maximize: only the automatic switch is undone; a stream or
+        // camera the user picked by hand while fullscreen is respected.
+        if (slot != null && slot.Camera == _fsPrevCamera && slot.Kind == "mainStream")
+        {
+            slot.Kind = _fsPrevKind;
+            slot.Path = _fsPrevPath;
+        }
+        _fsIndex = null;
+        _fsPrevKind = _fsPrevPath = _fsPrevCamera = null;
+        await InvokeAsync(async () =>
+        {
+            await SaveAsync();
+            StateHasChanged();
+        });
+    }
 
     // ------------------------------------------------------------ player reconciliation
 

--- a/src/Neolink.WebClient/wwwroot/css/app.css
+++ b/src/Neolink.WebClient/wwwroot/css/app.css
@@ -486,6 +486,10 @@ video[data-live="1"] ~ .tile-status { display: none; }
     inset: 0 !important;
     width: auto !important;
     height: auto !important;
+    /* An abspos GRID CHILD with a grid placement uses its grid AREA as the
+       containing block — a focus/mosaic hero would only fill its own cell.
+       Clearing the placement makes inset:0 span the whole grid container. */
+    grid-area: auto !important;
     z-index: 5;
 }
 

--- a/src/Neolink.WebClient/wwwroot/js/neolink.js
+++ b/src/Neolink.WebClient/wwwroot/js/neolink.js
@@ -697,6 +697,18 @@
             const p = players[videoId];
             if (p) { p.destroy(); delete players[videoId]; }
         },
+        // Tells Blazor when browser fullscreen ends — Esc, the toggle button or
+        // the browser's own UI all land here — so the fullscreen sub→main
+        // stream switch can be reverted. Idempotent.
+        fsWatch(dotnetRef) {
+            if (document.body.dataset.fsWatch) return;
+            document.body.dataset.fsWatch = '1';
+            document.addEventListener('fullscreenchange', () => {
+                if (!document.fullscreenElement)
+                    dotnetRef.invokeMethodAsync('OnFullscreenExit').catch(() => { });
+            });
+        },
+
         // Toggle: the same tile button enters and leaves browser fullscreen.
         fullscreen(elementId) {
             if (document.fullscreenElement) {


### PR DESCRIPTION
Two fixes for the in-place maximize shipped in #18.

## 1. Maximized tile didn't fill the screen (focus/mosaic)

CSS spec subtlety: an **absolutely-positioned child of a grid container uses its grid *area* as the containing block** when the item has a grid placement. Focus/Mosaic tiles carry an inline `grid-area` (hero spans etc.), so the maxed tile's `inset: 0` only stretched across its original cell. Grid mode has no explicit placement, which is why the original verification (done in grid mode) looked fine.

**Fix:** one line — `grid-area: auto !important` on `.tile.maxed` clears the placement so `inset: 0` spans the whole grid container.

Verified edge-to-edge (tile rect == stage rect) in **Grid, Focus, Mosaic and Free**.

## 2. Browser fullscreen now upgrades to the main stream

The sub→main auto-switch only existed on maximize. The tile's fullscreen button now does the same: entering fullscreen on a sub-stream card switches it to the camera's main stream. A JS `fullscreenchange` watcher notifies Blazor when fullscreen ends — **however** it ends (toggle button, Esc, or the browser's own UI) — and the sub stream comes back.

Same manners as maximize: only the automatic switch is undone; a stream or camera picked by hand while fullscreen is respected on exit. A card already on main is left untouched (verified through a full round trip).

## Verification (running app, 5-camera fixture)

- Maxed tile fills the stage exactly in all four layout modes
- sub → fullscreen → **main** → exit → **sub**
- main → fullscreen → exit → main (no spurious switch)
- Maximize round trip unchanged: sub → maximize → main → restore → sub, tile fills

Note for testing on real hardware: entering fullscreen visibly steps quality up a beat later — that's the player reconnecting to the main-stream WebSocket, same as maximize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)