### PR TITLE
Home Assistant: add server health device & UI polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ in the README). Paste the matching section below into the GitHub release.
 
 ### New
 
+- **The server reports itself to Home Assistant**: alongside the cameras, MQTT
+  discovery now creates a "Neolink.NET Server" device carrying the monitor
+  page's vitals — CPU, memory, storage free/used, recordings size, recording
+  write rate, viewers, cameras online/recording and the start time. Published
+  every `mqtt.stats_interval` seconds (default 60, minimum 5, 0 turns the
+  device off) — the cadence is also editable in the web UI's server settings
+  under *MQTT / Home Assistant*.
+
 - **Timeline precision controls** — frame-level review without leaving the
   browser:
   - *Zoom*: scroll or pinch on the lanes to zoom from the full 24 h down to a
@@ -25,6 +33,13 @@ in the README). Paste the matching section below into the GitHub release.
     button shows the cheat sheet.
   - *Slow motion*: ¼× and ½× join the playback speeds.
   - The clock is clickable: type 16:39:12 and you're there.
+
+### Changed
+
+- Server settings panel: the header now carries a live "● N unsaved" badge and
+  the Save/Restart buttons live in a pinned footer with the unsaved-changes
+  notice — no more scrolling to find out whether edits were written. Save
+  errors and status also surface in the footer, always visible.
 
 ### Fixed
 

--- a/src/Neolink.Server/Config/ConfigEditor.cs
+++ b/src/Neolink.Server/Config/ConfigEditor.cs
@@ -66,6 +66,11 @@ public static class ConfigEditor
                     segmentMinutes = cfg.Recording.SegmentMinutes,
                     continuousRetentionDays = cfg.Recording.ContinuousRetentionDays,
                 },
+                // Broker/credentials stay file-only; the UI adjusts the cadence.
+                mqtt = cfg.Mqtt == null ? null : new
+                {
+                    statsInterval = cfg.Mqtt.StatsIntervalSeconds,
+                },
             },
         };
     }
@@ -124,6 +129,17 @@ public static class ConfigEditor
     /// <summary>The (possibly differently-spelled) child object for a section, created on demand.</summary>
     public static JsonObject Section(JsonObject root, string key)
     {
+        if (TryGetSection(root, key) is { } existing) return existing;
+        var section = new JsonObject();
+        root[key] = section;
+        return section;
+    }
+
+    /// <summary>Like <see cref="Section"/>, but never creates — for sections that
+    /// are only meaningful with fields the UI doesn't edit (an mqtt block without
+    /// a broker would just fail validation).</summary>
+    public static JsonObject? TryGetSection(JsonObject root, string key)
+    {
         string Normalized(string k) => k.Replace("_", "").Replace("-", "").ToLowerInvariant();
         var target = Normalized(key);
         foreach (var kv in root)
@@ -131,8 +147,6 @@ public static class ConfigEditor
             if (Normalized(kv.Key) == target && kv.Value is JsonObject existing)
                 return existing;
         }
-        var section = new JsonObject();
-        root[key] = section;
-        return section;
+        return null;
     }
 }

--- a/src/Neolink.Server/Config/NeolinkConfig.cs
+++ b/src/Neolink.Server/Config/NeolinkConfig.cs
@@ -219,6 +219,8 @@ public sealed class NeolinkConfig
                 case "discoveryprefix": mqtt.DiscoveryPrefix = prop.Value.GetString() ?? mqtt.DiscoveryPrefix; break;
                 case "keepalive": mqtt.KeepAliveSeconds = prop.Value.GetInt32(); break;
                 case "tls" or "ssl": mqtt.Tls = prop.Value.GetBoolean(); break;
+                case "statsinterval" or "statsintervalseconds":
+                    mqtt.StatsIntervalSeconds = prop.Value.GetInt32(); break;
                 default:
                     Log.Warn($"Config: ignoring unknown mqtt option '{prop.Name}'");
                     break;
@@ -287,6 +289,7 @@ public sealed class NeolinkConfig
                 DiscoveryPrefix = MiniToml.GetString(mqtt, "discovery_prefix") ?? "homeassistant",
                 KeepAliveSeconds = (int)(MiniToml.GetInt(mqtt, "keepalive") ?? 30),
                 Tls = MiniToml.GetBool(mqtt, "tls") ?? false,
+                StatsIntervalSeconds = (int)(MiniToml.GetInt(mqtt, "stats_interval") ?? 60),
             };
         }
 
@@ -482,6 +485,8 @@ public sealed class NeolinkConfig
                 throw new FormatException("mqtt.keepalive must be 5..3600");
             if (string.IsNullOrWhiteSpace(Mqtt.BaseTopic))
                 throw new FormatException("mqtt.base_topic must not be empty");
+            if (Mqtt.StatsIntervalSeconds is not 0 and (< 5 or > 86400))
+                throw new FormatException("mqtt.stats_interval must be 0 (off) or 5..86400 seconds");
         }
     }
 
@@ -555,6 +560,11 @@ public sealed class MqttConfig
     public int KeepAliveSeconds { get; set; } = 30;
     /// <summary>Connect with TLS (broker port is usually 8883). Certificates are not validated.</summary>
     public bool Tls { get; set; }
+    /// <summary>How often the server publishes its own health (CPU, memory, disk,
+    /// viewers, …) as sensors on a "Neolink.NET Server" device in Home Assistant.
+    /// 60 s covers dashboards comfortably; lower it for near-live gauges.
+    /// 0 disables the server device entirely.</summary>
+    public int StatsIntervalSeconds { get; set; } = 60;
 }
 
 /// <summary>Event recording settings ("recording" in the config).</summary>

--- a/src/Neolink.Server/Mqtt/HomeAssistantMqtt.cs
+++ b/src/Neolink.Server/Mqtt/HomeAssistantMqtt.cs
@@ -31,6 +31,11 @@ namespace Neolink.Mqtt;
 ///   • button:        reboot, and PTZ steps              (per capability)
 ///   • camera:        latest snapshot                    (when the camera supports it)
 ///
+/// The SERVER also reports itself: a "Neolink.NET Server" device with health
+/// sensors straight off the monitor page (CPU, memory, disk, recordings size,
+/// write rate, viewers, cameras online/recording, start time), published every
+/// mqtt.stats_interval seconds (default 60; 0 turns the device off).
+///
 /// Availability is two-level (HA marks entities unavailable when either is off):
 /// a bridge-wide Last-Will topic and a per-camera online topic. Commands from HA
 /// arrive on ".../{entity}/set" and are executed through <see cref="ICameraControl"/>.
@@ -86,11 +91,21 @@ public sealed class HomeAssistantMqtt
     internal string Version => _version;
     internal string AvailabilityTopic => _availabilityTopic;
 
+    /// <summary>Resource sampler feeding the server's own HA device; when null
+    /// (or stats_interval is 0) the server device is not announced.</summary>
+    public Web.SystemMonitor? Monitor { get; init; }
+
+    private bool ServerStatsEnabled => Monitor != null && _cfg.StatsIntervalSeconds > 0;
+
     public async Task RunAsync(CancellationToken ct)
     {
         Log.Info($"MQTT: Home Assistant bridge enabled → {_cfg.Broker}:{_cfg.Port} " +
-                 $"(base topic '{_cfg.BaseTopic}'{(_cfg.Discovery ? ", discovery on" : "")})");
+                 $"(base topic '{_cfg.BaseTopic}'{(_cfg.Discovery ? ", discovery on" : "")}" +
+                 $"{(ServerStatsEnabled ? $", server health every {_cfg.StatsIntervalSeconds}s" : "")})");
         var refresh = Task.Run(() => RefreshLoopAsync(ct), CancellationToken.None);
+        var stats = ServerStatsEnabled
+            ? Task.Run(() => ServerStatsLoopAsync(ct), CancellationToken.None)
+            : Task.CompletedTask;
         try
         {
             await _client.RunAsync(ct).ConfigureAwait(false);
@@ -98,6 +113,7 @@ public sealed class HomeAssistantMqtt
         finally
         {
             try { await refresh.ConfigureAwait(false); } catch { }
+            try { await stats.ConfigureAwait(false); } catch { }
         }
     }
 
@@ -137,6 +153,11 @@ public sealed class HomeAssistantMqtt
         await _client.SubscribeAsync(subs, CancellationToken.None).ConfigureAwait(false);
         foreach (var cam in _cameras.Values)
             await cam.AnnounceAsync(CancellationToken.None).ConfigureAwait(false);
+        if (ServerStatsEnabled)
+        {
+            await AnnounceServerAsync(CancellationToken.None).ConfigureAwait(false);
+            await PublishServerStatsAsync(CancellationToken.None).ConfigureAwait(false);
+        }
     }
 
     private void OnMessage(string topic, byte[] payload)
@@ -148,6 +169,117 @@ public sealed class HomeAssistantMqtt
         if (rest.Length != 3 || rest[2] != "set") return;
         if (!_cameras.TryGetValue(rest[0], out var cam)) return;
         _ = cam.HandleCommandAsync(rest[1], System.Text.Encoding.UTF8.GetString(payload));
+    }
+
+    // ------------------------------------------------------------------ server health device
+
+    /// <summary>The server's own sensors: key (topic leaf), display name, unit,
+    /// device class, icon, and whether HA should file it under diagnostics.
+    /// Internal so the self-tests can pin the contract.</summary>
+    internal static readonly (string Key, string Name, string? Unit, string? DeviceClass, string? Icon, bool Diagnostic)[]
+        ServerSensors =
+    {
+        ("cpu", "CPU usage", "%", null, "mdi:cpu-64-bit", false),
+        ("memory", "Memory", "MB", null, "mdi:memory", false),
+        ("disk_free", "Storage free", "GB", null, "mdi:harddisk", false),
+        ("disk_used_pct", "Storage used", "%", null, "mdi:harddisk", false),
+        ("recordings_size", "Recordings size", "GB", null, "mdi:filmstrip-box-multiple", false),
+        ("write_rate", "Recording write rate", "MB/s", null, "mdi:content-save-move", false),
+        ("viewers", "Viewers", null, null, "mdi:eye", false),
+        ("cameras_online", "Cameras online", null, null, "mdi:cctv", false),
+        ("cameras_recording", "Cameras recording", null, null, "mdi:record-rec", false),
+        ("started", "Started", null, "timestamp", null, true),
+    };
+
+    /// <summary>One monitor sample → the state payloads to publish. Sensors whose
+    /// source is unavailable (no disk volume, recording off) are simply absent.
+    /// Internal/static so the self-tests can verify values and skip rules.</summary>
+    internal static List<(string Key, string Value)> ServerStatePayloads(Web.SystemSample s, int camerasOnline)
+    {
+        const double MB = 1024.0 * 1024.0, GB = MB * 1024.0;
+        var list = new List<(string, string)>
+        {
+            ("cpu", s.CpuPercent.ToString("0.#")),
+            ("memory", (s.WorkingSetBytes / MB).ToString("0")),
+            ("write_rate", s.StorageMbPerSec.ToString("0.##")),
+            ("viewers", s.Viewers.ToString()),
+            ("cameras_online", camerasOnline.ToString()),
+            ("cameras_recording", s.RecordingCameras.ToString()),
+        };
+        if (s.DiskTotalBytes > 0)
+        {
+            list.Add(("disk_free", (s.DiskFreeBytes / GB).ToString("0.#")));
+            list.Add(("disk_used_pct",
+                ((1 - (double)s.DiskFreeBytes / s.DiskTotalBytes) * 100).ToString("0.#")));
+        }
+        if (s.RecordingsBytes >= 0)
+            list.Add(("recordings_size", (s.RecordingsBytes / GB).ToString("0.##")));
+        return list;
+    }
+
+    private string ServerTopic(string key) => $"{_cfg.BaseTopic}/server/{key}";
+
+    private object ServerDevice() => new
+    {
+        identifiers = new[] { "neolink_server" },
+        name = "Neolink.NET Server",
+        manufacturer = "Neolink.NET",
+        model = "Camera bridge / NVR",
+        sw_version = _version,
+    };
+
+    private async Task AnnounceServerAsync(CancellationToken ct)
+    {
+        if (!_cfg.Discovery) return;
+        foreach (var s in ServerSensors)
+        {
+            var config = new
+            {
+                name = s.Name,
+                unique_id = $"neolink_server_{s.Key}",
+                state_topic = ServerTopic(s.Key),
+                unit_of_measurement = s.Unit,
+                device_class = s.DeviceClass,
+                // Numeric gauges chart as measurements; the timestamp doesn't.
+                state_class = s.DeviceClass == "timestamp" ? null : "measurement",
+                icon = s.Icon,
+                entity_category = s.Diagnostic ? "diagnostic" : null,
+                device = ServerDevice(),
+                availability = new object[] { new { topic = _availabilityTopic } },
+                availability_mode = "all",
+            };
+            await PublishAsync($"{_cfg.DiscoveryPrefix}/sensor/neolink_server/{s.Key}/config",
+                JsonSerializer.Serialize(config), ct).ConfigureAwait(false);
+        }
+        await PublishAsync(ServerTopic("started"), Web.SystemMonitor.Started.ToString("o"), ct)
+            .ConfigureAwait(false);
+    }
+
+    private async Task PublishServerStatsAsync(CancellationToken ct)
+    {
+        if (Monitor?.Latest() is not { } sample) return;
+        int online = _cameras.Values.Count(c => c.Online);
+        foreach (var (key, value) in ServerStatePayloads(sample, online))
+            await PublishAsync(ServerTopic(key), value, ct).ConfigureAwait(false);
+    }
+
+    private async Task ServerStatsLoopAsync(CancellationToken ct)
+    {
+        var interval = TimeSpan.FromSeconds(Math.Clamp(_cfg.StatsIntervalSeconds, 5, 86400));
+        while (!ct.IsCancellationRequested)
+        {
+            try { await Task.Delay(interval, ct).ConfigureAwait(false); }
+            catch (OperationCanceledException) { return; }
+            if (!_client.IsConnected) continue;
+            try
+            {
+                await PublishServerStatsAsync(ct).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Log.Debug($"MQTT: server stats publish failed: {Log.Flatten(ex)}");
+            }
+        }
     }
 
     private async Task RefreshLoopAsync(CancellationToken ct)
@@ -199,6 +331,9 @@ internal sealed class CameraBridge
     private bool _lastOnline;
 
     public string Id { get; }
+
+    /// <summary>Live camera reachability (feeds the server device's online count).</summary>
+    internal bool Online => _control.Online;
 
     public CameraBridge(WebCameraInfo cam, HomeAssistantMqtt hub)
     {

--- a/src/Neolink.Server/Program.cs
+++ b/src/Neolink.Server/Program.cs
@@ -312,13 +312,30 @@ foreach (var cam in config.Cameras)
         motionTargets.Add((primaryService, cam.Name, recorderSink));
 }
 
+// Resource sampler: feeds the UI's monitor page AND the server's own Home
+// Assistant device — created whenever either consumer runs. ViewerCount
+// deliberately excludes the server's own recorder subscriptions — "viewers"
+// means humans/externals watching, not us taping.
+SystemMonitor? monitor = null;
+if (config.WebPort > 0 || config.Mqtt is { StatsIntervalSeconds: > 0 })
+{
+    monitor = new SystemMonitor(
+        diskProbePath: eventStore?.Root ?? stateDir,
+        recordingsRoot: eventStore?.Root,
+        viewerCount: () => webCameras.Sum(c => c.Streams.Sum(s => s.Hub.ViewerCount)),
+        recordingCameras: () => webCameras.Count(c => c.ContinuousActive?.Invoke() == true),
+        cameraStates: () => webCameras.Select(c => (c.Name, c.Control.Online)));
+    var mon = monitor;
+    tasks.Add(Task.Run(() => mon.RunAsync(shutdown.Token)));
+}
+
 // MQTT / Home Assistant bridge (single connection for all cameras), then wire
 // motion: the camera's alarm push goes to the recorder and/or the bridge. The
 // alarm-push listener only runs when a MotionSink is set, so this also enables
 // motion for MQTT-only setups (recording off).
 if (config.Mqtt is { } mqttCfg)
 {
-    mqtt = new HomeAssistantMqtt(mqttCfg, webCameras, Version);
+    mqtt = new HomeAssistantMqtt(mqttCfg, webCameras, Version) { Monitor = monitor };
     tasks.Add(Task.Run(() => mqtt.RunAsync(shutdown.Token)));
 }
 foreach (var (primary, name, recorderSink) in motionTargets)
@@ -351,17 +368,6 @@ if (config.WebPort > 0)
     // Daily best-effort check for newer releases (feeds the UI's update banner).
     var updates = new UpdateChecker(Version);
     tasks.Add(Task.Run(() => updates.RunAsync(shutdown.Token)));
-
-    // Resource sampler for the UI's monitor page (CPU/RAM/disk/viewers over time).
-    // ViewerCount deliberately excludes the server's own recorder subscriptions —
-    // "viewers" means humans/externals watching, not us taping.
-    var monitor = new SystemMonitor(
-        diskProbePath: eventStore?.Root ?? stateDir,
-        recordingsRoot: eventStore?.Root,
-        viewerCount: () => webCameras.Sum(c => c.Streams.Sum(s => s.Hub.ViewerCount)),
-        recordingCameras: () => webCameras.Count(c => c.ContinuousActive?.Invoke() == true),
-        cameraStates: () => webCameras.Select(c => (c.Name, c.Control.Online)));
-    tasks.Add(Task.Run(() => monitor.RunAsync(shutdown.Token)));
 
     var webOptions = new WebApiOptions
     {

--- a/src/Neolink.Server/SelfTest.cs
+++ b/src/Neolink.Server/SelfTest.cs
@@ -745,6 +745,39 @@ public static class SelfTest
             AssertEq(rl[1], (byte)0x02);
         });
 
+        Test("server health sensors for Home Assistant", () =>
+        {
+            var sample = new Web.SystemSample(
+                UnixMs: 0, CpuPercent: 12.34, WorkingSetBytes: 512L * 1024 * 1024,
+                ManagedHeapBytes: 0, AllocMbPerSec: 0, Threads: 0, Handles: 0,
+                DiskTotalBytes: 1000L * 1024 * 1024 * 1024, DiskFreeBytes: 250L * 1024 * 1024 * 1024,
+                RecordingsBytes: 42L * 1024 * 1024 * 1024, Viewers: 3, RecordingCameras: 2,
+                StorageMbPerSec: 7.5, StorageFiles: 0);
+            var payloads = Mqtt.HomeAssistantMqtt.ServerStatePayloads(sample, camerasOnline: 5)
+                .ToDictionary(p => p.Key, p => p.Value);
+            AssertEq(payloads["cpu"], "12.3");
+            AssertEq(payloads["memory"], "512");
+            AssertEq(payloads["disk_free"], "250");
+            AssertEq(payloads["disk_used_pct"], "75");
+            AssertEq(payloads["recordings_size"], "42");
+            AssertEq(payloads["write_rate"], "7.5");
+            AssertEq(payloads["viewers"], "3");
+            AssertEq(payloads["cameras_online"], "5");
+            AssertEq(payloads["cameras_recording"], "2");
+
+            // Every published key has a matching discovery config — the contract
+            // between the state loop and what HA is told to expect.
+            Assert(payloads.Keys.All(k => Mqtt.HomeAssistantMqtt.ServerSensors.Any(s => s.Key == k)),
+                "every payload key has a discovery sensor");
+
+            // Sources that don't exist simply don't publish: no probed volume,
+            // recording disabled — absent beats a misleading zero.
+            var headless = sample with { DiskTotalBytes = 0, RecordingsBytes = -1 };
+            var keys = Mqtt.HomeAssistantMqtt.ServerStatePayloads(headless, 0).Select(p => p.Key).ToList();
+            Assert(!keys.Contains("disk_free") && !keys.Contains("disk_used_pct")
+                && !keys.Contains("recordings_size"), "unavailable sources are absent, not zero");
+        });
+
         Test("config editor: read-modify-write with validation", () =>
         {
             var dir = Path.Combine(Path.GetTempPath(), $"neolink-selftest-{Guid.NewGuid():N}");

--- a/src/Neolink.Server/Web/SystemMonitor.cs
+++ b/src/Neolink.Server/Web/SystemMonitor.cs
@@ -73,6 +73,18 @@ public sealed class SystemMonitor
     /// <summary>Uptime/outage history per camera, sampled on the same 2s tick.</summary>
     public CameraAvailability Availability { get; } = new();
 
+    /// <summary>When this server process started (feeds the HA "Started" sensor).</summary>
+    public static DateTimeOffset Started => StartedUtc;
+
+    /// <summary>The most recent sample, if one has been taken yet.</summary>
+    public SystemSample? Latest()
+    {
+        lock (_gate)
+        {
+            return _count == 0 ? null : _ring[(_next - 1 + Capacity) % Capacity];
+        }
+    }
+
     /// <summary>Static facts for the monitor page header (measured once).</summary>
     public object Info() => new
     {

--- a/src/Neolink.Server/Web/WebApi.cs
+++ b/src/Neolink.Server/Web/WebApi.cs
@@ -122,8 +122,11 @@ public static class WebApi
         bool? Talk = null);
     private sealed record AdminRecordingSettings(string? Path, int? RetentionDays, int? PreSeconds,
         int? PostSeconds, int? MaxClipSeconds, string? Stream, int? SegmentMinutes, int? ContinuousRetentionDays);
+    /// <summary>Only the cadence is UI-editable; broker/credentials stay file-only.</summary>
+    private sealed record AdminMqttSettings(int? StatsInterval);
     private sealed record AdminConfigRequest(string? Bind, int? BindPort, int? WebPort, string? WebBind,
-        bool? WebUi, AdminUiSettings? Ui, AdminRecordingSettings? Recording, bool? RemoveRecording);
+        bool? WebUi, AdminUiSettings? Ui, AdminRecordingSettings? Recording, bool? RemoveRecording,
+        AdminMqttSettings? Mqtt = null);
 
     public static async Task RunAsync(WebApiOptions o, CancellationToken ct)
     {
@@ -397,6 +400,17 @@ public static class WebApi
                         if (r.SegmentMinutes != null) ConfigEditor.Set(rec, "segment_minutes", r.SegmentMinutes);
                         if (r.ContinuousRetentionDays != null)
                             ConfigEditor.Set(rec, "continuous_retention_days", r.ContinuousRetentionDays);
+                    }
+
+                    if (req.Mqtt is { StatsInterval: { } statsInterval })
+                    {
+                        // Never conjure a broker-less mqtt section; the knob only
+                        // exists once MQTT is configured in the file.
+                        if (ConfigEditor.TryGetSection(root, "mqtt") is { } mq)
+                            ConfigEditor.Set(mq, "stats_interval", statsInterval);
+                        else
+                            throw new FormatException(
+                                "mqtt is not configured — add the mqtt section (broker etc.) to config.json first");
                     }
                 });
                 Log.Warn($"config.json updated via the web UI by '{SessionName(ctx)}' — restart to apply");

--- a/src/Neolink.Server/config.example.json
+++ b/src/Neolink.Server/config.example.json
@@ -57,7 +57,8 @@
   // Optional: publish to MQTT for Home Assistant (auto-discovery). Remove to disable.
   // HA creates a device per camera with motion/person/vehicle/animal sensors,
   // battery, night-vision, floodlight, PIR, reboot + PTZ buttons and a snapshot,
-  // depending on what each camera supports.
+  // depending on what each camera supports — plus a "Neolink.NET Server" device
+  // with the server's own health (CPU, memory, disk, viewers, ...).
   // "mqtt": {
   //   "broker": "192.168.1.10",        // MQTT broker host (often the HA / Mosquitto box)
   //   "port": 1883,                    // 8883 with "tls": true
@@ -68,7 +69,9 @@
   //   "discovery": true,               // publish HA discovery config
   //   "discovery_prefix": "homeassistant",  // must match HA's MQTT integration
   //   "keepalive": 30,
-  //   "tls": false
+  //   "tls": false,
+  //   "stats_interval": 60             // server health publish cadence in seconds
+  //                                    // (0 = off, minimum 5; editable in the web UI)
   // },
 
   // Optional: password-protect the RTSP server. Remove entries for open access.

--- a/src/Neolink.WebClient/Components/Pages/Home.razor
+++ b/src/Neolink.WebClient/Components/Pages/Home.razor
@@ -727,105 +727,140 @@
     @if (_showServerSettings)
     {
         <div class="backdrop panel-backdrop" @onclick="() => _showServerSettings = false"></div>
-        <aside class="campanel auth-panel" role="dialog" aria-label="Server settings">
+        @* Head and foot are pinned; only the sections scroll. The unsaved state
+           lives in BOTH: a badge in the header and the save bar in the footer,
+           so it can never scroll out of sight. *@
+        <aside class="campanel auth-panel settings-panel" role="dialog" aria-label="Server settings">
             <div class="campanel-head">
                 <span class="campanel-title">🛠 SERVER SETTINGS</span>
+                @if (_adminConfig != null && AdminPendingCount is var pend and > 0)
+                {
+                    <span class="unsaved-badge"
+                          title="Nothing is written until you click Save to config.json below. Closing this panel discards the changes.">
+                        ● @pend unsaved
+                    </span>
+                }
                 <span class="tile-spacer"></span>
                 <button class="icon-btn" title="Close" @onclick="() => _showServerSettings = false">✕</button>
             </div>
 
-            @if (_adminError != null)
+            @if (_adminConfig == null)
             {
-                <div class="notice error">@_adminError</div>
-            }
-            else if (_adminConfig == null)
-            {
-                <div class="notice">Loading…</div>
+                @if (_adminError != null)
+                {
+                    <div class="notice error">@_adminError</div>
+                }
+                else
+                {
+                    <div class="notice">Loading…</div>
+                }
             }
             else
             {
-                <div class="notice small">
-                    Editing <code>@_adminConfigPath</code>.
-                    @if (!_adminWritable)
-                    {
-                        <b> Read-only — the file cannot be written (check the mount).</b>
-                    }
-                    Changes are saved to the file and take effect after a restart. Comments in the file are not preserved.
-                </div>
-
-                <div class="campanel-section">
-                    <div class="campanel-section-title">NETWORK</div>
-                    @AdminField("Bind address", "bind", "text")
-                    @AdminField("RTSP port", "bindPort", "number")
-                    @AdminField("Web port", "webPort", "number")
-                    @AdminField("Web bind (blank = same as bind)", "webBind", "text")
-                    @AdminToggle("Serve the web UI", "webUi")
-                </div>
-
-                <div class="campanel-section">
-                    <div class="campanel-section-title">WEB UI</div>
-                    @AdminField("Preview playback speed (×)", "ui.trickleSpeed", "number")
-                    @AdminField("State directory (accounts/settings)", "ui.stateDir", "text")
-                    @AdminToggle("Allow admin-password reset on login", "ui.resetAdminPassword")
-                    <div class="control-row">
-                        <span>Two-way talk <span class="beta-tag">BETA</span></span>
-                        <button class="chip @(AdminBool("ui.talk") ? "" : "chip-off")"
-                                @onclick=@(() => _adminEdits["ui.talk"] = (!AdminBool("ui.talk")).ToString().ToLowerInvariant())>
-                            @(AdminBool("ui.talk") ? "on" : "off")</button>
-                    </div>
+                <div class="settings-body">
                     <div class="notice small">
-                        Streams your microphone to the camera's speaker (doorbells and other
-                        cameras that support talk). Browsers only allow microphone access on
-                        <b>HTTPS</b> or <b>localhost</b> pages — on a plain http:// address the
-                        mic button will report that a secure connection is required.
+                        Editing <code>@_adminConfigPath</code>.
+                        @if (!_adminWritable)
+                        {
+                            <b> Read-only — the file cannot be written (check the mount).</b>
+                        }
+                        Changes are saved to the file and take effect after a restart. Comments in the file are not preserved.
                     </div>
-                </div>
 
-                @if (_adminHasRecording)
-                {
                     <div class="campanel-section">
-                        <div class="campanel-section-title">RECORDING</div>
-                        @AdminField("Storage path", "recording.path", "text")
-                        @AdminField("Event retention (days, 0 = forever)", "recording.retentionDays", "number")
-                        @AdminField("Pre-roll (seconds)", "recording.preSeconds", "number")
-                        @AdminField("Post-roll (seconds)", "recording.postSeconds", "number")
-                        @AdminField("Max clip length (seconds)", "recording.maxClipSeconds", "number")
-                        @AdminField("Record stream (auto|mainStream|subStream)", "recording.stream", "text")
-                        @AdminField("Segment length (minutes)", "recording.segmentMinutes", "number")
-                        @AdminField("Continuous retention (days, blank = event value)", "recording.continuousRetentionDays", "number")
+                        <div class="campanel-section-title">NETWORK</div>
+                        @AdminField("Bind address", "bind", "text")
+                        @AdminField("RTSP port", "bindPort", "number")
+                        @AdminField("Web port", "webPort", "number")
+                        @AdminField("Web bind (blank = same as bind)", "webBind", "text")
+                        @AdminToggle("Serve the web UI", "webUi")
                     </div>
-                }
 
-                @if (_adminStatus != null)
-                {
-                    <div class="notice">@_adminStatus</div>
-                }
-
-                @if (AdminPendingCount is var pending and > 0)
-                {
-                    <div class="notice pending">
-                        @pending unsaved change@(pending == 1 ? "" : "s") — nothing is written until
-                        you click <b>Save to config.json</b>. Closing this panel discards them.
+                    <div class="campanel-section">
+                        <div class="campanel-section-title">WEB UI</div>
+                        @AdminField("Preview playback speed (×)", "ui.trickleSpeed", "number")
+                        @AdminField("State directory (accounts/settings)", "ui.stateDir", "text")
+                        @AdminToggle("Allow admin-password reset on login", "ui.resetAdminPassword")
+                        <div class="control-row">
+                            <span>Two-way talk <span class="beta-tag">BETA</span></span>
+                            <button class="chip @(AdminBool("ui.talk") ? "" : "chip-off")"
+                                    @onclick=@(() => _adminEdits["ui.talk"] = (!AdminBool("ui.talk")).ToString().ToLowerInvariant())>
+                                @(AdminBool("ui.talk") ? "on" : "off")</button>
+                        </div>
+                        <div class="notice small">
+                            Streams your microphone to the camera's speaker (doorbells and other
+                            cameras that support talk). Browsers only allow microphone access on
+                            <b>HTTPS</b> or <b>localhost</b> pages — on a plain http:// address the
+                            mic button will report that a secure connection is required.
+                        </div>
                     </div>
-                }
 
-                <div class="event-player-foot">
-                    <button class="chip @(AdminPendingCount > 0 ? "chip-active" : "")" disabled="@(!_adminWritable)"
-                            @onclick="SaveServerSettingsAsync">Save to config.json</button>
-                    <span class="tile-spacer"></span>
-                    @if (!_confirmRestart)
+                    @if (_adminHasRecording)
                     {
-                        <button class="chip chip-danger" @onclick="() => _confirmRestart = true">Restart service…</button>
+                        <div class="campanel-section">
+                            <div class="campanel-section-title">RECORDING</div>
+                            @AdminField("Storage path", "recording.path", "text")
+                            @AdminField("Event retention (days, 0 = forever)", "recording.retentionDays", "number")
+                            @AdminField("Pre-roll (seconds)", "recording.preSeconds", "number")
+                            @AdminField("Post-roll (seconds)", "recording.postSeconds", "number")
+                            @AdminField("Max clip length (seconds)", "recording.maxClipSeconds", "number")
+                            @AdminField("Record stream (auto|mainStream|subStream)", "recording.stream", "text")
+                            @AdminField("Segment length (minutes)", "recording.segmentMinutes", "number")
+                            @AdminField("Continuous retention (days, blank = event value)", "recording.continuousRetentionDays", "number")
+                        </div>
                     }
-                    else
+
+                    @if (_adminHasMqtt)
                     {
-                        <button class="chip chip-danger" @onclick="RestartServiceAsync">Confirm restart</button>
-                        <button class="chip" @onclick="() => _confirmRestart = false">Cancel</button>
+                        <div class="campanel-section">
+                            <div class="campanel-section-title">MQTT / HOME ASSISTANT</div>
+                            @AdminField("Server health interval (seconds, 0 = off)", "mqtt.statsInterval", "number")
+                            <div class="notice small">
+                                How often the server publishes its own health — CPU, memory, disk,
+                                recording rate, viewers — as a <b>Neolink.NET Server</b> device in
+                                Home Assistant. 60 s suits dashboards; lower it for near-live gauges
+                                (minimum 5). Broker details are edited in the file directly.
+                            </div>
+                        </div>
                     }
+
+                    <div class="notice small">
+                        Restart stops the service; your container/systemd restart policy brings it back within seconds
+                        (needed to apply saved changes). The UI reconnects automatically.
+                    </div>
                 </div>
-                <div class="notice small">
-                    Restart stops the service; your container/systemd restart policy brings it back within seconds
-                    (needed to apply saved changes). The UI reconnects automatically.
+
+                <div class="settings-foot">
+                    @if (_adminError != null)
+                    {
+                        <div class="notice error">@_adminError</div>
+                    }
+                    @if (_adminStatus != null)
+                    {
+                        <div class="notice">@_adminStatus</div>
+                    }
+                    @if (AdminPendingCount is var pending and > 0)
+                    {
+                        <div class="notice pending">
+                            @pending unsaved change@(pending == 1 ? "" : "s") — nothing is written until
+                            you click <b>Save to config.json</b>. Closing this panel discards them.
+                        </div>
+                    }
+                    <div class="settings-foot-btns">
+                        <button class="chip @(AdminPendingCount > 0 ? "chip-active" : "")" disabled="@(!_adminWritable)"
+                                @onclick="SaveServerSettingsAsync">Save to config.json</button>
+                        <span class="tile-spacer"></span>
+                        @if (!_confirmRestart)
+                        {
+                            <button class="chip chip-danger" title="Stop the service so the restart policy brings it back — needed to apply saved changes"
+                                    @onclick="() => _confirmRestart = true">Restart service…</button>
+                        }
+                        else
+                        {
+                            <button class="chip chip-danger" @onclick="RestartServiceAsync">Confirm restart</button>
+                            <button class="chip" @onclick="() => _confirmRestart = false">Cancel</button>
+                        }
+                    </div>
                 </div>
             }
         </aside>
@@ -1580,6 +1615,7 @@
         && _latestVersion != _updateDismissedVersion;
 
     private bool _adminHasRecording;
+    private bool _adminHasMqtt;
 
     private async Task DismissUpdateAsync()
     {
@@ -1610,6 +1646,8 @@
             _adminConfigPath = cfg.Path;
             _adminHasRecording = cfg.Settings.TryGetProperty("recording", out var r)
                 && r.ValueKind == JsonValueKind.Object;
+            _adminHasMqtt = cfg.Settings.TryGetProperty("mqtt", out var m)
+                && m.ValueKind == JsonValueKind.Object;
         }
         catch (Exception ex)
         {
@@ -1687,6 +1725,7 @@
         var payload = new Dictionary<string, object?>();
         var ui = new Dictionary<string, object?>();
         var rec = new Dictionary<string, object?>();
+        var mqtt = new Dictionary<string, object?>();
 
         object? Num(string p) => double.TryParse(AdminValue(p), out var d) ? d : null;
         int? Int(string p) => int.TryParse(AdminValue(p), out var i) ? i : (int?)null;
@@ -1712,10 +1751,12 @@
                 case "recording.stream": rec["stream"] = AdminValue(path); break;
                 case "recording.segmentMinutes": rec["segmentMinutes"] = Int(path); break;
                 case "recording.continuousRetentionDays": rec["continuousRetentionDays"] = Int(path); break;
+                case "mqtt.statsInterval": mqtt["statsInterval"] = Int(path); break;
             }
         }
         if (ui.Count > 0) payload["ui"] = ui;
         if (rec.Count > 0) payload["recording"] = rec;
+        if (mqtt.Count > 0) payload["mqtt"] = mqtt;
         if (payload.Count == 0) { _adminStatus = "No changes to save."; return; }
 
         try

--- a/src/Neolink.WebClient/wwwroot/css/app.css
+++ b/src/Neolink.WebClient/wwwroot/css/app.css
@@ -1204,6 +1204,60 @@ body.is-fullscreen .fs-exit { display: inline-flex; }
     padding: 10px 12px;
 }
 
+/* Server settings: head and foot pinned, only the sections scroll — the
+   unsaved state and the Save/Restart buttons can never leave the screen. */
+.settings-panel { overflow: hidden; }
+
+.settings-panel .campanel-head {
+    position: static;
+    top: auto;
+    padding: 0 0 4px;
+    flex: 0 0 auto;
+}
+
+.settings-body {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    /* breathing room so focus rings aren't clipped by the scroll edge */
+    padding: 2px;
+    margin: -2px;
+}
+
+.settings-foot {
+    flex: 0 0 auto;
+    border-top: 1px solid var(--line);
+    padding-top: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.settings-foot-btns {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+/* Pending-edits badge in the settings header (hover for the full story) */
+.unsaved-badge {
+    margin-left: 10px;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    color: #e8b054;
+    border: 1px solid color-mix(in srgb, #e8b054 40%, transparent);
+    background: color-mix(in srgb, #e8b054 9%, transparent);
+    border-radius: 999px;
+    padding: 2px 9px;
+    white-space: nowrap;
+    cursor: help;
+}
+
 .campanel-section-title {
     font-size: 11px;
     color: var(--muted);


### PR DESCRIPTION
The server now reports its own health and status to Home Assistant via MQTT as a "Neolink.NET Server" device, publishing metrics like CPU, memory, disk, recordings, viewers, and uptime at a configurable interval (`mqtt.stats_interval`). 

The web UI's server settings panel has been redesigned with a persistent unsaved-changes badge and pinned Save/Restart buttons. 
The server health publish interval is now editable in the UI. Example config, docs, and self-tests updated; UI/CSS improvements for better usability and visibility of status/errors.