### PR TITLE
Timeline precision controls: zoomable lanes, transport cluster, keyboard shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,39 @@ Release notes for Neolink.NET. Releasing works by tagging `vX.Y.Z` — the docke
 workflow bakes the tag into the app as its version (see "Versioning & releases"
 in the README). Paste the matching section below into the GitHub release.
 
-## 0.8.2 — unreleased
+## 0.8.3 — unreleased
+
+### New
+
+- **Timeline precision controls** — frame-level review without leaving the
+  browser:
+  - *Zoom*: scroll or pinch on the lanes to zoom from the full 24 h down to a
+    one-minute window (double-click, the zoom chip or `0` resets; Shift+scroll
+    pans). The ruler adapts from hours down to seconds as you go.
+  - *Day overview*: a slim always-visible strip of the whole day above the
+    lanes — drag its highlighted window to move the zoomed view.
+  - *Hover readout*: a hairline with the exact time (tenths when zoomed tight)
+    follows the mouse across the lanes.
+  - *Transport cluster*: previous/next event hop, −10s/−1s/+1s/+10s around
+    play/pause, with 0.1 s nudges for near-frame stepping (paused seeks now
+    land within 0.05 s).
+  - *Keyboard*: Space/K play-pause, ←/→ step (Shift 10 s, Ctrl 0.1 s), J/L,
+    ,/. nudge, [/] event hop, +/−/0 zoom, T to type an exact time — the `?`
+    button shows the cheat sheet.
+  - *Slow motion*: ¼× and ½× join the playback speeds.
+  - The clock is clickable: type 16:39:12 and you're there.
+
+### Fixed
+
+- The timeline's buffering spinner no longer lingers after pausing: the veil
+  now follows the video element's own events, so it clears the moment the
+  paused frame is ready (and appears instantly on a genuine mid-stream stall).
+- Content-free smart-event pushes (an empty `yoloWorldEventList`, sent
+  constantly by some firmware) no longer land in the Info log on every
+  reconnect — the capture aid only surfaces msg-600 payloads that actually
+  carry data. `NEOLINK_DEBUG_ALARMS=1` still logs everything.
+
+## 0.8.2
 
 ### Changed
 
@@ -35,7 +67,7 @@ in the README). Paste the matching section below into the GitHub release.
   review, except while the filter editor is open (so filters can be adjusted
   back).
 
-## 0.8.0 — unreleased
+## 0.8.0
 
 ### New
 

--- a/src/Neolink.Server/Neolink.Server.csproj
+++ b/src/Neolink.Server/Neolink.Server.csproj
@@ -11,7 +11,7 @@
          log, /api/features and the web UI. Release builds override it with the
          git tag (docker.yml passes -p:Version), so tagging vX.Y.Z is what
          increments the released version. -->
-    <Version>0.8.2</Version>
+    <Version>0.8.3</Version>
     <InvariantGlobalization>true</InvariantGlobalization>
     <ServerGarbageCollection>false</ServerGarbageCollection>
     <TieredPgo>true</TieredPgo>

--- a/src/Neolink.Server/Protocol/BcCamera.cs
+++ b/src/Neolink.Server/Protocol/BcCamera.cs
@@ -386,8 +386,10 @@ public sealed class BcCamera : IBcCamera
     /// <summary>
     /// Capture aid for perimeter protection: newer firmware pushes smart events
     /// (yoloWorldEventList, msg 600) whose XML shape has not been mapped yet.
-    /// The first push per connection is logged in full at Info so a user tripping
-    /// their line-crossing/intrusion zone can report the exact wire format.
+    /// The first push per connection WITH ACTUAL CONTENT is logged in full at
+    /// Info so a user tripping their line-crossing/intrusion zone can report
+    /// the exact wire format. Empty lists (&lt;yoloWorldEventList /&gt;) ride
+    /// along constantly on some firmware and say nothing — those stay at Debug.
     /// </summary>
     private async Task WatchSmartAiEventsAsync(CancellationToken ct)
     {
@@ -406,7 +408,8 @@ public sealed class BcCamera : IBcCamera
             }
             if (msg.Xml == null) continue;
             var raw = Encoding.UTF8.GetString(msg.Xml.Serialize()).Replace('\r', ' ').Replace('\n', ' ');
-            if (!logged || Log.AlarmXml)
+            bool hasContent = msg.Xml.Raw.Any(e => e.HasElements);
+            if (hasContent && (!logged || Log.AlarmXml))
             {
                 logged = true;
                 Log.Info($"BC {_logTag}: smart-event push (msg 600) — raw: " +

--- a/src/Neolink.Server/SelfTest.cs
+++ b/src/Neolink.Server/SelfTest.cs
@@ -322,6 +322,13 @@ public static class SelfTest
                 "<AItype>none</AItype><smartAiTypeList /></AlarmEvent>"));
             Assert(!emptySmart.Active, "empty smart list is not a detection");
 
+            // Content-free msg-600 pushes (<yoloWorldEventList />) must not reach
+            // the Info log — the capture aid only surfaces payloads with substance.
+            var emptyYolo = Bc.Xml.BcXmlBody.TryParse(Encoding.UTF8.GetBytes(
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?><body><yoloWorldEventList version=\"1.1\" /></body>"));
+            Assert(emptyYolo != null && emptyYolo.Raw.Count > 0 && !emptyYolo.Raw.Any(e => e.HasElements),
+                "empty yoloWorldEventList counts as content-free");
+
             // Perimeter labels are OPT-IN: an untouched filter (null) records the
             // classic detections but not the new labels — nobody's recordings
             // change until they tick the chips.

--- a/src/Neolink.WebClient/Components/Pages/Timeline.razor
+++ b/src/Neolink.WebClient/Components/Pages/Timeline.razor
@@ -15,33 +15,78 @@
     <div class="toolbar tl-toolbar">
         <a class="tool-btn" href="" title="Back to live view">‹ Live</a>
         <span class="tool-label">TIMELINE</span>
-        @* Day navigation uses thin chevrons; the transport control below is a solid
-           accent pill with a filled glyph, so the two can't be mistaken for each other. *@
+        @* Day navigation uses thin chevrons; the transport cluster below uses a solid
+           accent pill and filled glyphs, so the two can't be mistaken for each other. *@
         <button class="tool-btn tl-daynav" title="Previous day" @onclick="() => ChangeDayAsync(-1)">@UiIcon.Render("chev-left", 16)</button>
         <span class="tl-date">@_date.ToString("ddd, d MMMM yyyy")</span>
         <button class="tool-btn tl-daynav" title="Next day" disabled="@(_date >= DateTime.Today)"
                 @onclick="() => ChangeDayAsync(1)">@UiIcon.Render("chev-right", 16)</button>
         <span class="tool-sep"></span>
+        @* Precision transport: event hops, coarse and fine steps around play/pause.
+           Every control names its keyboard twin — the fastest way to learn them. *@
+        <button class="tool-btn tl-step" title="Previous event   —   [" @onclick="() => JumpEventAsync(-1)">@UiIcon.Render("skip-back", 13)</button>
+        <button class="tool-btn tl-step" title="Back 10 seconds   —   J or Shift+←" @onclick="() => StepAsync(-10)">−10s</button>
+        <button class="tool-btn tl-step" title="Back 1 second   —   ←   (Ctrl+← or , for 0.1 s)" @onclick="() => StepAsync(-1)">−1s</button>
         <button class="tl-play @(_playing ? "playing" : "")"
-                title="@(_playing ? "Pause playback" : "Play the day from the cursor")" @onclick="TogglePlayAsync">
+                title="@(_playing ? "Pause — Space or K" : "Play — Space or K")" @onclick="TogglePlayAsync">
             @UiIcon.Render(_playing ? "pause" : "play", 14) <span class="tool-name">@(_playing ? "Pause" : "Play")</span>
         </button>
-        @* Fast playback for skimming a day; the choice sticks (localStorage). *@
+        <button class="tool-btn tl-step" title="Forward 1 second   —   →   (Ctrl+→ or . for 0.1 s)" @onclick="() => StepAsync(1)">+1s</button>
+        <button class="tool-btn tl-step" title="Forward 10 seconds   —   L or Shift+→" @onclick="() => StepAsync(10)">+10s</button>
+        <button class="tool-btn tl-step" title="Next event   —   ]" @onclick="() => JumpEventAsync(1)">@UiIcon.Render("skip-fwd", 13)</button>
+        @* Slow motion through fast skim; the choice sticks (localStorage). *@
         @foreach (var s in SpeedOptions)
         {
             var sp = s;
             <button class="chip tl-speed @(_speed == sp ? "chip-active" : "")"
-                    title="Play at @(sp)× speed (beta)" @onclick="() => SetSpeedAsync(sp)">@(sp)×</button>
+                    title="Play at @SpeedLabel(sp) speed (beta)" @onclick="() => SetSpeedAsync(sp)">@SpeedLabel(sp)</button>
         }
         <span class="beta-tag" title="Fast playback is new — expect rough edges and report anything odd">BETA</span>
         @if (Lagging)
         {
-            <span class="tl-lag" title="The streams can't sustain @(_speed)× right now (server delivery or browser decoding is the limit) — the timeline slows down until they catch up">
+            <span class="tl-lag" title="The streams can't sustain @SpeedLabel(_speed) right now (server delivery or browser decoding is the limit) — the timeline slows down until they catch up">
                 ⏳ catching up…
             </span>
         }
-        <span class="tl-clock">@TimeText(_t)</span>
+        <button class="tool-btn tl-keys-btn @(_showKeys ? "active" : "")" title="Keyboard shortcuts"
+                @onclick="() => _showKeys = !_showKeys">?</button>
+        <button class="chip tl-zoom-chip @(Zoomed ? "chip-active" : "chip-off")"
+                title="@(Zoomed ? "Zoomed in — click (or press 0) to see the whole day again" : "Scroll or pinch on the timeline to zoom in for fine seeking")"
+                @onclick="ResetZoomAsync">@UiIcon.Render("zoom", 12) @SpanLabel(_viewSpan)</button>
+        @if (_editClock)
+        {
+            <input id="tl-clock-edit" class="tl-clock-edit" value="@TimeText(_t)" spellcheck="false"
+                   placeholder="HH:mm:ss" @onchange="ClockEditedAsync" @onblur="() => _editClock = false" />
+        }
+        else
+        {
+            <span class="tl-clock tl-clock-btn" role="button" title="Click (or press T) to type an exact time"
+                  @onclick="OpenClockEdit">@TimeText(_t)</span>
+        }
     </div>
+
+    @if (_showKeys)
+    {
+        <div class="tl-keys-backdrop" @onclick="() => _showKeys = false">
+            <div class="tl-keys-panel" @onclick:stopPropagation="true">
+                <div class="tl-keys-title">
+                    <span>KEYBOARD SHORTCUTS</span>
+                    <button class="icon-btn" title="Close" @onclick="() => _showKeys = false">✕</button>
+                </div>
+                <div class="tl-keys-grid">
+                    <span>Space · K</span><span>Play / pause</span>
+                    <span>← →</span><span>Step 1 s &nbsp;(Shift: 10 s, Ctrl: 0.1 s)</span>
+                    <span>J · L</span><span>Back / forward 10 s</span>
+                    <span>, · .</span><span>Nudge 0.1 s — frame-level review</span>
+                    <span>[ · ]</span><span>Previous / next event</span>
+                    <span>scroll</span><span>Zoom in/out around the mouse (Shift: pan)</span>
+                    <span>+ − 0</span><span>Zoom in / out / whole day</span>
+                    <span>T</span><span>Jump to an exact time</span>
+                </div>
+                <div class="event-sub tl-keys-hint">Drag the thin day strip above the lanes to move the zoomed view. Double-click the lanes to zoom back out.</div>
+            </div>
+        </div>
+    }
 
     @if (_error != null)
     {
@@ -80,17 +125,45 @@
         {
         <div class="tl-board">
             <div class="tl-names">
-                <div class="tl-name"></div>
+                <div class="tl-name tl-name-head"></div>
                 @foreach (var cam in Included)
                 {
                     <div class="tl-name" title="@cam.Name">@cam.Name</div>
                 }
             </div>
-            <div class="tl-lanes" id="tl-scrub">
-                <div class="tl-ruler">
-                    @for (int h = 0; h <= 24; h += 3)
+            @* data-vs/data-vspan let the JS hover bubble map pixels → time locally,
+               with zero server round-trips while the mouse moves. *@
+            <div class="tl-lanes" id="tl-scrub" data-vs="@_viewStart" data-vspan="@_viewSpan">
+                @* The whole day at a glance, always: footage blocks, the red cursor,
+                   and — when zoomed — the draggable view-window rectangle. *@
+                <div class="tl-overview">
+                    @foreach (var cam in Included)
                     {
-                        <span class="tl-tick" style="left:@Pct(h * 3600.0)">@($"{h:00}")</span>
+                        @if (_cov.TryGetValue(cam.Name, out var ovSegs))
+                        {
+                            @foreach (var s in ovSegs)
+                            {
+                                <div class="tl-ov-cov" style="left:@DayPct(s.Start); width:@DayPct(s.Span)"></div>
+                            }
+                        }
+                    }
+                    <div class="tl-ov-cursor" style="left:@DayPct(_t)"></div>
+                    @if (Zoomed)
+                    {
+                        <div class="tl-ov-win" style="left:@DayPct(_viewStart); width:@DayPct(_viewSpan)"></div>
+                    }
+                </div>
+                <div class="tl-ruler">
+                    @foreach (var (t, label) in RulerTicks())
+                    {
+                        @if (label != null)
+                        {
+                            <span class="tl-tick" style="left:@Pct(t)">@label</span>
+                        }
+                        else
+                        {
+                            <span class="tl-tick-minor" style="left:@Pct(t)"></span>
+                        }
                     }
                 </div>
                 @foreach (var cam in Included)
@@ -100,22 +173,31 @@
                         {
                             @foreach (var s in segs)
                             {
-                                <div class="tl-cov" style="left:@Pct(s.Start); width:@Pct(s.Span)"></div>
+                                @if (InView(s.Start, s.Start + s.Span))
+                                {
+                                    <div class="tl-cov" style="left:@Pct(s.Start); width:@W(s.Span)"></div>
+                                }
                             }
                         }
                         @if (_marks.TryGetValue(cam.Name, out var marks))
                         {
                             @foreach (var m in marks)
                             {
-                                <div class="tl-ev" title="@m.Title"
-                                     style="left:@Pct(m.Start); width:@Pct(Math.Max(m.End - m.Start, 40)); background:@m.Color"></div>
+                                @if (InView(m.Start, m.End))
+                                {
+                                    <div class="tl-ev" title="@m.Title"
+                                         style="left:@Pct(m.Start); width:@WMark(m.End - m.Start); background:@m.Color"></div>
+                                }
                             }
                         }
                     </div>
                 }
-                <div class="tl-cursor" style="left:@Pct(_t)">
-                    <span class="tl-cursor-time">@TimeText(_t)</span>
-                </div>
+                @if (InView(_t, _t))
+                {
+                    <div class="tl-cursor" style="left:@Pct(_t)">
+                        <span class="tl-cursor-time">@TimeText(_t)</span>
+                    </div>
+                }
             </div>
         </div>
 
@@ -173,11 +255,88 @@
     private sealed class Prefs
     {
         public List<string> Included { get; set; } = new();
-        public int Speed { get; set; } = 1;
+        public double Speed { get; set; } = 1;
     }
 
-    private static readonly int[] SpeedOptions = { 1, 2, 4, 8, 16 };
-    private int _speed = 1;
+    // 0.25/0.5 are slow motion — fine review of a fast moment; the rest skim.
+    private static readonly double[] SpeedOptions = { 0.25, 0.5, 1, 2, 4, 8, 16 };
+    private double _speed = 1;
+
+    private static string SpeedLabel(double sp) => sp switch
+    {
+        0.25 => "¼×",
+        0.5 => "½×",
+        _ => $"{sp:0.#}×",
+    };
+
+    // ------------------------------------------------------------ zoomable view window
+    //
+    // The lanes show [_viewStart, _viewStart + _viewSpan] seconds of the day.
+    // At the full 24 h a pixel is ~a minute of footage — zooming to the 60 s
+    // floor makes a pixel ~50 ms, which is what turns scrubbing from "roughly
+    // there" into frame-level seeking.
+
+    private const double MinSpan = 60;
+    private double _viewStart;
+    private double _viewSpan = DaySeconds;
+    private bool _showKeys;
+    private bool _editClock;
+    private bool _focusClock;
+
+    private bool Zoomed => _viewSpan < DaySeconds - 1;
+
+    private string Pct(double seconds) =>
+        $"{(seconds - _viewStart) / _viewSpan * 100:0.####}%";
+
+    /// <summary>Width of an exact span within the view window.</summary>
+    private string W(double span) => $"{span / _viewSpan * 100:0.####}%";
+
+    /// <summary>Event-mark width: never thinner than ~2px worth of the window.</summary>
+    private string WMark(double span) => W(Math.Max(span, _viewSpan * 0.0018));
+
+    /// <summary>Position on the full-day overview strip (never windowed).</summary>
+    private static string DayPct(double seconds) => $"{seconds / DaySeconds * 100:0.###}%";
+
+    private bool InView(double start, double end) =>
+        end >= _viewStart && start <= _viewStart + _viewSpan;
+
+    private static string SpanLabel(double span) => span switch
+    {
+        >= DaySeconds - 1 => "24 h",
+        >= 3600 => $"{span / 3600:0.#} h",
+        >= 60 => $"{span / 60:0.#} m",
+        _ => $"{span:0} s",
+    };
+
+    /// <summary>
+    /// Adaptive ruler: pick the largest step that yields ≲16 labeled ticks for
+    /// the current window, with unlabeled minor ticks between them. Labels grow
+    /// detail as the window shrinks (hours → minutes → seconds).
+    /// </summary>
+    private IEnumerable<(double T, string? Label)> RulerTicks()
+    {
+        // Smallest step that still fits ≲16 labels (the array is descending).
+        double[] steps = { 10800, 7200, 3600, 1800, 900, 600, 300, 120, 60, 30, 10, 5, 2, 1 };
+        double major = steps.LastOrDefault(s => _viewSpan / s <= 16, 10800);
+        int perMajor = major >= 60 ? 4 : 5;
+        double minor = major / perMajor;
+        long from = (long)Math.Ceiling(_viewStart / minor);
+        long to = (long)Math.Floor((_viewStart + _viewSpan) / minor);
+        for (long k = from; k <= to; k++)
+        {
+            double t = k * minor;
+            bool isMajor = k % perMajor == 0;
+            yield return (t, isMajor ? TickLabel(t, major) : null);
+        }
+    }
+
+    private static string TickLabel(double t, double major)
+    {
+        var ts = TimeSpan.FromSeconds(t);
+        return major >= 3600 ? $"{(int)ts.TotalHours:00}"
+            : major >= 60 ? $"{(int)ts.TotalHours:00}:{ts.Minutes:00}"
+            : $"{(int)ts.TotalHours:00}:{ts.Minutes:00}:{ts.Seconds:00}";
+    }
 
     // Adaptive playback: when the slowest healthy video falls behind the cursor
     // (server can't serve segments fast enough, or the browser can't decode this
@@ -220,7 +379,7 @@
                 if (json != null && JsonSerializer.Deserialize<Prefs>(json) is { } p)
                 {
                     _included = new HashSet<string>(p.Included, StringComparer.OrdinalIgnoreCase);
-                    _speed = SpeedOptions.Contains(p.Speed) ? p.Speed : 1;
+                    _speed = SpeedOptions.Contains(p.Speed) ? p.Speed : 1d;
                 }
             }
             catch { }
@@ -230,24 +389,34 @@
             await LoadDayAsync();
 
             _selfRef = DotNetObjectReference.Create(this);
+            await JS.InvokeVoidAsync("neolink.tlKeysInit", _selfRef);
             _ = ClockLoopAsync();
             _booted = true;
             StateHasChanged();
             return;
         }
 
-        // The lane strip only exists while cameras are selected; (re)hook the
-        // scrub handler whenever it (re)appears.
         if (!_booted || _selfRef == null) return;
+
+        if (_focusClock)
+        {
+            _focusClock = false;
+            await JS.InvokeVoidAsync("neolink.focusEl", "tl-clock-edit");
+        }
+
+        // The lane strip only exists while cameras are selected; (re)hook the
+        // scrub + zoom/hover handlers whenever it (re)appears.
         if (Included.Any() && !_scrubInit)
         {
             _scrubInit = true;
             await JS.InvokeVoidAsync("neolink.tlScrubInit", "tl-scrub", _selfRef);
+            await JS.InvokeVoidAsync("neolink.tlZoomInit", "tl-scrub", _selfRef);
         }
         else if (!Included.Any() && _scrubInit)
         {
             _scrubInit = false;
             await JS.InvokeVoidAsync("neolink.tlScrubDispose", "tl-scrub");
+            await JS.InvokeVoidAsync("neolink.tlZoomDispose", "tl-scrub");
         }
     }
 
@@ -451,10 +620,83 @@
     {
         await InvokeAsync(async () =>
         {
-            _t = Math.Clamp(fraction, 0, 1) * DaySeconds;
+            // The lane strip shows the view window, so a drag fraction maps
+            // through it — zoomed in, the same pixel distance seeks far finer.
+            _t = _viewStart + Math.Clamp(fraction, 0, 1) * _viewSpan;
             await SyncVideosAsync();
             StateHasChanged();
         });
+    }
+
+    /// <summary>Wheel/pinch zoom: the instant under the pointer stays put.</summary>
+    [JSInvokable]
+    public async Task OnTimelineZoom(double frac, double factor)
+    {
+        await InvokeAsync(() =>
+        {
+            double anchor = _viewStart + Math.Clamp(frac, 0, 1) * _viewSpan;
+            _viewSpan = Math.Clamp(_viewSpan * factor, MinSpan, DaySeconds);
+            _viewStart = Math.Clamp(anchor - Math.Clamp(frac, 0, 1) * _viewSpan, 0, DaySeconds - _viewSpan);
+            StateHasChanged();
+        });
+    }
+
+    [JSInvokable]
+    public async Task OnTimelinePan(int dir)
+    {
+        await InvokeAsync(() =>
+        {
+            _viewStart = Math.Clamp(_viewStart + dir * _viewSpan * 0.2, 0, DaySeconds - _viewSpan);
+            StateHasChanged();
+        });
+    }
+
+    /// <summary>Dragging the day-overview strip moves the zoomed window (a viewport
+    /// control — the cursor stays where it is).</summary>
+    [JSInvokable]
+    public async Task OnOverviewSeek(double frac)
+    {
+        await InvokeAsync(() =>
+        {
+            if (!Zoomed) return;
+            _viewStart = Math.Clamp(frac * DaySeconds - _viewSpan / 2, 0, DaySeconds - _viewSpan);
+            StateHasChanged();
+        });
+    }
+
+    [JSInvokable]
+    public async Task OnTimelineKey(string action)
+    {
+        await InvokeAsync(async () =>
+        {
+            var parts = action.Split(':');
+            switch (parts[0])
+            {
+                case "playpause":
+                    await TogglePlayAsync();
+                    break;
+                case "step" when double.TryParse(parts[1], System.Globalization.CultureInfo.InvariantCulture, out var s):
+                    await StepAsync(s);
+                    break;
+                case "event":
+                    await JumpEventAsync(parts[1] == "-1" ? -1 : 1);
+                    break;
+                case "zoom":
+                    if (parts[1] == "reset") await ResetZoomAsync();
+                    else await OnTimelineZoom(CursorFrac(), parts[1] == "in" ? 0.6 : 1.7);
+                    break;
+                case "clock":
+                    OpenClockEdit();
+                    break;
+            }
+            StateHasChanged();
+        });
+    }
+
+    private double CursorFrac()
+    {
+        double f = (_t - _viewStart) / _viewSpan;
+        return f is >= 0 and <= 1 ? f : 0.5;
     }
 
     private async Task TogglePlayAsync()
@@ -464,7 +706,74 @@
         await SyncVideosAsync();
     }
 
-    private async Task SetSpeedAsync(int speed)
+    /// <summary>Nudge the cursor and keep it on screen. Fine steps (0.1 s) pair
+    /// with the tight paused seek tolerance for near-frame-level review.</summary>
+    private async Task StepAsync(double seconds)
+    {
+        _t = Math.Clamp(_t + seconds, 0, DaySeconds - 0.05);
+        EnsureCursorVisible();
+        await SyncVideosAsync();
+        StateHasChanged();
+    }
+
+    /// <summary>Snap to the previous/next detection across the included cameras —
+    /// the fastest way to review a day: [ and ] hop from incident to incident.</summary>
+    private async Task JumpEventAsync(int dir)
+    {
+        var starts = Included
+            .SelectMany(c => _marks.TryGetValue(c.Name, out var m) ? m : (IEnumerable<Mark>)Array.Empty<Mark>())
+            .Select(m => m.Start)
+            .OrderBy(s => s);
+        double? target = dir > 0
+            ? starts.Where(s => s > _t + 0.25).Cast<double?>().FirstOrDefault()
+            : starts.Where(s => s < _t - 0.25).Cast<double?>().LastOrDefault();
+        if (target == null) return;
+        _t = target.Value;
+        EnsureCursorVisible(center: true);
+        await SyncVideosAsync();
+        StateHasChanged();
+    }
+
+    private async Task ResetZoomAsync()
+    {
+        _viewStart = 0;
+        _viewSpan = DaySeconds;
+        await Task.CompletedTask;
+        StateHasChanged();
+    }
+
+    /// <summary>Keeps the cursor inside the zoomed window after steps and jumps.</summary>
+    private void EnsureCursorVisible(bool center = false)
+    {
+        if (!Zoomed) return;
+        if (center)
+            _viewStart = _t - _viewSpan / 2;
+        else if (_t < _viewStart || _t > _viewStart + _viewSpan)
+            _viewStart = _t - _viewSpan * 0.2;
+        else
+            return;
+        _viewStart = Math.Clamp(_viewStart, 0, DaySeconds - _viewSpan);
+    }
+
+    private void OpenClockEdit()
+    {
+        _editClock = true;
+        _focusClock = true;
+    }
+
+    /// <summary>"16:39" or "16:39:12" → jump straight there.</summary>
+    private async Task ClockEditedAsync(ChangeEventArgs e)
+    {
+        _editClock = false;
+        if (!TimeSpan.TryParse((string?)e.Value, System.Globalization.CultureInfo.InvariantCulture, out var ts)
+            || ts < TimeSpan.Zero || ts >= TimeSpan.FromDays(1))
+            return;
+        _t = ts.TotalSeconds;
+        EnsureCursorVisible(center: true);
+        await SyncVideosAsync();
+    }
+
+    private async Task SetSpeedAsync(double speed)
     {
         _speed = speed;
         await SavePrefsAsync();
@@ -501,6 +810,12 @@
                     _t = DaySeconds - 1;
                     _playing = false;
                 }
+                // Zoomed playback follows the cursor — but ONLY when it just
+                // walked up to the window's right edge. A cursor far outside the
+                // window means the user deliberately zoomed elsewhere; stealing
+                // the view back would fight them.
+                if (Zoomed && _t > _viewStart + _viewSpan * 0.85 && _t < _viewStart + _viewSpan * 1.5)
+                    _viewStart = Math.Clamp(_t - _viewSpan * 0.15, 0, DaySeconds - _viewSpan);
                 await InvokeAsync(async () =>
                 {
                     await SyncVideosAsync();
@@ -601,16 +916,18 @@
         return n <= 1 ? 1 : (int)Math.Ceiling(Math.Sqrt(n));
     }
 
-    private static string Pct(double seconds) =>
-        $"{seconds / DaySeconds * 100:0.###}%";
-
     private static string TimeText(double t) =>
         TimeSpan.FromSeconds(Math.Clamp(t, 0, DaySeconds - 1)).ToString(@"hh\:mm\:ss");
 
     public async ValueTask DisposeAsync()
     {
         _clock?.Dispose();
-        try { await JS.InvokeVoidAsync("neolink.tlScrubDispose", "tl-scrub"); }
+        try
+        {
+            await JS.InvokeVoidAsync("neolink.tlScrubDispose", "tl-scrub");
+            await JS.InvokeVoidAsync("neolink.tlZoomDispose", "tl-scrub");
+            await JS.InvokeVoidAsync("neolink.tlKeysDispose");
+        }
         catch { /* circuit already gone */ }
         _selfRef?.Dispose();
     }

--- a/src/Neolink.WebClient/Models.cs
+++ b/src/Neolink.WebClient/Models.cs
@@ -201,6 +201,9 @@ public static class UiIcon
             "pause" => "<rect x=\"5\" y=\"4\" width=\"5\" height=\"16\" rx=\"1\" fill=\"currentColor\"/><rect x=\"14\" y=\"4\" width=\"5\" height=\"16\" rx=\"1\" fill=\"currentColor\"/>",
             "chev-left" => "<polyline points=\"15 18 9 12 15 6\"/>",
             "chev-right" => "<polyline points=\"9 18 15 12 9 6\"/>",
+            "skip-back" => "<polygon points=\"19 20 9 12 19 4 19 20\" fill=\"currentColor\"/><line x1=\"5\" y1=\"19\" x2=\"5\" y2=\"5\"/>",
+            "skip-fwd" => "<polygon points=\"5 4 15 12 5 20 5 4\" fill=\"currentColor\"/><line x1=\"19\" y1=\"5\" x2=\"19\" y2=\"19\"/>",
+            "zoom" => "<circle cx=\"11\" cy=\"11\" r=\"7\"/><line x1=\"21\" y1=\"21\" x2=\"16\" y2=\"16\"/>",
             _ => "",
         };
         return new MarkupString(

--- a/src/Neolink.WebClient/wwwroot/css/app.css
+++ b/src/Neolink.WebClient/wwwroot/css/app.css
@@ -1898,6 +1898,83 @@ body.is-fullscreen .fs-exit { display: inline-flex; }
     color: var(--accent);
 }
 
+.tl-clock-btn { cursor: text; border-radius: 6px; padding: 1px 6px; }
+.tl-clock-btn:hover { background: var(--accent-soft); }
+
+/* The clock swapped for direct input: type 16:39:12, Enter, you're there. */
+.tl-clock-edit {
+    margin-left: auto;
+    width: 108px;
+    background: var(--bg);
+    border: 1px solid var(--accent);
+    border-radius: 6px;
+    color: var(--accent);
+    font-size: 15px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    text-align: center;
+    padding: 1px 6px;
+    outline: none;
+}
+
+/* Fine-step transport buttons: compact, tabular, clearly a cluster */
+.tl-step {
+    min-width: 34px;
+    padding: 5px 8px;
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+}
+
+.tl-zoom-chip { font-variant-numeric: tabular-nums; white-space: nowrap; }
+
+.tl-keys-btn { min-width: 30px; font-weight: 700; color: var(--muted); }
+.tl-keys-btn:hover, .tl-keys-btn.active { color: var(--accent); }
+
+/* Keyboard cheat-sheet popover */
+.tl-keys-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 70;
+    background: rgba(0, 0, 0, 0.35);
+}
+
+.tl-keys-panel {
+    position: absolute;
+    top: 62px;
+    right: 16px;
+    width: min(360px, calc(100vw - 24px));
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 14px 16px;
+    box-shadow: var(--shadow);
+}
+
+.tl-keys-title {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 11px;
+    letter-spacing: 2px;
+    color: var(--muted);
+    margin-bottom: 10px;
+}
+
+.tl-keys-grid {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 7px 14px;
+    font-size: 12px;
+}
+
+.tl-keys-grid span:nth-child(odd) {
+    color: var(--accent);
+    font-family: Consolas, "Cascadia Mono", monospace;
+    white-space: nowrap;
+}
+
+.tl-keys-hint { margin-top: 10px; }
+
 /* Adaptive playback: shown while the clock is held back for lagging streams */
 .tl-lag {
     font-size: 10px;
@@ -1949,6 +2026,49 @@ body.is-fullscreen .fs-exit { display: inline-flex; }
     user-select: none;
 }
 
+/* The whole day at a glance while the lanes are zoomed: footage blocks, the
+   red cursor and the draggable view-window rectangle. */
+.tl-overview {
+    position: relative;
+    height: 16px;
+    margin-bottom: 4px;
+    background: color-mix(in srgb, var(--panel) 70%, transparent);
+    border-radius: 4px;
+    overflow: hidden;
+    cursor: grab;
+}
+
+.tl-ov-cov {
+    position: absolute;
+    top: 5px;
+    height: 6px;
+    background: #35507e;
+    border-radius: 2px;
+    pointer-events: none;
+}
+
+.tl-ov-win {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    min-width: 3px;
+    background: var(--accent-soft);
+    border: 1px solid color-mix(in srgb, var(--accent) 55%, transparent);
+    border-radius: 4px;
+    pointer-events: none;
+}
+
+.tl-ov-cursor {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: var(--err);
+    pointer-events: none;
+}
+
+.tl-name-head { height: 46px; } /* overview strip + ruler */
+
 .tl-ruler { position: relative; height: 26px; }
 
 .tl-tick {
@@ -1960,6 +2080,47 @@ body.is-fullscreen .fs-exit { display: inline-flex; }
     color: var(--muted);
     padding-left: 3px;
     pointer-events: none;
+    white-space: nowrap;
+}
+
+.tl-tick-minor {
+    position: absolute;
+    bottom: 0;
+    height: 6px;
+    border-left: 1px solid color-mix(in srgb, var(--line) 55%, transparent);
+    pointer-events: none;
+}
+
+/* JS-owned hover readout: a hairline plus a time bubble under the mouse */
+.tl-hover {
+    position: absolute;
+    top: 20px;
+    bottom: 0;
+    display: none;
+    pointer-events: none;
+    z-index: 4;
+}
+
+.tl-hover-line {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: color-mix(in srgb, var(--text) 30%, transparent);
+}
+
+.tl-hover-time {
+    position: absolute;
+    top: 2px;
+    left: 4px;
+    font-size: 10px;
+    font-variant-numeric: tabular-nums;
+    color: var(--text);
+    background: var(--panel-2);
+    border: 1px solid var(--line);
+    padding: 0 4px;
+    border-radius: 3px;
+    white-space: nowrap;
 }
 
 .tl-lane {
@@ -1991,7 +2152,7 @@ body.is-fullscreen .fs-exit { display: inline-flex; }
 
 .tl-cursor {
     position: absolute;
-    top: 0;
+    top: 20px; /* below the day-overview strip, which has its own mini cursor */
     bottom: 0;
     width: 2px;
     background: var(--err);

--- a/src/Neolink.WebClient/wwwroot/js/neolink.js
+++ b/src/Neolink.WebClient/wwwroot/js/neolink.js
@@ -360,6 +360,9 @@
 
     // ---------- timeline page (recorded footage scrubbing) ----------
     const scrubs = {};
+    const zooms = {};      // per-element zoom/hover/pinch handler registries
+    let tlKeyHandler = null;
+    let tlPinching = false; // two-finger zoom in progress: scrubbing must yield
 
     // ---------- monitor page (browser-side FPS/heap sampling state) ----------
     const perf = { raf: 0, frames: 0, windowStart: 0, fps: 0 };
@@ -815,6 +818,23 @@
             // otherwise a slow segment just looks frozen.
             const tile = v.closest('.tl-tile');
             const busy = (b) => { if (tile) tile.classList.toggle('tl-loading', b); };
+            // The sync loop only ticks while playing, so a seek issued on PAUSE
+            // (snapping the frame to the cursor) would strand the veil at
+            // whatever state this call left it in. The media element's own
+            // events keep it truthful between syncs instead.
+            if (!v.dataset.tlBusyHook) {
+                v.dataset.tlBusyHook = '1';
+                const settle = () => {
+                    const t2 = v.closest('.tl-tile');
+                    if (!t2) return;
+                    const playing = v.dataset.tlPlaying === '1';
+                    t2.classList.toggle('tl-loading', !!v.dataset.tlUrl && !v.error
+                        && (v.seeking || v.readyState < (playing ? 3 : 2)));
+                };
+                for (const ev of ['seeking', 'waiting', 'seeked', 'canplay', 'playing', 'loadeddata'])
+                    v.addEventListener(ev, settle);
+            }
+            v.dataset.tlPlaying = playing ? '1' : '0';
             v.muted = true;
             if (!url) {
                 busy(false);
@@ -833,7 +853,9 @@
                 // playback rate — widen the drift tolerance accordingly or fast
                 // playback degrades into a seek-storm. (The adaptive clock keeps
                 // real lag below this while playing; seeks stay exceptional.)
-                const tolerance = playing ? Math.max(1.5, r * 0.75) : 0.35;
+                // Paused is the precision path: 0.05 s so the 0.1 s keyboard
+                // nudges land on a genuinely different picture.
+                const tolerance = playing ? Math.max(1.5, r * 0.75) : 0.05;
                 if (Math.abs(v.currentTime - offset) > tolerance) v.currentTime = offset;
             }
             // AFTER the src/load branch: load() resets playbackRate to the default,
@@ -859,6 +881,7 @@
             if (!el) return;
             let lastSent = 0;
             const send = (e, final) => {
+                if (tlPinching) return; // two-finger zoom owns the gesture
                 const now = performance.now();
                 if (!final && now - lastSent < 70) return;
                 lastSent = now;
@@ -868,6 +891,7 @@
             };
             const down = (e) => {
                 if (e.button !== 0 && e.pointerType === 'mouse') return;
+                if (e.target.closest('.tl-overview')) return; // the day strip pans, never scrubs
                 e.preventDefault();
                 try { el.setPointerCapture(e.pointerId); } catch { }
                 send(e, false);
@@ -886,6 +910,167 @@
         tlScrubDispose(elemId) {
             const s = scrubs[elemId];
             if (s) { s.el.removeEventListener('pointerdown', s.down); delete scrubs[elemId]; }
+        },
+
+        // Fine-seek interactions on the lane strip: wheel/pinch zoom around the
+        // pointer, a JS-local hover time bubble (zero server round-trips while
+        // the mouse moves), and drag-to-pan on the day-overview strip.
+        tlZoomInit(elemId, dotnetRef) {
+            this.tlZoomDispose(elemId);
+            const el = document.getElementById(elemId);
+            if (!el) return;
+            const st = { el, handlers: [] };
+            const on = (target, ev, fn, opts) => {
+                target.addEventListener(ev, fn, opts);
+                st.handlers.push([target, ev, fn, opts]);
+            };
+            const fracAt = (clientX) => {
+                const r = el.getBoundingClientRect();
+                return Math.min(1, Math.max(0, (clientX - r.left) / r.width));
+            };
+
+            // Hover: a hairline + time bubble under the mouse. Mapped through the
+            // data-vs/data-vspan window attributes Blazor keeps fresh, so it stays
+            // correct at any zoom without a single interop call.
+            const hover = document.createElement('div');
+            hover.className = 'tl-hover';
+            hover.innerHTML = '<div class="tl-hover-line"></div><div class="tl-hover-time"></div>';
+            el.appendChild(hover);
+            const bubble = hover.querySelector('.tl-hover-time');
+            on(el, 'pointermove', (e) => {
+                if (e.pointerType !== 'mouse' || e.target.closest('.tl-overview')) { hover.style.display = 'none'; return; }
+                const f = fracAt(e.clientX);
+                const vs = parseFloat(el.dataset.vs || '0');
+                const span = parseFloat(el.dataset.vspan || '86400');
+                let sec = Math.max(0, Math.min(86399.9, vs + f * span));
+                const pad = (v) => String(v).padStart(2, '0');
+                let text = `${pad(Math.floor(sec / 3600))}:${pad(Math.floor(sec / 60) % 60)}:${pad(Math.floor(sec % 60))}`;
+                if (span <= 900) text += '.' + Math.floor((sec % 1) * 10); // tenths once zoomed tight
+                bubble.textContent = text;
+                hover.style.left = (f * 100) + '%';
+                // Keep the bubble on-screen near the right edge.
+                bubble.style.transform = f > 0.92 ? 'translateX(calc(-100% - 6px))' : '';
+                hover.style.display = 'block';
+            });
+            on(el, 'pointerleave', () => { hover.style.display = 'none'; });
+
+            // Wheel: zoom around the pointer; Shift+wheel pans the window.
+            let lastWheel = 0;
+            on(el, 'wheel', (e) => {
+                e.preventDefault();
+                const now = performance.now();
+                if (now - lastWheel < 40) return;
+                lastWheel = now;
+                if (e.shiftKey)
+                    dotnetRef.invokeMethodAsync('OnTimelinePan', (e.deltaY || e.deltaX) > 0 ? 1 : -1);
+                else
+                    dotnetRef.invokeMethodAsync('OnTimelineZoom', fracAt(e.clientX), e.deltaY > 0 ? 1.3 : 0.75);
+            }, { passive: false });
+
+            on(el, 'dblclick', () => dotnetRef.invokeMethodAsync('OnTimelineKey', 'zoom:reset'));
+
+            // Pinch: two touch pointers zoom around their midpoint. Capture-phase
+            // listeners see both pointers even while the scrub handler holds one;
+            // the shared tlPinching flag makes scrubbing yield for the duration.
+            const touches = new Map();
+            let pinchBase = null;
+            on(el, 'pointerdown', (e) => {
+                if (e.pointerType !== 'touch') return;
+                touches.set(e.pointerId, e.clientX);
+                if (touches.size === 2) { tlPinching = true; pinchBase = null; }
+            }, true);
+            on(el, 'pointermove', (e) => {
+                if (!touches.has(e.pointerId)) return;
+                touches.set(e.pointerId, e.clientX);
+                if (touches.size !== 2) return;
+                const [a, b] = [...touches.values()];
+                const dist = Math.abs(a - b);
+                if (pinchBase == null) { pinchBase = dist; return; }
+                if (dist > 20 && Math.abs(dist - pinchBase) > 12) {
+                    dotnetRef.invokeMethodAsync('OnTimelineZoom', fracAt((a + b) / 2), pinchBase / dist);
+                    pinchBase = dist;
+                }
+            }, true);
+            const lift = (e) => {
+                touches.delete(e.pointerId);
+                pinchBase = null;
+                if (touches.size < 2) tlPinching = false;
+            };
+            on(el, 'pointerup', lift, true);
+            on(el, 'pointercancel', lift, true);
+
+            // Day-overview strip: drag to move the zoomed view window.
+            const ov = el.querySelector('.tl-overview');
+            if (ov) {
+                const seek = (e) => {
+                    const r = ov.getBoundingClientRect();
+                    dotnetRef.invokeMethodAsync('OnOverviewSeek',
+                        Math.min(1, Math.max(0, (e.clientX - r.left) / r.width)));
+                };
+                on(ov, 'pointerdown', (e) => {
+                    e.stopPropagation();
+                    try { ov.setPointerCapture(e.pointerId); } catch { }
+                    seek(e);
+                    let last = 0;
+                    const move = (ev) => {
+                        const n = performance.now();
+                        if (n - last > 60) { last = n; seek(ev); }
+                    };
+                    const up = () => {
+                        ov.removeEventListener('pointermove', move);
+                        ov.removeEventListener('pointerup', up);
+                    };
+                    ov.addEventListener('pointermove', move);
+                    ov.addEventListener('pointerup', up);
+                });
+            }
+            zooms[elemId] = st;
+        },
+        tlZoomDispose(elemId) {
+            const st = zooms[elemId];
+            if (!st) return;
+            for (const [t, ev, fn, opts] of st.handlers) t.removeEventListener(ev, fn, opts);
+            st.el.querySelector('.tl-hover')?.remove();
+            delete zooms[elemId];
+        },
+
+        // NLE-style keyboard transport for the timeline page. Ignores keystrokes
+        // aimed at form fields, and Alt/Meta chords stay with the browser.
+        tlKeysInit(dotnetRef) {
+            this.tlKeysDispose();
+            tlKeyHandler = (e) => {
+                const t = e.target;
+                if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.tagName === 'SELECT' || t.isContentEditable)) return;
+                if (e.altKey || e.metaKey) return;
+                let action = null;
+                switch (e.key) {
+                    case ' ': case 'k': case 'K': action = 'playpause'; break;
+                    case 'ArrowLeft': action = 'step:' + (e.ctrlKey ? -0.1 : e.shiftKey ? -10 : -1); break;
+                    case 'ArrowRight': action = 'step:' + (e.ctrlKey ? 0.1 : e.shiftKey ? 10 : 1); break;
+                    case 'j': case 'J': action = 'step:-10'; break;
+                    case 'l': case 'L': action = 'step:10'; break;
+                    case ',': action = 'step:-0.1'; break;
+                    case '.': action = 'step:0.1'; break;
+                    case '[': action = 'event:-1'; break;
+                    case ']': action = 'event:1'; break;
+                    case '+': case '=': action = 'zoom:in'; break;
+                    case '-': case '_': action = 'zoom:out'; break;
+                    case '0': action = 'zoom:reset'; break;
+                    case 't': case 'T': action = 'clock'; break;
+                }
+                if (!action) return;
+                e.preventDefault();
+                dotnetRef.invokeMethodAsync('OnTimelineKey', action).catch(() => { });
+            };
+            document.addEventListener('keydown', tlKeyHandler);
+        },
+        tlKeysDispose() {
+            if (tlKeyHandler) { document.removeEventListener('keydown', tlKeyHandler); tlKeyHandler = null; }
+        },
+
+        focusEl(id) {
+            const el = document.getElementById(id);
+            if (el) { el.focus(); el.select?.(); }
         },
 
         attach(videoId, wsUrl) {


### PR DESCRIPTION
## Summary

**Timeline precision controls â€” frame-level review in the browser.** At the full 24 h view a timeline pixel covers about a minute of footage, which is why seeking felt coarse no matter how fast the files got. The lanes are now a zoomable window over the day:

- **Zoom** â€” scroll (or pinch on touch) zooms 24 h â†’ 60 s anchored on the point under the pointer; at the floor a pixel is ~50 ms. Shift+scroll pans; double-click, the zoom chip, or `0` resets. The ruler adapts from hour labels down to seconds with minor ticks.
- **Day overview strip** â€” a slim, always-visible map of the whole day above the lanes (footage blocks + cursor); when zoomed, its highlighted window rectangle drags to move the view. Panning and scrubbing can't collide â€” the strip pans, the lanes seek.
- **Hover readout** â€” a hairline + exact-time bubble follows the mouse (tenths of a second when zoomed tight). Fully JS-local: zero server round-trips on mouse move.
- **Transport cluster** â€” previous/next **event hop** and âˆ’10s / âˆ’1s / +1s / +10s steps around play/pause.
- **Keyboard (NLE-style)** â€” Space/K play-pause Â· â†/â†’ step 1 s (Shift 10 s, Ctrl 0.1 s) Â· J/L âˆ“10 s Â· `,`/`.` 0.1 s nudges Â· `[`/`]` event hops Â· +/âˆ’/0 zoom Â· T to type an exact time Â· `?` shows the cheat sheet.
- **Slow motion** â€” Â¼Ã— and Â½Ã— join the speed chips (speeds are now fractional throughout).
- **Click-to-edit clock** â€” type `16:39:12`, Enter, you're there.
- Paused seek tolerance tightened 0.35 s â†’ 0.05 s so the 0.1 s nudges land on a genuinely different frame.

**Fixes**
- The buffering veil no longer lingers after pausing: pausing snaps the frame to the cursor (a seek), but the state was only refreshed by the sync loop, which stops while paused. The veil now settles off the video element's own events â€” and appears instantly on genuine mid-stream stalls.
- Content-free `yoloWorldEventList` pushes (msg 600, sent constantly by some firmware) no longer hit the Info log on every reconnect. The capture aid still surfaces the first msg-600 payload that actually carries data, and `NEOLINK_DEBUG_ALARMS=1` still logs everything.

**Housekeeping** â€” version 0.8.3; changelog marks 0.8.0/0.8.2 as released and opens `0.8.3 â€” unreleased`.

## Reviewer notes

- The window model is two fields (`_viewStart`, `_viewSpan`); all lane geometry maps through them, marks/coverage are culled to the window, and the JS hover reads the window from `data-vs`/`data-vspan` attributes.
- Auto-follow during zoomed playback only engages when the cursor walks off the window's right edge naturally (85â€“150 % band) â€” deliberately zooming elsewhere never gets yanked back.
- Playback speeds changed from `int` to `double` (persisted prefs deserialize old integer values fine).

## Testing

- 30/30 self-tests pass (new assertion: empty `yoloWorldEventList` classifies as content-free).
- Browser-verified against real recordings end-to-end: anchored wheel zoom (16:41 stays under the pointer through 10 notches), adaptive ruler labels (3 h â†’ 10 min â†’ seconds), hover bubble times, every keyboard action (steps moved the clock and the actual `video.currentTime` by Â±0.1 s while paused), `[` hopped exactly to a 12:00:00 event, T-edit jumped to `16:39:30` = the right segment at offset 443 s, Â½Ã— reached `playbackRate`, overview click re-centered the window preserving span, double-click reset, and the pause-spinner scenario (clear at 0.15 s / 1 s / 2.5 s after pausing, previously stuck).

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)