### PR TITLE
Fix HA discovery: omit null fields in config JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,17 @@ in the README). Paste the matching section below into the GitHub release.
 
 ### Fixed
 
+- **Camera sensors going "Unavailable" in Home Assistant, and the missing
+  "Neolink.NET Server" device** — one bug: discovery configs were serialized
+  with explicit nulls for unset fields ("icon": null on the motion/person/
+  vehicle/animal sensors, "device_class": null on PTZ buttons,
+  "unit_of_measurement": null on the server sensors). HA rejects such configs
+  and silently drops the entity. Existing camera entities coasted on their
+  previously-retained configs until the next HA restart replayed the poisoned
+  ones — then they flipped to Unavailable; the brand-new server device never
+  appeared at all. Every discovery publish now omits unset fields entirely,
+  and the fixed build heals HA on its next connect by overwriting the
+  retained configs with valid ones — no HA-side action needed.
 - The timeline's buffering spinner no longer lingers after pausing: the veil
   now follows the video element's own events, so it clears the moment the
   paused frame is ready (and appears instantly on a genuine mid-stream stall).

--- a/src/Neolink.Server/Mqtt/HomeAssistantMqtt.cs
+++ b/src/Neolink.Server/Mqtt/HomeAssistantMqtt.cs
@@ -46,6 +46,16 @@ public sealed class HomeAssistantMqtt
     /// <summary>How long a detection stays "on" after the last alarm push for it.</summary>
     private static readonly TimeSpan MotionOffDelay = TimeSpan.FromSeconds(20);
 
+    /// <summary>Discovery JSON must OMIT unset fields: Home Assistant validates
+    /// every key it sees, and an explicit null ("icon": null) fails that
+    /// validation — the whole entity is then discarded with only an HA-side log
+    /// to show for it. Configs here are anonymous objects whose optional members
+    /// default to null, so every discovery publish must serialize with this.</summary>
+    internal static readonly JsonSerializerOptions DiscoveryJson = new()
+    {
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
     /// <summary>Every detection label that gets a binary sensor. The classic four
     /// are announced on every camera; the smart labels (package + the perimeter
     /// events set up in the Reolink app) announce lazily on their first push, so
@@ -249,7 +259,7 @@ public sealed class HomeAssistantMqtt
                 availability_mode = "all",
             };
             await PublishAsync($"{_cfg.DiscoveryPrefix}/sensor/neolink_server/{s.Key}/config",
-                JsonSerializer.Serialize(config), ct).ConfigureAwait(false);
+                JsonSerializer.Serialize(config, DiscoveryJson), ct).ConfigureAwait(false);
         }
         await PublishAsync(ServerTopic("started"), Web.SystemMonitor.Started.ToString("o"), ct)
             .ConfigureAwait(false);
@@ -437,7 +447,7 @@ internal sealed class CameraBridge
     {
         if (!_hub.Config.Discovery) return Task.CompletedTask;
         var topic = $"{_hub.Config.DiscoveryPrefix}/{component}/neolink_{Id}/{objectId}/config";
-        return _hub.PublishAsync(topic, JsonSerializer.Serialize(config), ct);
+        return _hub.PublishAsync(topic, JsonSerializer.Serialize(config, HomeAssistantMqtt.DiscoveryJson), ct);
     }
 
     /// <summary>The device block shared by every entity so HA groups them under one device.</summary>

--- a/src/Neolink.Server/SelfTest.cs
+++ b/src/Neolink.Server/SelfTest.cs
@@ -776,6 +776,15 @@ public static class SelfTest
             var keys = Mqtt.HomeAssistantMqtt.ServerStatePayloads(headless, 0).Select(p => p.Key).ToList();
             Assert(!keys.Contains("disk_free") && !keys.Contains("disk_used_pct")
                 && !keys.Contains("recordings_size"), "unavailable sources are absent, not zero");
+
+            // Discovery JSON must OMIT unset fields: HA validates every key it
+            // sees, rejects explicit nulls ("icon": null) and silently drops the
+            // entity — the reason a config built with optional members must go
+            // through the null-stripping serializer.
+            var json = System.Text.Json.JsonSerializer.Serialize(
+                new { name = "X", icon = (string?)null, unit_of_measurement = (string?)null },
+                Mqtt.HomeAssistantMqtt.DiscoveryJson);
+            AssertEq(json, "{\"name\":\"X\"}");
         });
 
         Test("config editor: read-modify-write with validation", () =>


### PR DESCRIPTION
Home Assistant entities were dropped when discovery configs included explicit null values for unset fields (e.g., "icon": null). This commit introduces a custom JsonSerializerOptions to omit null fields during serialization, ensuring valid configs and restoring missing entities. Added tests confirm null fields are excluded from the output.