### PR TITLE
Per-camera capture schedule, full HA event coverage, and UI fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,44 @@ Release notes for Neolink.NET. Releasing works by tagging `vX.Y.Z` — the docke
 workflow bakes the tag into the app as its version (see "Versioning & releases"
 in the README). Paste the matching section below into the GitHub release.
 
-## 0.7.0 — unreleased
+## 0.8.0 — unreleased
+
+### New
+
+- **Per-camera capture schedule (beta, opt-in)**: switch *Scheduled capture*
+  on in camera settings → *Recording* to choose the days of the week and the
+  time of day that camera records events — day chips plus a from/until window
+  that can span midnight (e.g. 22:00–06:00 for nights-only). Applies to all
+  selected event types; anything arriving outside the schedule is discarded.
+  Off by default (capture at all times), and switching it off keeps the
+  schedule for later instead of deleting it.
+- **Home Assistant: every detection type is now a sensor**: package,
+  line-crossing, intrusion and loitering join the motion/person/vehicle/animal
+  binary sensors. They are announced on their first detection, so cameras
+  without those features don't grow dead entities.
+- **Home Assistant: "Visitor" doorbell sensor**: the doorbell press now also
+  pulses a binary sensor that HA clears by itself a few seconds later — the
+  existing *event* entity keeps the press history but always displays the last
+  press, which read as a button stuck "pressed" on dashboards. Repeated
+  "visitor" pushes while the chime rings no longer count as extra presses.
+
+### Fixed
+
+- Timeline playback shows a buffering spinner while a video is still loading
+  under the cursor, instead of looking frozen with no indication.
+- The timeline's play button no longer looks like the previous/next-day
+  arrows: day navigation uses thin chevrons, play/pause is a solid accent
+  pill with a filled glyph.
+- On phones, a video tile's controls no longer overflow off the right edge of
+  the screen: the camera name shrinks to an ellipsis and the buttons compact,
+  so every icon stays reachable.
+
+### Changed
+
+- The server version moved from the sidebar's footer to the right edge of the
+  top toolbar, so it stays visible with the sidebar collapsed.
+
+## 0.7.0
 
 ### New
 

--- a/src/Neolink.Server/Mqtt/HomeAssistantMqtt.cs
+++ b/src/Neolink.Server/Mqtt/HomeAssistantMqtt.cs
@@ -17,8 +17,12 @@ namespace Neolink.Mqtt;
 ///
 /// Per camera it publishes (all retained, so HA repopulates after a restart):
 ///   • binary_sensor: motion, person, vehicle, animal   (from the alarm pushes)
+///   • binary_sensor: package, line crossing, intrusion,
+///                    loitering                          (lazily, on first detection)
 ///   • binary_sensor: siren                              (from the status pushes)
 ///   • event:         doorbell press                     (video doorbells; not retained)
+///   • binary_sensor: visitor                            (doorbell press pulse; HA
+///                                                        auto-clears it via off_delay)
 ///   • sensor:        battery                            (battery cameras)
 ///   • sensor:        Wi-Fi signal, diagnostic           (from the status pushes)
 ///   • switch:        PIR sensor                         (PIR cameras)
@@ -37,7 +41,13 @@ public sealed class HomeAssistantMqtt
     /// <summary>How long a detection stays "on" after the last alarm push for it.</summary>
     private static readonly TimeSpan MotionOffDelay = TimeSpan.FromSeconds(20);
 
-    internal static readonly string[] DetectionLabels = { "motion", "person", "vehicle", "animal" };
+    /// <summary>Every detection label that gets a binary sensor. The classic four
+    /// are announced on every camera; the smart labels (package + the perimeter
+    /// events set up in the Reolink app) announce lazily on their first push, so
+    /// cameras without those features never grow dead entities in HA.</summary>
+    internal static readonly string[] DetectionLabels =
+        { "motion", "person", "vehicle", "animal", "package", "line-crossing", "intrusion", "loitering" };
+    internal static readonly string[] CoreLabels = { "motion", "person", "vehicle", "animal" };
 
     private readonly MqttConfig _cfg;
     private readonly string _version;
@@ -174,9 +184,12 @@ internal sealed class CameraBridge
     private readonly string _base;      // {baseTopic}/{id}
     private readonly Dictionary<string, DateTime> _activeUntil = new();
     private readonly HashSet<string> _sensorOn = new();
+    /// <summary>Smart detection labels seen at least once (announced lazily).</summary>
+    private readonly HashSet<string> _smartAnnounced = new();
 
     private bool _featuresAnnounced;
     private bool _doorbellAnnounced;
+    private DateTime _lastDoorbellPress = DateTime.MinValue;
     private bool _wifiAnnounced, _sirenAnnounced;  // lazily, on the first status push
     private int? _wifiDbm;
     private bool? _sirenOn, _floodlightOn;
@@ -220,13 +233,15 @@ internal sealed class CameraBridge
             return;
         }
 
-        // Detection sensors and reboot exist on every Baichuan camera — announce immediately.
-        foreach (var label in HomeAssistantMqtt.DetectionLabels)
+        // Detection sensors and reboot exist on every Baichuan camera — announce
+        // immediately (plus any lazily-discovered smart labels seen so far).
+        var labels = HomeAssistantMqtt.CoreLabels.Concat(_smartAnnounced).ToList();
+        foreach (var label in labels)
             await AnnounceEntityAsync("binary_sensor", label, BinarySensorConfig(label), ct).ConfigureAwait(false);
         await AnnounceEntityAsync("button", "reboot", ButtonConfig("Reboot", "reboot", "restart"), ct).ConfigureAwait(false);
 
         // Publish current detection states so HA doesn't show "unknown".
-        foreach (var label in HomeAssistantMqtt.DetectionLabels)
+        foreach (var label in labels)
             await _hub.PublishAsync(StateTopic(label), _sensorOn.Contains(label) ? "ON" : "OFF", ct).ConfigureAwait(false);
 
         if (_featuresAnnounced)
@@ -235,7 +250,10 @@ internal sealed class CameraBridge
         // A broker restart wipes retained discovery configs; re-announce the
         // doorbell (lazily created on first press) so it survives, like the rest.
         if (_doorbellAnnounced)
+        {
             await AnnounceEntityAsync("event", "doorbell", DoorbellEventConfig(), ct).ConfigureAwait(false);
+            await AnnounceEntityAsync("binary_sensor", "visitor", VisitorConfig(), ct).ConfigureAwait(false);
+        }
         // Same for the entities created lazily on the first status push.
         if (_wifiAnnounced)
             await AnnounceEntityAsync("sensor", "wifi_signal", WifiSignalConfig(), ct).ConfigureAwait(false);
@@ -306,12 +324,32 @@ internal sealed class CameraBridge
 
     private object BinarySensorConfig(string label) => new
     {
-        name = label switch { "motion" => "Motion", "person" => "Person", "vehicle" => "Vehicle", "animal" => "Animal", _ => label },
+        name = label switch
+        {
+            "motion" => "Motion",
+            "person" => "Person",
+            "vehicle" => "Vehicle",
+            "animal" => "Animal",
+            "package" => "Package",
+            "line-crossing" => "Line crossing",
+            "intrusion" => "Intrusion",
+            "loitering" => "Loitering",
+            _ => label,
+        },
         unique_id = $"neolink_{Id}_{label}",
         state_topic = StateTopic(label),
         payload_on = "ON",
         payload_off = "OFF",
         device_class = "motion",
+        // The smart labels aren't plain motion — give them a telling icon.
+        icon = label switch
+        {
+            "package" => "mdi:package-variant-closed",
+            "line-crossing" => "mdi:vector-line",
+            "intrusion" => "mdi:shield-alert-outline",
+            "loitering" => "mdi:account-clock-outline",
+            _ => (string?)null,
+        },
         device = Device(),
         availability = Availability(),
         availability_mode = "all",
@@ -400,13 +438,27 @@ internal sealed class CameraBridge
         var now = DateTime.UtcNow;
         var labels = EventRecorder.LabelsOf(push); // person/vehicle/animal/... or "motion"
         if (push.Active && labels.Contains("doorbell"))
-            _ = PublishDoorbellPressAsync(CancellationToken.None);
+        {
+            // Cameras re-push "visitor" while the chime is ringing unanswered;
+            // without a grace window every re-push looks like another press.
+            if (now - _lastDoorbellPress > TimeSpan.FromSeconds(3))
+            {
+                _lastDoorbellPress = now;
+                _ = PublishDoorbellPressAsync(CancellationToken.None);
+            }
+        }
         if (push.Active)
         {
             _activeUntil["motion"] = now + HomeAssistantMqtt.OffDelay;
             foreach (var l in labels)
                 if (Array.IndexOf(HomeAssistantMqtt.DetectionLabels, l) >= 0)
+                {
                     _activeUntil[l] = now + HomeAssistantMqtt.OffDelay;
+                    // Smart labels announce on first sight (retained state follows
+                    // right after, so HA shows a value as soon as the entity exists).
+                    if (Array.IndexOf(HomeAssistantMqtt.CoreLabels, l) < 0 && _smartAnnounced.Add(l))
+                        _ = AnnounceEntityAsync("binary_sensor", l, BinarySensorConfig(l), CancellationToken.None);
+                }
         }
         else
         {
@@ -421,9 +473,12 @@ internal sealed class CameraBridge
 
     /// <summary>
     /// A doorbell button press becomes an HA EVENT entity (device_class doorbell) —
-    /// the natural trigger for ring automations. Announced lazily on the FIRST
-    /// press, so ordinary cameras never grow a dead doorbell entity. (HA may need
-    /// a beat to create the entity, so the very first ring can be discovery-only.)
+    /// the natural trigger for ring automations — plus a momentary "visitor"
+    /// binary sensor that HA clears by itself (off_delay), so dashboards show a
+    /// short "pressed" pulse instead of a state stuck until the next ring.
+    /// Both are announced lazily on the FIRST press, so ordinary cameras never
+    /// grow dead doorbell entities. (HA may need a beat to create the entities,
+    /// so the very first ring can be discovery-only.)
     /// </summary>
     private async Task PublishDoorbellPressAsync(CancellationToken ct)
     {
@@ -433,15 +488,34 @@ internal sealed class CameraBridge
             {
                 _doorbellAnnounced = true;
                 await AnnounceEntityAsync("event", "doorbell", DoorbellEventConfig(), ct).ConfigureAwait(false);
+                await AnnounceEntityAsync("binary_sensor", "visitor", VisitorConfig(), ct).ConfigureAwait(false);
             }
             await _hub.PublishTransientAsync(StateTopic("doorbell"), "{\"event_type\":\"press\"}", ct)
                 .ConfigureAwait(false);
+            // Not retained: a stale ON must never replay into HA after a restart
+            // (off_delay only starts counting from when HA receives the message).
+            await _hub.PublishTransientAsync(StateTopic("visitor"), "ON", ct).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             Log.Debug($"{_cam.Name}: doorbell publish failed: {Log.Flatten(ex)}");
         }
     }
+
+    /// <summary>The momentary press state: ON on the ring, auto-reset by HA a few
+    /// seconds later — no OFF publish needed (and none ever comes from the camera).</summary>
+    private object VisitorConfig() => new
+    {
+        name = "Visitor",
+        unique_id = $"neolink_{Id}_visitor",
+        state_topic = StateTopic("visitor"),
+        payload_on = "ON",
+        off_delay = 5,
+        icon = "mdi:doorbell",
+        device = Device(),
+        availability = Availability(),
+        availability_mode = "all",
+    };
 
     private object DoorbellEventConfig() => new
     {

--- a/src/Neolink.Server/Neolink.Server.csproj
+++ b/src/Neolink.Server/Neolink.Server.csproj
@@ -11,7 +11,7 @@
          log, /api/features and the web UI. Release builds override it with the
          git tag (docker.yml passes -p:Version), so tagging vX.Y.Z is what
          increments the released version. -->
-    <Version>0.7.0</Version>
+    <Version>0.8.0</Version>
     <InvariantGlobalization>true</InvariantGlobalization>
     <ServerGarbageCollection>false</ServerGarbageCollection>
     <TieredPgo>true</TieredPgo>

--- a/src/Neolink.Server/Recording/EventRecorder.cs
+++ b/src/Neolink.Server/Recording/EventRecorder.cs
@@ -282,10 +282,12 @@ public sealed class EventRecorder
             }
             if (!push.Active) continue; // stray all-clear with no open event
 
-            // Runtime switches (web UI): events off, or every label of this push
-            // filtered out by the camera's event-type selection → discard silently.
+            // Runtime switches (web UI): events off, outside the camera's capture
+            // schedule, or every label of this push filtered out by the camera's
+            // event-type selection → discard silently.
             var settings = _settings.Get(_camera);
             if (!settings.Events) continue;
+            if (!settings.ScheduleAllows(DateTime.Now)) continue; // schedules are wall-clock local
             var labels = LabelsOf(push).Where(settings.AllowsLabel).ToList();
             if (labels.Count == 0) continue;
 

--- a/src/Neolink.Server/Recording/RecordingSettings.cs
+++ b/src/Neolink.Server/Recording/RecordingSettings.cs
@@ -10,11 +10,18 @@ namespace Neolink.Recording;
 /// consistent snapshot. Retention overrides are per recording type: null = use
 /// the server-wide default, 0 = keep forever, otherwise days. RecordStream picks
 /// which stream is taped ("mainStream"/"subStream"/"externStream"; null = the
-/// server default from the recording config).
+/// server default from the recording config). The capture schedule gates event
+/// recording by local wall-clock time, but ONLY while ScheduleEnabled — the
+/// explicit opt-in keeps "capture always" the safe default and lets a schedule
+/// be switched off without losing it. ScheduleDays lists the enabled days
+/// ("mon".."sun", null = every day) and ScheduleStart/ScheduleEnd bound the
+/// time of day ("HH:mm"; null = midnight, so both null = all day).
 /// </summary>
 public sealed record CameraRecordingSettings(bool Events, bool Continuous, List<string>? EventTypes,
     int? EventRetentionDays = null, int? ContinuousRetentionDays = null,
-    string? RecordStream = null)
+    string? RecordStream = null,
+    List<string>? ScheduleDays = null, string? ScheduleStart = null, string? ScheduleEnd = null,
+    bool ScheduleEnabled = false)
 {
     /// <summary>Known detection labels (what the UI offers as event-type filters).</summary>
     public static readonly string[] KnownLabels =
@@ -39,6 +46,43 @@ public sealed record CameraRecordingSettings(bool Events, bool Continuous, List<
     /// <summary>A null EventTypes list means the default set (perimeter labels are opt-in).</summary>
     public bool AllowsLabel(string label) =>
         EventTypes != null ? EventTypes.Contains(label) : DefaultLabels.Contains(label);
+
+    /// <summary>Capture-schedule day tokens, in display order.</summary>
+    public static readonly string[] WeekDays = { "mon", "tue", "wed", "thu", "fri", "sat", "sun" };
+
+    /// <summary>
+    /// True when the capture schedule admits events at this LOCAL wall-clock
+    /// instant; always true while the schedule is switched off (the default).
+    /// Start > end wraps past midnight (22:00–06:00); the day check applies
+    /// to the day the event actually occurs on, so the small hours of an
+    /// overnight window belong to the following day. Start inclusive, end
+    /// exclusive; a degenerate window (start == end) means all day.
+    /// </summary>
+    public bool ScheduleAllows(DateTime local)
+    {
+        if (!ScheduleEnabled) return true;
+        if (ScheduleDays is { Count: > 0 } days && !days.Contains(DayToken(local.DayOfWeek)))
+            return false;
+        int s = ParseMinutes(ScheduleStart) ?? 0, e = ParseMinutes(ScheduleEnd) ?? 0;
+        if (s == e) return true;
+        int t = local.Hour * 60 + local.Minute;
+        return s < e ? t >= s && t < e : t >= s || t < e;
+    }
+
+    public static string DayToken(DayOfWeek day) => day switch
+    {
+        DayOfWeek.Monday => "mon",
+        DayOfWeek.Tuesday => "tue",
+        DayOfWeek.Wednesday => "wed",
+        DayOfWeek.Thursday => "thu",
+        DayOfWeek.Friday => "fri",
+        DayOfWeek.Saturday => "sat",
+        _ => "sun",
+    };
+
+    /// <summary>"HH:mm" → minutes since midnight; null on anything else.</summary>
+    public static int? ParseMinutes(string? hhmm) =>
+        TimeOnly.TryParseExact(hhmm, "HH\\:mm", out var t) ? t.Hour * 60 + t.Minute : null;
 }
 
 /// <summary>
@@ -123,7 +167,11 @@ public sealed class RecordingSettings
         List<string>? eventTypes, bool setEventTypes,
         int? eventRetentionDays = null, bool setEventRetention = false,
         int? continuousRetentionDays = null, bool setContinuousRetention = false,
-        string? recordStream = null, bool setRecordStream = false)
+        string? recordStream = null, bool setRecordStream = false,
+        List<string>? scheduleDays = null, bool setScheduleDays = false,
+        string? scheduleStart = null, bool setScheduleStart = false,
+        string? scheduleEnd = null, bool setScheduleEnd = false,
+        bool? scheduleEnabled = null)
     {
         lock (_gate)
         {
@@ -136,7 +184,11 @@ public sealed class RecordingSettings
                 setEventTypes ? eventTypes : cur.EventTypes,
                 setEventRetention ? eventRetentionDays : cur.EventRetentionDays,
                 setContinuousRetention ? continuousRetentionDays : cur.ContinuousRetentionDays,
-                setRecordStream ? recordStream : cur.RecordStream);
+                setRecordStream ? recordStream : cur.RecordStream,
+                setScheduleDays ? scheduleDays : cur.ScheduleDays,
+                setScheduleStart ? scheduleStart : cur.ScheduleStart,
+                setScheduleEnd ? scheduleEnd : cur.ScheduleEnd,
+                scheduleEnabled ?? cur.ScheduleEnabled);
             _cameras[camera] = next;
             SaveLocked();
             return next;

--- a/src/Neolink.Server/SelfTest.cs
+++ b/src/Neolink.Server/SelfTest.cs
@@ -336,6 +336,59 @@ public static class SelfTest
                 "explicit filter is exact");
         });
 
+        Test("capture schedule (per-camera day/time gate on events)", () =>
+        {
+            // 2026-07-06 is a Monday; the week runs Mon 6th .. Sun 12th.
+            var untouched = new Recording.CameraRecordingSettings(Events: true, Continuous: false, EventTypes: null);
+            Assert(untouched.ScheduleAllows(new DateTime(2026, 7, 12, 3, 30, 0)),
+                "untouched schedule captures any day, any hour");
+
+            // The schedule is opt-in: while switched off, a configured window is
+            // dormant and everything captures — turning it off must never mean
+            // "capture nothing" or silently keep filtering.
+            var dormant = new Recording.CameraRecordingSettings(true, false, null,
+                ScheduleDays: new List<string> { "mon" }, ScheduleStart: "08:00", ScheduleEnd: "09:00",
+                ScheduleEnabled: false);
+            Assert(dormant.ScheduleAllows(new DateTime(2026, 7, 12, 3, 30, 0)),
+                "disabled schedule captures everything despite a stored window");
+
+            var weekdays = new Recording.CameraRecordingSettings(true, false, null,
+                ScheduleDays: new List<string> { "mon", "tue", "wed", "thu", "fri" }, ScheduleEnabled: true);
+            Assert(weekdays.ScheduleAllows(new DateTime(2026, 7, 10, 12, 0, 0)), "Friday passes a weekday filter");
+            Assert(!weekdays.ScheduleAllows(new DateTime(2026, 7, 11, 12, 0, 0)), "Saturday is discarded");
+
+            var office = new Recording.CameraRecordingSettings(true, false, null,
+                ScheduleStart: "08:00", ScheduleEnd: "18:00", ScheduleEnabled: true);
+            Assert(office.ScheduleAllows(new DateTime(2026, 7, 6, 8, 0, 0)), "window start is inclusive");
+            Assert(!office.ScheduleAllows(new DateTime(2026, 7, 6, 18, 0, 0)), "window end is exclusive");
+            Assert(!office.ScheduleAllows(new DateTime(2026, 7, 6, 3, 0, 0)), "before the window is discarded");
+
+            // A window past midnight (nights-only) wraps; the day filter applies
+            // to the day the event lands on, so 01:00 needs Saturday enabled.
+            var nights = new Recording.CameraRecordingSettings(true, false, null,
+                ScheduleDays: new List<string> { "fri", "sat" }, ScheduleStart: "22:00", ScheduleEnd: "06:00",
+                ScheduleEnabled: true);
+            Assert(nights.ScheduleAllows(new DateTime(2026, 7, 10, 23, 30, 0)), "overnight window before midnight");
+            Assert(nights.ScheduleAllows(new DateTime(2026, 7, 11, 1, 0, 0)), "overnight window after midnight");
+            Assert(!nights.ScheduleAllows(new DateTime(2026, 7, 10, 12, 0, 0)), "midday outside an overnight window");
+
+            // One-sided windows: a lone start runs to midnight, a lone end from it.
+            var fromSix = new Recording.CameraRecordingSettings(true, false, null,
+                ScheduleStart: "06:00", ScheduleEnabled: true);
+            Assert(!fromSix.ScheduleAllows(new DateTime(2026, 7, 6, 5, 0, 0)), "lone start: small hours excluded");
+            Assert(fromSix.ScheduleAllows(new DateTime(2026, 7, 6, 23, 59, 0)), "lone start: runs to midnight");
+            var untilTen = new Recording.CameraRecordingSettings(true, false, null,
+                ScheduleEnd: "22:00", ScheduleEnabled: true);
+            Assert(untilTen.ScheduleAllows(new DateTime(2026, 7, 6, 0, 0, 0)), "lone end: starts at midnight");
+            Assert(!untilTen.ScheduleAllows(new DateTime(2026, 7, 6, 23, 0, 0)), "lone end: late evening excluded");
+
+            AssertEq(Recording.CameraRecordingSettings.ParseMinutes("07:45") ?? -1, 7 * 60 + 45);
+            Assert(Recording.CameraRecordingSettings.ParseMinutes("7:45") == null
+                && Recording.CameraRecordingSettings.ParseMinutes("nope") == null
+                && Recording.CameraRecordingSettings.ParseMinutes(null) == null,
+                "only strict HH:mm parses");
+        });
+
         Test("status push parsing (unsolicited camera broadcasts)", () =>
         {
             // msg 464 NetInfo — the inner fields are from a real Wi-Fi camera

--- a/src/Neolink.Server/Web/WebApi.cs
+++ b/src/Neolink.Server/Web/WebApi.cs
@@ -86,9 +86,14 @@ public static class WebApi
         uint? Framerate, uint? Bitrate);
     private sealed record ReviewRequest(bool? Reviewed);
     /// <summary>Retention fields: null = unchanged, negative = back to the server default, 0 = keep forever.
-    /// RecordStream: null = unchanged, "" = back to the server default, else a served stream kind.</summary>
+    /// RecordStream: null = unchanged, "" = back to the server default, else a served stream kind.
+    /// Capture schedule: applied only while ScheduleEnabled; ScheduleDays null = unchanged,
+    /// empty or all seven = every day; ScheduleStart/ScheduleEnd null = unchanged,
+    /// "" = midnight (both cleared = all day).</summary>
     private sealed record RecordingSettingsRequest(bool? Events, bool? Continuous, List<string>? EventTypes,
-        int? EventRetentionDays = null, int? ContinuousRetentionDays = null, string? RecordStream = null);
+        int? EventRetentionDays = null, int? ContinuousRetentionDays = null, string? RecordStream = null,
+        List<string>? ScheduleDays = null, string? ScheduleStart = null, string? ScheduleEnd = null,
+        bool? ScheduleEnabled = null);
     private sealed record CredentialsRequest(string? Username, string? Password);
     private sealed record PasswordRequest(string? Password);
     private sealed record AdminUiSettings(double? TrickleSpeed, string? StateDir, bool? ResetAdminPassword,
@@ -802,6 +807,13 @@ public static class WebApi
                 recordStream = s.RecordStream,
                 defaultRecordStream = DefaultRecordKind(cam),
                 availableStreams = cam.Streams.Select(x => x.Kind).ToList(),
+                // Capture schedule, always in effective form: the day list is never
+                // null (the UI chips render it directly) and "" means midnight.
+                // It only takes effect while scheduleEnabled (opt-in).
+                scheduleEnabled = s.ScheduleEnabled,
+                scheduleDays = (IEnumerable<string>?)s.ScheduleDays ?? CameraRecordingSettings.WeekDays,
+                scheduleStart = s.ScheduleStart ?? "",
+                scheduleEnd = s.ScheduleEnd ?? "",
             };
 
             app.MapGet("/api/cameras/{name}/recording", (string name, HttpContext ctx) =>
@@ -843,6 +855,19 @@ public static class WebApi
                     {
                         error = $"recordStream must be one of: {string.Join(", ", cam.Streams.Select(s => s.Kind))}",
                     }, statusCode: 400);
+                // Capture schedule: unknown day tokens are dropped; an empty or
+                // complete day list stores as null (= every day). Times must be
+                // HH:mm — anything else (including "") clears to midnight.
+                List<string>? schedDays = null;
+                if (req.ScheduleDays != null)
+                {
+                    schedDays = req.ScheduleDays.Select(d => d.Trim().ToLowerInvariant())
+                        .Where(CameraRecordingSettings.WeekDays.Contains).Distinct().ToList();
+                    if (schedDays.Count == 0 || schedDays.Count == CameraRecordingSettings.WeekDays.Length)
+                        schedDays = null;
+                }
+                static string? SchedTime(string? v) =>
+                    v != null && CameraRecordingSettings.ParseMinutes(v) is int m && m > 0 ? v : null;
                 var updated = recordingSettings.Update(cam.Name, req.Events, continuous,
                     types, setEventTypes: req.EventTypes != null,
                     eventRetentionDays: Retention(req.EventRetentionDays),
@@ -850,7 +875,11 @@ public static class WebApi
                     continuousRetentionDays: Retention(req.ContinuousRetentionDays),
                     setContinuousRetention: req.ContinuousRetentionDays != null,
                     recordStream: req.RecordStream is { Length: > 0 } v ? v : null,
-                    setRecordStream: req.RecordStream != null);
+                    setRecordStream: req.RecordStream != null,
+                    scheduleDays: schedDays, setScheduleDays: req.ScheduleDays != null,
+                    scheduleStart: SchedTime(req.ScheduleStart), setScheduleStart: req.ScheduleStart != null,
+                    scheduleEnd: SchedTime(req.ScheduleEnd), setScheduleEnd: req.ScheduleEnd != null,
+                    scheduleEnabled: req.ScheduleEnabled);
                 return Results.Json(ShapeSettings(cam, updated));
             });
         }

--- a/src/Neolink.WebClient/Components/CameraPanel.razor
+++ b/src/Neolink.WebClient/Components/CameraPanel.razor
@@ -235,9 +235,51 @@
                         filter on what arrives: disabled types are discarded and the camera's own settings
                         are never changed.
                     </div>
+                    <div class="control-row">
+                        <span>Scheduled capture <span class="beta-tag" title="Scheduled capture is new — report anything odd">BETA</span></span>
+                        <button class="chip @(_recording.ScheduleEnabled ? "" : "chip-off")"
+                                title="@(_recording.ScheduleEnabled ? "Events are captured only inside the schedule below — click to capture at all times" : "Events are captured at all times — click to restrict capture to a schedule")"
+                                @onclick="() => SetRecordingAsync(scheduleEnabled: !_recording.ScheduleEnabled)">
+                            @(_recording.ScheduleEnabled ? "on" : "off")
+                        </button>
+                    </div>
+                    @if (_recording.ScheduleEnabled)
+                    {
+                        <div class="sched">
+                            <div class="sched-days">
+                                @foreach (var d in WeekDayTokens)
+                                {
+                                    var day = d;
+                                    <button class="chip sched-day @(DayEnabled(day) ? "" : "chip-off")"
+                                            title="@(DayEnabled(day) ? $"Capturing on {DayName(day)} — click to skip this day" : $"Skipping {DayName(day)} — click to capture")"
+                                            @onclick="() => ToggleScheduleDayAsync(day)">@DayLabel(day)</button>
+                                }
+                            </div>
+                            <div class="sched-times">
+                                <label class="sched-time">from
+                                    <input type="time" value="@(_recording.ScheduleStart ?? "")"
+                                           title="Capture from this time of day (blank = midnight)"
+                                           @onchange="e => SetScheduleTimeAsync(start: (string?)e.Value)" />
+                                </label>
+                                <label class="sched-time">until
+                                    <input type="time" value="@(_recording.ScheduleEnd ?? "")"
+                                           title="Capture until this time of day (blank = midnight). Earlier than “from” spans midnight."
+                                           @onchange="e => SetScheduleTimeAsync(end: (string?)e.Value)" />
+                                </label>
+                                @if (HasTimeWindow)
+                                {
+                                    <button class="chip" title="Clear the time window — capture at any hour"
+                                            @onclick='() => SetScheduleTimeAsync(start: "", end: "")'>all day</button>
+                                }
+                            </div>
+                            <div class="event-sub">@ScheduleSummary</div>
+                        </div>
+                    }
                 }
                 @if (_recording.ContinuousAvailable)
                 {
+                    @* Hairline between the event-based half above and 24/7 below. *@
+                    <div class="campanel-divider"></div>
                     <div class="control-row">
                         <span>Continuous (24/7)</span>
                         <button class="chip @(_recording.Continuous ? "" : "chip-off")"
@@ -419,9 +461,15 @@
     };
 
     private async Task SetRecordingAsync(bool? events = null, bool? continuous = null, List<string>? eventTypes = null,
-        int? eventRetentionDays = null, int? continuousRetentionDays = null, string? recordStream = null)
+        int? eventRetentionDays = null, int? continuousRetentionDays = null, string? recordStream = null,
+        List<string>? scheduleDays = null, string? scheduleStart = null, string? scheduleEnd = null,
+        bool? scheduleEnabled = null)
     {
-        object body = new { events, continuous, eventTypes, eventRetentionDays, continuousRetentionDays, recordStream };
+        object body = new
+        {
+            events, continuous, eventTypes, eventRetentionDays, continuousRetentionDays, recordStream,
+            scheduleDays, scheduleStart, scheduleEnd, scheduleEnabled,
+        };
         if (await PostAsync("recording", body))
             _recording = await GetAsync<ApiRecordingSettings>("recording");
     }
@@ -453,6 +501,79 @@
         var types = (_recording.EventTypes ?? _recording.KnownTypes ?? new List<string>()).ToList();
         if (!types.Remove(label)) types.Add(label);
         return SetRecordingAsync(eventTypes: types);
+    }
+
+    // ------------------------------------------------------------ capture schedule
+
+    private static readonly string[] WeekDayTokens = { "mon", "tue", "wed", "thu", "fri", "sat", "sun" };
+
+    private bool DayEnabled(string day) =>
+        _recording?.ScheduleDays is not { Count: > 0 } days || days.Contains(day);
+
+    private static string DayLabel(string day) => char.ToUpperInvariant(day[0]) + day[1..];
+    private static string DayName(string day) => day switch
+    {
+        "mon" => "Mondays", "tue" => "Tuesdays", "wed" => "Wednesdays", "thu" => "Thursdays",
+        "fri" => "Fridays", "sat" => "Saturdays", _ => "Sundays",
+    };
+
+    private static int MinutesOf(string? hhmm) =>
+        hhmm is { Length: >= 5 }
+        && int.TryParse(hhmm.AsSpan(0, 2), out var h) && int.TryParse(hhmm.AsSpan(3, 2), out var m)
+            ? h * 60 + m
+            : 0;
+
+    private bool HasTimeWindow =>
+        _recording != null && MinutesOf(_recording.ScheduleStart) != MinutesOf(_recording.ScheduleEnd);
+
+    private async Task ToggleScheduleDayAsync(string day)
+    {
+        if (_recording == null) return;
+        var days = _recording.ScheduleDays is { Count: > 0 } d ? d.ToList() : WeekDayTokens.ToList();
+        if (!days.Remove(day)) days.Add(day);
+        if (days.Count == 0)
+        {
+            // No days = capture nothing, which is what the events switch is for.
+            _status = "At least one day stays selected — to stop capturing entirely, turn off detection events.";
+            return;
+        }
+        await SetRecordingAsync(scheduleDays: days);
+    }
+
+    /// <summary>Time inputs post only the field that changed (null = leave alone).</summary>
+    private Task SetScheduleTimeAsync(string? start = null, string? end = null) =>
+        SetRecordingAsync(scheduleStart: Hhmm(start), scheduleEnd: Hhmm(end));
+
+    /// <summary>Browsers may report "HH:mm:ss" — the API wants strict HH:mm ("" clears).</summary>
+    private static string? Hhmm(string? raw) =>
+        raw is { Length: > 5 } ? raw[..5] : raw;
+
+    private string ScheduleSummary
+    {
+        get
+        {
+            if (_recording == null) return "";
+            var days = _recording.ScheduleDays;
+            string dayPart;
+            if (days is not { Count: > 0 } || days.Count >= 7)
+                dayPart = "every day";
+            else
+            {
+                var ordered = WeekDayTokens.Where(days.Contains).ToList();
+                dayPart = string.Join(", ", ordered) switch
+                {
+                    "mon, tue, wed, thu, fri" => "on weekdays",
+                    "sat, sun" => "at weekends",
+                    _ => "on " + string.Join(", ", ordered.Select(DayLabel)),
+                };
+            }
+            if (!HasTimeWindow) return $"Capturing events all day, {dayPart}.";
+            int s = MinutesOf(_recording.ScheduleStart), e = MinutesOf(_recording.ScheduleEnd);
+            string from = s == 0 ? "midnight" : _recording.ScheduleStart!;
+            string until = e == 0 ? "midnight" : _recording.ScheduleEnd!;
+            string wrap = s > e && e != 0 ? " (overnight)" : "";
+            return $"Capturing events {from}–{until}{wrap}, {dayPart}. Anything outside is discarded.";
+        }
     }
 
     private async Task RebootAsync()

--- a/src/Neolink.WebClient/Components/Pages/Home.razor
+++ b/src/Neolink.WebClient/Components/Pages/Home.razor
@@ -166,10 +166,6 @@
             {
                 <span>Neolink.NET web client</span>
             }
-            @if (!string.IsNullOrEmpty(_version))
-            {
-                <span class="sidebar-version" title="Neolink.NET server version">v@(_version)</span>
-            }
         </div>
     </aside>
 
@@ -356,6 +352,11 @@
 
             <span class="tool-sep"></span>
             <a class="tool-btn" href="monitor" title="Server & browser resource usage, live">@UiIcon.Render("activity", 14) <span class="tool-name">Monitor</span></a>
+
+            @if (!string.IsNullOrEmpty(_version))
+            {
+                <span class="toolbar-version" title="Neolink.NET server version">v@(_version)</span>
+            }
         </div>
 
         @if (_showLayouts)

--- a/src/Neolink.WebClient/Components/Pages/Timeline.razor
+++ b/src/Neolink.WebClient/Components/Pages/Timeline.razor
@@ -15,13 +15,16 @@
     <div class="toolbar tl-toolbar">
         <a class="tool-btn" href="" title="Back to live view">‹ Live</a>
         <span class="tool-label">TIMELINE</span>
-        <button class="tool-btn" title="Previous day" @onclick="() => ChangeDayAsync(-1)">◀</button>
+        @* Day navigation uses thin chevrons; the transport control below is a solid
+           accent pill with a filled glyph, so the two can't be mistaken for each other. *@
+        <button class="tool-btn tl-daynav" title="Previous day" @onclick="() => ChangeDayAsync(-1)">@UiIcon.Render("chev-left", 16)</button>
         <span class="tl-date">@_date.ToString("ddd, d MMMM yyyy")</span>
-        <button class="tool-btn" title="Next day" disabled="@(_date >= DateTime.Today)"
-                @onclick="() => ChangeDayAsync(1)">▶</button>
+        <button class="tool-btn tl-daynav" title="Next day" disabled="@(_date >= DateTime.Today)"
+                @onclick="() => ChangeDayAsync(1)">@UiIcon.Render("chev-right", 16)</button>
         <span class="tool-sep"></span>
-        <button class="tool-btn @(_playing ? "active" : "")" @onclick="TogglePlayAsync">
-            @(_playing ? "❚❚" : "▶") <span class="tool-name">@(_playing ? "Pause" : "Play")</span>
+        <button class="tl-play @(_playing ? "playing" : "")"
+                title="@(_playing ? "Pause playback" : "Play the day from the cursor")" @onclick="TogglePlayAsync">
+            @UiIcon.Render(_playing ? "pause" : "play", 14) <span class="tool-name">@(_playing ? "Pause" : "Play")</span>
         </button>
         @* Fast playback for skimming a day; the choice sticks (localStorage). *@
         @foreach (var s in SpeedOptions)

--- a/src/Neolink.WebClient/Models.cs
+++ b/src/Neolink.WebClient/Models.cs
@@ -77,13 +77,18 @@ public sealed record ApiAuthToken(string Token, string User, bool Admin);
 /// <summary>GET /api/users — one account row.</summary>
 public sealed record ApiUserInfo(string Name, bool Admin);
 
-/// <summary>GET/POST /api/cameras/{name}/recording — runtime recording switches.</summary>
+/// <summary>GET/POST /api/cameras/{name}/recording — runtime recording switches.
+/// The capture schedule arrives in effective form: ScheduleDays is the full day
+/// list (never null in practice), Schedule times are "HH:mm" or "" (= midnight).
+/// It only applies while ScheduleEnabled (opt-in; off = capture always).</summary>
 public sealed record ApiRecordingSettings(bool Events, bool Continuous,
     List<string>? EventTypes, List<string>? KnownTypes, bool ContinuousAvailable = false,
     int? EventRetentionDays = null, int? ContinuousRetentionDays = null,
     int DefaultEventRetentionDays = 7, int DefaultContinuousRetentionDays = 7,
     bool EventsAvailable = true, string? RecordStream = null,
-    string? DefaultRecordStream = null, List<string>? AvailableStreams = null)
+    string? DefaultRecordStream = null, List<string>? AvailableStreams = null,
+    List<string>? ScheduleDays = null, string? ScheduleStart = null, string? ScheduleEnd = null,
+    bool ScheduleEnabled = false)
 {
     /// <summary>null EventTypes = every detection type is recorded.</summary>
     public bool TypeEnabled(string label) => EventTypes == null || EventTypes.Contains(label);
@@ -191,6 +196,11 @@ public static class UiIcon
             "battery" => "<rect x=\"1\" y=\"6\" width=\"18\" height=\"12\" rx=\"2\"/><line x1=\"23\" y1=\"11\" x2=\"23\" y2=\"13\"/>",
             "bolt" => "<polygon points=\"13 2 3 14 12 14 11 22 21 10 12 10 13 2\"/>",
             "moon" => "<path d=\"M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z\"/>",
+            // Transport controls are FILLED so they read as playback, not navigation.
+            "play" => "<polygon points=\"6 4 20 12 6 20 6 4\" fill=\"currentColor\"/>",
+            "pause" => "<rect x=\"5\" y=\"4\" width=\"5\" height=\"16\" rx=\"1\" fill=\"currentColor\"/><rect x=\"14\" y=\"4\" width=\"5\" height=\"16\" rx=\"1\" fill=\"currentColor\"/>",
+            "chev-left" => "<polyline points=\"15 18 9 12 15 6\"/>",
+            "chev-right" => "<polyline points=\"9 18 15 12 9 6\"/>",
             _ => "",
         };
         return new MarkupString(

--- a/src/Neolink.WebClient/wwwroot/css/app.css
+++ b/src/Neolink.WebClient/wwwroot/css/app.css
@@ -309,14 +309,15 @@ html, body {
     padding-top: 10px;
 }
 
-/* Server version, always visible at the sidebar bottom */
-.sidebar-version {
-    display: block;
-    margin-top: 4px;
+/* Server version, pinned to the toolbar's right edge */
+.toolbar-version {
+    margin-left: auto;
+    padding-left: 10px;
     font-size: 10px;
     letter-spacing: 0.06em;
     color: color-mix(in srgb, var(--muted) 70%, transparent);
     font-variant-numeric: tabular-nums;
+    white-space: nowrap;
 }
 
 /* Signed-in user + sign-out, pinned at the sidebar bottom */
@@ -1090,6 +1091,35 @@ body.is-fullscreen .fs-exit { display: inline-flex; }
 
     .tile-bar { opacity: 1; } /* no hover on touch: keep controls visible */
 
+    /* Phones: every tile control must stay on-screen. The camera name is the
+       only flexible item — it shrinks to an ellipsis — while the buttons and
+       the stream picker compact instead of being pushed off the right edge. */
+    .tile-bar { gap: 4px; padding: 4px 6px; }
+
+    .tile-name {
+        flex: 0 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .tile-bar select {
+        min-width: 0;
+        max-width: 72px;
+        font-size: 11px;
+        padding: 2px 4px;
+    }
+
+    .tile-bar .icon-btn {
+        min-width: 30px;
+        min-height: 30px;
+        padding: 4px;
+        flex: 0 0 auto;
+    }
+
+    .cam-rec-badge { letter-spacing: 0.5px; padding: 1px 5px; }
+
     /* Phones: the toolbar scrolls sideways instead of stacking into a wall */
     .toolbar {
         flex-wrap: nowrap;
@@ -1110,7 +1140,7 @@ body.is-fullscreen .fs-exit { display: inline-flex; }
 
 /* Touch devices, any width: finger-sized targets and no hover-only affordances */
 @media (pointer: coarse) {
-    .tool-btn, .tool-select { min-height: 40px; }
+    .tool-btn, .tool-select, .tl-play { min-height: 40px; }
     .icon-btn { min-width: 36px; min-height: 36px; }
     .chip { min-height: 32px; padding: 5px 13px; }
     .zoom-hud { display: flex; } /* no hover on touch: keep the zoom pill visible */
@@ -1828,6 +1858,38 @@ body.is-fullscreen .fs-exit { display: inline-flex; }
 .tl-toolbar { flex: 0 0 auto; }
 .tl-date { font-size: 13px; font-weight: 600; min-width: 150px; text-align: center; }
 
+/* Day-selector chevrons stay quiet so the transport control can stand out */
+.tl-daynav { color: var(--muted); }
+.tl-daynav:hover:not(:disabled) { color: var(--text); }
+.tl-daynav:disabled { opacity: 0.35; cursor: default; }
+
+/* The play/pause transport: a solid accent pill with a filled glyph — nothing
+   like the thin date chevrons, so the two can't be confused again. */
+.tl-play {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 7px;
+    min-height: 32px;
+    padding: 5px 16px;
+    border: 1px solid transparent;
+    border-radius: 999px;
+    background: var(--accent);
+    color: #0a1424;
+    font-size: 13px;
+    font-weight: 700;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.tl-play:hover { filter: brightness(1.12); }
+
+.tl-play.playing {
+    background: var(--accent-soft);
+    border-color: color-mix(in srgb, var(--accent) 45%, transparent);
+    color: var(--accent);
+}
+
 .tl-clock {
     margin-left: auto;
     font-size: 15px;
@@ -1999,6 +2061,30 @@ body.is-fullscreen .fs-exit { display: inline-flex; }
     justify-content: center;
     color: var(--muted);
     font-size: 13px;
+}
+
+/* Buffering veil: JS (tlSync) toggles .tl-loading while the player has no
+   decodable picture under the cursor. The fade-in delay keeps ordinary quick
+   seeks spinner-free — only genuinely slow loads surface it. */
+.tl-tile.tl-loading::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 26px;
+    height: 26px;
+    margin: -13px 0 0 -13px;
+    border-radius: 50%;
+    border: 3px solid rgba(255, 255, 255, 0.18);
+    border-top-color: var(--accent);
+    opacity: 0;
+    animation:
+        tl-busy-in 0.15s ease 0.35s forwards,
+        reconnect-spin 0.9s linear infinite;
+}
+
+@keyframes tl-busy-in {
+    to { opacity: 1; }
 }
 
 .event-player-foot {
@@ -2654,6 +2740,58 @@ body.is-fullscreen .fs-exit { display: inline-flex; }
 
 .ret-input:focus { border-color: var(--accent); }
 .ret-input::placeholder { color: var(--muted); }
+
+/* Full-bleed hairline splitting a campanel section into halves (event-based
+   recording above, continuous below) */
+.campanel-divider {
+    border-top: 1px solid var(--line);
+    margin: 10px -12px;
+}
+
+/* Capture schedule (camera panel → RECORDING): day chips + a time window,
+   shown only while the "Scheduled capture" switch is on */
+.sched {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 8px;
+    min-width: 0;
+    padding: 2px 0 4px;
+}
+
+.sched-days { display: flex; gap: 4px; flex-wrap: wrap; justify-content: flex-end; }
+
+.sched-day {
+    min-width: 42px;
+    justify-content: center;
+    text-align: center;
+    padding-left: 0;
+    padding-right: 0;
+}
+
+.sched-times { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; justify-content: flex-end; }
+
+.sched-time {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    color: var(--muted);
+}
+
+.sched-time input[type="time"] {
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 4px 6px;
+    font-size: 12px;
+    color-scheme: dark;
+}
+
+.sched-time input[type="time"]:focus { border-color: var(--accent); outline: none; }
+
+.sched .event-sub { text-align: right; }
 
 .control-row select {
     background: var(--bg);

--- a/src/Neolink.WebClient/wwwroot/js/neolink.js
+++ b/src/Neolink.WebClient/wwwroot/js/neolink.js
@@ -809,8 +809,15 @@
         tlSync(videoId, url, offset, playing, rate) {
             const v = document.getElementById(videoId);
             if (!v) return 0;
+            // Busy veil: while the player has no decodable picture under the
+            // cursor (first load, a seek into an unbuffered range, a stalled
+            // fetch), the tile carries .tl-loading and CSS shows a spinner —
+            // otherwise a slow segment just looks frozen.
+            const tile = v.closest('.tl-tile');
+            const busy = (b) => { if (tile) tile.classList.toggle('tl-loading', b); };
             v.muted = true;
             if (!url) {
+                busy(false);
                 delete v.dataset.tlUrl;
                 if (v.getAttribute('src')) { v.removeAttribute('src'); try { v.load(); } catch { } }
                 return 0;
@@ -837,7 +844,10 @@
             } catch { }
             if (playing) { if (v.paused) v.play().catch(() => { }); }
             else if (!v.paused) v.pause();
-            if (v.error) return -1; // dead media must not hold the timeline hostage
+            if (v.error) { busy(false); return -1; } // dead media must not hold the timeline hostage
+            // Playing needs future data to keep moving; a paused scrub only needs
+            // the current frame to be showing something.
+            busy(v.seeking || v.readyState < (playing ? 3 : 2));
             return playing ? Math.max(0, offset - (v.currentTime || 0)) : 0;
         },
 


### PR DESCRIPTION
## Summary

**Per-camera capture schedule (beta, opt-in)** â€” Camera settings â†’ Recording gains a *Scheduled capture* switch. When on, Monâ€“Sun day chips and a from/until time window (overnight spans like 22:00â€“06:00 supported) control when events are captured; pushes outside the schedule are discarded server-side before an event opens. Off by default â€” capture at all times â€” and switching it off keeps the schedule dormant instead of deleting it. Persisted in `settings.json`, exposed on `GET/POST /api/cameras/{name}/recording`.

**Home Assistant: all event types reported** â€” package, line-crossing, intrusion and loitering now get binary sensors alongside motion/person/vehicle/animal. Announced lazily on first detection so cameras without those features don't accumulate dead entities.

**Home Assistant: doorbell press no longer looks stuck** â€” new "Visitor" binary sensor pulses ON at the press and is auto-cleared by HA via `off_delay` (the event entity remains for automations, but it inherently displays the last press forever, which read as a held state). A 3-second grace window dedupes the repeated "visitor" pushes cameras send while the chime rings.

**UI fixes**
- Timeline: play/pause is a solid accent pill with a filled glyph; day navigation uses thin chevrons â€” no more confusing the two.
- Timeline: tiles show a buffering spinner while footage under the cursor is loading (fades in after 350 ms so quick seeks stay clean).
- Mobile: video-tile controls always fit on-screen â€” the camera name shrinks to an ellipsis and buttons compact instead of overflowing off the right edge.
- Camera settings: hairline divider between the event-based and continuous recording controls.
- Server version moved from the sidebar footer to the right edge of the top toolbar (visible with the sidebar collapsed).

**Housekeeping** â€” version bumped to 0.8.0; changelog split so 0.7.0 reflects what is already released.

## Testing

- `dotnet build` clean; all 29 self-tests pass, including a new capture-schedule suite (day filter, inclusive/exclusive bounds, overnight wrap, one-sided windows, dormant-while-disabled, strict `HH:mm` parsing).
- Verified against a live instance: schedule API roundtrip (enable â†’ configure â†’ disable keeps the schedule dormant â†’ unrelated updates leave it untouched â†’ re-enable restores it), timeline toolbar and spinner rendering, and the worst-case mobile tile bar (REC badge + stream select + 5 buttons) at 375 px with zero overflow.
- MQTT changes are build/code-verified only â€” the new sensors announce on first detection after deploying against a broker + HA.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)