### PR TITLE
Events page, deep links & HA last-event sensor (0.8.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,63 @@ Release notes for Neolink.NET. Releasing works by tagging `vX.Y.Z` — the docke
 workflow bakes the tag into the app as its version (see "Versioning & releases"
 in the README). Paste the matching section below into the GitHub release.
 
+## 0.8.5
+
+### New
+
+- **Dedicated Events page (`/events`)** — recent detection events now have their
+  own full page instead of only a pop-up, built for the phone-notification flow:
+  a Home Assistant "motion detected" push can deep-link straight to
+  **`/events/{camera}`**, which pre-filters to that camera and opens its newest
+  clip on arrival — one tap from the alert to the footage. A recent-events list
+  (thumbnails, camera, time, filters for camera / day / unreviewed) sits beside
+  the player on desktop and stacks on phones. Every event and the header carry a
+  one-tap **Go live** jump to that camera's feed, and an Events ⇄ Live toggle
+  switches between reviewing and watching. The old pop-up is replaced; the live
+  view's ambient event strip is unchanged.
+
+- **Timeline calendar date-picker**: the date now opens a month calendar with
+  **days that hold footage highlighted** (a dot under the number), so you can
+  see at a glance which days have recordings and jump straight to one — no more
+  clicking through empty days. Month navigation, a Today shortcut, and future
+  days disabled. Backed by a new `GET /api/events/days` endpoint.
+
+- **Deep link to one exact event**: `/events?event={id}` opens the Events page
+  with that clip already selected and playing — even for events older than the
+  recent list (the page jumps to their day). Event ids come from
+  `GET /api/events`; backed by a new `GET /api/events/{id}` lookup. Per-camera
+  links (`/events/{camera}`) now always land on that camera's most recent event,
+  even when the last 24 hours were quiet.
+
+- **"Last event" sensor in Home Assistant**: cameras that record events get an
+  MQTT sensor whose state is the newest event's id, published (retained) the
+  instant the event starts — at the same moment as the motion trigger. A
+  notification automation can point its tap action at
+  `…/events?event={{ states('sensor.<cam>_last_event') }}` for true one-tap
+  alert-to-clip. Labels and start time ride along as attributes.
+
+- **Deep-linked clips start muted on a fresh page load**: when the Events page
+  auto-opens a clip on a full navigation (a notification tap), playback begins
+  muted — no surprise audio, and no autoplay-blocked freeze. Clicking an event
+  yourself keeps sound on as before.
+
+### Changed
+
+- **Beta tags retired**: two-way talk, timeline fast playback and scheduled
+  capture have proven themselves — the BETA pills and wording are gone. (Talk
+  remains opt-in via `ui.talk`, unchanged.)
+- **Timeline toolbar tidied**: the controls are grouped into labelled clusters
+  (date · transport · speed · view) inside subtle pills instead of one long run
+  of buttons, and the clock/zoom/help settle at the right edge — easier to scan
+  and it wraps by group on narrow screens.
+
+### Fixed
+
+- Suffixed builds (test images, prereleases like `0.8.5-events-test`) no longer
+  see every published release as an "update" — the version comparison now uses
+  the numeric prefix instead of silently falling back to 0.0 when the suffix
+  didn't parse.
+
 ## 0.8.4
 
 ### New

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The cameras are unmodified and no Reolink NVR is required.
   rules), a speaker button on the tile/quick-view unmutes; event clips and 24/7
   recordings carry the audio track too. ADPCM-only cameras play audio via RTSP only
   (browsers can't decode raw PCM in MP4)
-- **Two-way talk (beta, opt-in)** for cameras with a speaker (doorbells, floodlight
+- **Two-way talk (opt-in)** for cameras with a speaker (doorbells, floodlight
   cams): a mic button on the maximized tile / quick view streams your microphone to
   the camera — the browser's PCM is resampled and ADPCM-encoded server-side, no
   plugins. Disabled by default; enable it in *Server settings → Web UI* (or
@@ -556,6 +556,54 @@ Neolink speaks MQTT 3.1.1 directly, keeping the zero-dependency build.
 > Plain MQTT (port 1883) is unencrypted. For a LAN broker that's typical; enable
 > `tls` (port 8883) if the broker is remote.
 
+### Tap a phone alert straight to the footage
+
+The web UI's **Events page is deep-linkable**: `…/events/{camera}` opens filtered
+to that camera with its newest clip already playing. Point a Home Assistant
+notification's tap action at it and a "motion detected" push takes you one tap
+from the alert to the recording (and a **Go live** button is right there to jump
+to the feed):
+
+```yaml
+automation:
+  - alias: Notify on driveway motion
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.driveway_motion   # a Neolink camera sensor
+        to: "on"
+    action:
+      - service: notify.mobile_app_your_phone
+        data:
+          title: Driveway motion
+          message: Motion detected on the driveway
+          data:
+            # HA companion app: tapping the notification opens this URL
+            clickAction: https://neolink.example.com/events/Driveway
+```
+
+Plain `/events` (no camera) opens the full recent-events list. And when you know
+the exact event — its `id` from `GET /api/events` — `/events?event={id}` opens
+and plays that specific clip, even one older than the recent list (the page
+jumps to its day). All forms require the web UI to be reachable from the phone —
+usually via your reverse proxy.
+
+**Linking to the exact event from HA**: with MQTT enabled, every camera that
+records events gets a **Last event** sensor (e.g.
+`sensor.driveway_last_event`) whose state is the newest event's id — published
+the instant the event starts, alongside the motion trigger, so it is already
+current inside the automation that the motion fired. Point the tap action at
+the exact clip:
+
+```yaml
+          data:
+            clickAction: >-
+              https://neolink.example.com/events?event={{ states('sensor.driveway_last_event') }}
+```
+
+(You can also trigger the automation on the Last event sensor itself — a state
+change *is* a new recording, and `trigger.to_state.state` is the id.) Clips
+that auto-open from such a link start muted; tap the speaker to unmute.
+
 ## Using with Frigate
 
 ```yaml
@@ -646,7 +694,7 @@ issue with them so the mapping can be extended.
   the sub stream. This is a browser limitation — the RTSP side serves H.265 fine.
 - **Latency** adapts to the camera: ~1 s for cameras that deliver per-frame, more for
   cameras that batch whole GOPs (the buffer must cover the delivery gap).
-- **Two-way talk is a beta feature and off by default**: enable it in
+- **Two-way talk is off by default**: enable it in
   *Server settings → Web UI → Two-way talk* (writes `"ui": { "talk": true }` to the
   config; applies after a restart). It also needs a secure context — browsers only
   allow microphone capture over HTTPS (or on `localhost`). Behind a reverse proxy

--- a/src/Neolink.Server/Mqtt/HomeAssistantMqtt.cs
+++ b/src/Neolink.Server/Mqtt/HomeAssistantMqtt.cs
@@ -34,6 +34,10 @@ namespace Neolink.Mqtt;
 ///   • binary_sensor: recording — ON while the server is writing this camera's
 ///                    footage (an event clip, whatever triggered it, or a
 ///                    continuous segment)
+///   • sensor:        last event — the id of the newest detection event,
+///                    published (retained) the instant the event starts, so a
+///                    motion automation can deep-link to the exact clip via
+///                    {web-ui}/events?event={id}
 ///   • select:        night vision (auto/on/off)         (IR-capable cameras)
 ///   • light:         floodlight                         (cameras with a spotlight)
 ///   • button:        reboot, and PTZ steps              (per capability)
@@ -366,6 +370,26 @@ internal sealed class CameraBridge
         {
             rec.OnDemandChanged += session => _ = PublishRecordStateAsync(session != null);
             rec.RecordingChanged += on => _ = PublishRecordingStateAsync(force: false);
+            rec.EventStarted += ev => _ = PublishLastEventAsync(ev);
+        }
+    }
+
+    /// <summary>The new event's id lands (retained) the instant the event starts —
+    /// together with the motion trigger — so an automation can build a link to the
+    /// exact clip: {web-ui}/events?event={{ states('sensor.X_last_event') }}.</summary>
+    private async Task PublishLastEventAsync(EventRecord ev)
+    {
+        try
+        {
+            await _hub.PublishAsync(StateTopic("last_event"), ev.Id, CancellationToken.None)
+                .ConfigureAwait(false);
+            await _hub.PublishAsync(StateTopic("last_event/attr"),
+                JsonSerializer.Serialize(new { labels = ev.Labels, started = ev.StartUtc }),
+                CancellationToken.None).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Broker unreachable — the next event republishes; the topic is retained.
         }
     }
 
@@ -453,6 +477,9 @@ internal sealed class CameraBridge
             await AnnounceEntityAsync("switch", "record", RecordSwitchConfig(), ct).ConfigureAwait(false);
             await _hub.PublishAsync(StateTopic("record"), recorder.OnDemand != null ? "ON" : "OFF", ct)
                 .ConfigureAwait(false);
+            // Last event id: state is retained, so HA has the most recent id even
+            // across restarts — no state publish needed here.
+            await AnnounceEntityAsync("sensor", "last_event", LastEventConfig(), ct).ConfigureAwait(false);
         }
 
         // Recording status: is footage for this camera being written right now
@@ -653,6 +680,23 @@ internal sealed class CameraBridge
             await _hub.PublishAsync(StateTopic("record"), rec.OnDemand != null ? "ON" : "OFF",
                 CancellationToken.None).ConfigureAwait(false);
     }
+
+    /// <summary>The id of the camera's most recent detection event, updated the
+    /// moment the event starts. Made for notification deep links: append the
+    /// state to "{web-ui}/events?event=" and the tap opens that exact clip.
+    /// Labels and start time ride along as attributes.</summary>
+    private object LastEventConfig() => new
+    {
+        name = "Last event",
+        unique_id = $"neolink_{Id}_last_event",
+        state_topic = StateTopic("last_event"),
+        json_attributes_topic = StateTopic("last_event/attr"),
+        icon = "mdi:motion-play-outline",
+        entity_category = "diagnostic",
+        device = Device(),
+        availability = Availability(),
+        availability_mode = "all",
+    };
 
     private object RecordingSensorConfig() => new
     {

--- a/src/Neolink.Server/Neolink.Server.csproj
+++ b/src/Neolink.Server/Neolink.Server.csproj
@@ -11,7 +11,7 @@
          log, /api/features and the web UI. Release builds override it with the
          git tag (docker.yml passes -p:Version), so tagging vX.Y.Z is what
          increments the released version. -->
-    <Version>0.8.4</Version>
+    <Version>0.8.5</Version>
     <InvariantGlobalization>true</InvariantGlobalization>
     <ServerGarbageCollection>false</ServerGarbageCollection>
     <TieredPgo>true</TieredPgo>

--- a/src/Neolink.Server/Recording/EventRecorder.cs
+++ b/src/Neolink.Server/Recording/EventRecorder.cs
@@ -94,6 +94,11 @@ public sealed class EventRecorder
     /// bridge mirrors it into the camera's "Recording" status sensor.</summary>
     public event Action<bool>? RecordingChanged;
 
+    /// <summary>Fires the moment a detection event is created, before any media
+    /// work — the MQTT bridge forwards the id to HA so an automation firing on
+    /// the same trigger can deep-link to the exact clip (/events?event={id}).</summary>
+    public event Action<EventRecord>? EventStarted;
+
     // ------------------------------------------------------------------ on-demand recording
 
     /// <summary>A running user-commanded recording (web UI record button / HA Record switch).</summary>
@@ -442,6 +447,7 @@ public sealed class EventRecorder
         var rec = _store.Create(_camera,
             DateTime.UtcNow - TimeSpan.FromSeconds(_cfg.PreSeconds), initialLabels);
         Log.Info($"{_camera}: ⚡ event started ({string.Join("+", rec.Labels)})");
+        EventStarted?.Invoke(rec); // id out first: HA sees it with the trigger
         _eventActive = true;
         RecordingChanged?.Invoke(true);
         try

--- a/src/Neolink.Server/Recording/EventStore.cs
+++ b/src/Neolink.Server/Recording/EventStore.cs
@@ -172,6 +172,26 @@ public sealed class EventStore
         }
     }
 
+    /// <summary>
+    /// Every local day ("yyyy-MM-dd") that holds any recorded content — detection
+    /// events or continuous footage, for any camera — newest first. Feeds the
+    /// timeline's calendar so days with footage can be highlighted at a glance.
+    /// </summary>
+    public List<string> ListContentDays()
+    {
+        var days = new HashSet<string>(StringComparer.Ordinal);
+        if (Directory.Exists(_root))
+        {
+            foreach (var camDir in Directory.EnumerateDirectories(_root))
+                foreach (var dayDir in Directory.EnumerateDirectories(camDir))
+                {
+                    var name = Path.GetFileName(dayDir)!;
+                    if (IsDayName(name)) days.Add(name);
+                }
+        }
+        return days.OrderByDescending(d => d).ToList();
+    }
+
     // ------------------------------------------------------------------ continuous recordings
 
     /// <summary>Path for a new continuous-recording segment starting now (creates the day dir).</summary>

--- a/src/Neolink.Server/SelfTest.cs
+++ b/src/Neolink.Server/SelfTest.cs
@@ -1157,6 +1157,15 @@ public static class SelfTest
             Assert(!chk.IsNewer("v0.6.0"), "same version is not an update");
             Assert(!chk.IsNewer("0.5.9"), "older version is not an update");
             Assert(!chk.IsNewer("not-a-version"), "junk tag ignored");
+
+            // Suffixed builds (test tars, prereleases) compare by their numeric
+            // prefix — a 0.8.5-events-test box must NOT be offered 0.8.4 as an
+            // "update" (the regression: the suffix failed to parse, the running
+            // version fell back to 0.0, and every release looked newer).
+            var test = new Web.UpdateChecker("0.8.5-events-test");
+            Assert(!test.IsNewer("v0.8.4"), "release older than a test build's base is not an update");
+            Assert(!test.IsNewer("v0.8.5"), "the test build's own base release is not an update");
+            Assert(test.IsNewer("v0.8.6"), "a genuinely newer release still is");
         });
 
         Test("web api: auth gate, token transports, endpoint contracts", () =>
@@ -1166,11 +1175,22 @@ public static class SelfTest
             // seam merges keep touching: the auth middleware and the JSON shapes.
             var dir = Path.Combine(Path.GetTempPath(), $"neolink-selftest-{Guid.NewGuid():N}");
             Directory.CreateDirectory(dir);
+
+            // One event staged on disk before the store loads: the /api/events
+            // list and the single-event deep-link lookup have something to find.
+            const string evId = "apicam~2026-01-05~101112-sf01";
+            var evDir = Path.Combine(dir, "recordings", "apicam", "2026-01-05", "detections", "101112-sf01");
+            Directory.CreateDirectory(evDir);
+            File.WriteAllText(Path.Combine(evDir, "event.json"),
+                $$"""{"id":"{{evId}}","camera":"apicam","startUtc":"2026-01-05T10:11:12Z","endUtc":"2026-01-05T10:11:30Z","labels":["person"]}""");
+
             using var cts = new CancellationTokenSource();
             Task? server = null;
             try
             {
                 int port = FreeTcpPort();
+                var store = new Recording.EventStore(Path.Combine(dir, "recordings"));
+                store.Load(); // index the staged event, as Program does at startup
                 var hub = new Streaming.StreamHub("apicam");
                 var cam = new Web.WebCameraInfo("apicam",
                     new List<Web.WebStreamInfo> { new("mainStream", "/apicam/mainStream", hub) },
@@ -1183,7 +1203,7 @@ public static class SelfTest
                     Cameras = new[] { cam },
                     Users = new Dictionary<string, string>(),
                     RtspPort = 8654,
-                    Events = new Recording.EventStore(Path.Combine(dir, "recordings")),
+                    Events = store,
                     RecordingSettings = new Recording.RecordingSettings(dir),
                     UserStore = new Web.UserStore(dir),
                     Version = "0.0.0-selftest",
@@ -1274,8 +1294,16 @@ public static class SelfTest
                 Assert(rec.GetProperty("events").GetBoolean(), "recording switch persisted via API");
                 Assert(rec.TryGetProperty("continuous", out _), "continuous switch exposed");
 
-                // Recorded-events listing responds (empty store).
-                AssertEq(GetJson(http, $"/api/events{tokenQ}").GetArrayLength(), 0);
+                // Recorded-events listing sees the staged event, and the
+                // single-event lookup (notification deep links) round-trips.
+                var evList = GetJson(http, $"/api/events{tokenQ}");
+                AssertEq(evList.GetArrayLength(), 1);
+                AssertEq(evList[0].GetProperty("id").GetString()!, evId);
+                var one = GetJson(http, $"/api/events/{Uri.EscapeDataString(evId)}{tokenQ}");
+                AssertEq(one.GetProperty("id").GetString()!, evId);
+                AssertEq(one.GetProperty("camera").GetString()!, "apicam");
+                Assert(!one.GetProperty("hasClip").GetBoolean(), "staged event has no clip");
+                AssertEq((int)http.GetAsync($"/api/events/nope{tokenQ}").Result.StatusCode, 404);
             }
             finally
             {

--- a/src/Neolink.Server/Web/UpdateChecker.cs
+++ b/src/Neolink.Server/Web/UpdateChecker.cs
@@ -23,7 +23,12 @@ public sealed class UpdateChecker
 
     public UpdateChecker(string currentVersion)
     {
-        System.Version.TryParse(currentVersion, out var v);
+        // Only the numeric prefix counts: "0.8.5-events-test" compares as 0.8.5.
+        // System.Version can't parse suffixed versions, and falling back to 0.0
+        // made every test build see every release as an "update" (a downgrade
+        // banner on 0.8.5-test when 0.8.4 was the latest release).
+        var numeric = currentVersion.Split('-', '+')[0];
+        System.Version.TryParse(numeric, out var v);
         _current = v ?? new System.Version(0, 0);
     }
 

--- a/src/Neolink.Server/Web/WebApi.cs
+++ b/src/Neolink.Server/Web/WebApi.cs
@@ -71,7 +71,7 @@ public sealed class WebApiOptions
 ///   POST/PUT .../settings/stream            — change an encode profile (needs http_address)
 ///   GET/POST .../led /pir; POST .../ptz /reboot; GET .../battery — camera control
 ///   GET /api/events[?camera=&amp;reviewed=&amp;limit=] — recorded detection events (when enabled)
-///   GET /api/events/{id}/clip /thumb        — event artifacts; POST .../review to (un)dismiss
+///   GET /api/events/{id}[/clip /thumb]      — one event / its artifacts; POST .../review to (un)dismiss
 ///   GET/POST /api/cameras/{name}/recording  — per-camera recording switches + event-type filter
 ///   POST /api/cameras/{name}/record         — start/stop an on-demand clip (one clip, auto-capped)
 ///   GET /api/recordings/{camera}[/{date}[/{file}]] — browse/play continuous footage
@@ -793,6 +793,20 @@ public static class WebApi
                 return Results.Json(events.List(camera, reviewed, limit ?? 200, day).Select(Shape));
             });
 
+            // Days that hold any footage (events or continuous) — the timeline's
+            // calendar highlights these. Literal "days" beats the {id} routes.
+            app.MapGet("/api/events/days", () => Results.Json(events.ListContentDays()));
+
+            // Single-event lookup: notification deep links (/events?event={id})
+            // resolve the exact event even after it ages out of the 24h list.
+            app.MapGet("/api/events/{id}", (string id) =>
+            {
+                var rec = events.Find(id);
+                return rec == null
+                    ? Results.Json(new { error = "unknown event" }, statusCode: 404)
+                    : Results.Json(Shape(rec));
+            });
+
             app.MapGet("/api/events/{id}/clip", (string id) =>
             {
                 var path = events.ArtifactPath(id, "clip.mp4");
@@ -1109,7 +1123,7 @@ public static class WebApi
                 ctx.Response.StatusCode = 403;
                 await ctx.Response.WriteAsJsonAsync(new
                 {
-                    error = "two-way talk is a beta feature — enable it in Server settings (ui.talk)",
+                    error = "two-way talk is disabled — enable it in Server settings (ui.talk)",
                 });
                 return;
             }

--- a/src/Neolink.Server/config.example.json
+++ b/src/Neolink.Server/config.example.json
@@ -32,7 +32,7 @@
     // Playback speed of the ambient clip previews in the review strip.
     "trickle_speed": 4,
 
-    // BETA: two-way talk — a mic button on talk-capable cameras (doorbells etc.)
+    // Two-way talk — a mic button on talk-capable cameras (doorbells etc.)
     // streams your microphone to the camera's speaker. Off by default; can also
     // be toggled from the web UI (Server settings → Web UI). Browsers only allow
     // microphone access on HTTPS or localhost pages.

--- a/src/Neolink.WebClient/Components/CameraPanel.razor
+++ b/src/Neolink.WebClient/Components/CameraPanel.razor
@@ -236,7 +236,7 @@
                         are never changed.
                     </div>
                     <div class="control-row">
-                        <span>Scheduled capture <span class="beta-tag" title="Scheduled capture is new — report anything odd">BETA</span></span>
+                        <span>Scheduled capture</span>
                         <button class="chip @(_recording.ScheduleEnabled ? "" : "chip-off")"
                                 title="@(_recording.ScheduleEnabled ? "Events are captured only inside the schedule below — click to capture at all times" : "Events are captured at all times — click to restrict capture to a schedule")"
                                 @onclick="() => SetRecordingAsync(scheduleEnabled: !_recording.ScheduleEnabled)">

--- a/src/Neolink.WebClient/Components/Pages/Events.razor
+++ b/src/Neolink.WebClient/Components/Pages/Events.razor
@@ -1,0 +1,506 @@
+@page "/events"
+@page "/events/{Camera}"
+@using System.Text.Json
+@inject HttpClient Http
+@inject IJSRuntime JS
+@inject NavigationManager Nav
+@inject LocalApiInfo Local
+@implements IAsyncDisposable
+
+@* Dedicated events page — the landing target for "motion detected" push
+   notifications (Home Assistant's clickAction can deep-link /events/{camera}).
+   A recent-events list on the left, the selected clip on the right (stacked on
+   phones), and a one-tap jump to that camera's live feed. *@
+
+<PageTitle>Neolink — Events</PageTitle>
+
+<div class="ev-page @(_selected != null ? "has-selection" : "")">
+    <div class="toolbar ev-toolbar">
+        <a class="tool-btn" href="" title="Back to the live camera wall">@UiIcon.Render("chev-left", 16) <span class="tool-name">Live</span></a>
+        <span class="tool-label">EVENTS</span>
+
+        @* Events ⇄ Live segmented toggle: the fast switch the use case asks for. *@
+        <span class="ev-switch" role="tablist">
+            <span class="ev-switch-opt active" role="tab" aria-selected="true">Events</span>
+            <a class="ev-switch-opt" role="tab" href="@LiveHref()" title="Watch the cameras live">Live</a>
+        </span>
+
+        <span class="tile-spacer"></span>
+
+        <select class="event-filter" @bind="_cameraFilter" @bind:after="OnFilterChanged" title="Filter by camera">
+            <option value="">all cameras</option>
+            @foreach (var c in _cameras)
+            {
+                <option value="@c.Name">@c.Name</option>
+            }
+        </select>
+        <button class="chip @(_unreviewedOnly ? "chip-active" : "chip-off")" title="Only events awaiting review"
+                @onclick="() => _unreviewedOnly = !_unreviewedOnly">unreviewed</button>
+        <input class="event-filter event-date-input" type="date" title="Jump to a specific day"
+               max="@DateTime.Today.ToString("yyyy-MM-dd")"
+               value="@(_date?.ToString("yyyy-MM-dd") ?? "")"
+               @onchange="e => SetDateAsync((string?)e.Value)" />
+        @if (_date != null)
+        {
+            <button class="chip" title="Back to the rolling last 24 hours" @onclick="() => SetDateAsync(null)">↺ 24h</button>
+        }
+        <button class="icon-btn" title="Refresh" @onclick="RefreshAsync">@UiIcon.Render("refresh", 14)</button>
+    </div>
+
+    @if (_error != null)
+    {
+        <div class="notice error">@_error</div>
+    }
+    else if (!_supported)
+    {
+        <div class="notice">
+            Recording is not enabled on this server — add a "recording" section to the config to capture events.
+        </div>
+    }
+    else
+    {
+        <div class="ev-body">
+            <div class="ev-list" role="list">
+                @if (_loading)
+                {
+                    <div class="notice">Loading…</div>
+                }
+                else if (!Filtered.Any())
+                {
+                    <div class="notice">
+                        @(_unreviewedOnly ? "Nothing awaiting review — all clear."
+                            : _date != null ? "No events on this day."
+                            : "No events in the last 24 hours.")
+                    </div>
+                }
+                @foreach (var day in Filtered.GroupBy(e => e.Start.ToLocalTime().Date))
+                {
+                    <div class="ev-day">
+                        <div class="ev-day-head">@DayLabel(day.Key) <span class="event-day-count">@day.Count()</span></div>
+                        @foreach (var ev in day)
+                        {
+                            <div class="event-row @(ev.Reviewed ? "reviewed" : "") @(_selected?.Id == ev.Id ? "selected" : "")"
+                                 @key="ev.Id" role="listitem" title="Play this event" @onclick="() => SelectAsync(ev)">
+                                <div class="event-row-thumb">
+                                    @if (ev.HasThumb)
+                                    {
+                                        <img src="@Artifact(ev, "thumb")" loading="lazy" alt="" />
+                                    }
+                                    else
+                                    {
+                                        <span class="event-thumb-icon">@ev.Icon</span>
+                                    }
+                                    <span class="event-row-dur">@DurationText(ev)</span>
+                                    @if (ev.Ongoing)
+                                    {
+                                        <span class="event-live">● REC</span>
+                                    }
+                                </div>
+                                <div class="event-row-main">
+                                    <span class="event-title">@ev.Icon @ev.Title</span>
+                                    <span class="event-sub">@ev.Camera · @ev.Start.ToLocalTime().ToString("HH:mm:ss") · @Ago(ev.Start)</span>
+                                </div>
+                                @if (!ev.Reviewed)
+                                {
+                                    <span class="event-new-dot" title="Unreviewed"></span>
+                                }
+                                <a class="icon-btn ev-row-live" href="@LiveHref(ev.Camera)"
+                                   title="Watch @ev.Camera live" @onclick:stopPropagation="true">@UiIcon.Render("activity", 14)</a>
+                            </div>
+                        }
+                    </div>
+                }
+            </div>
+
+            <div class="ev-detail @(_selected == null ? "empty" : "")">
+                @if (_selected is { } sel)
+                {
+                    <div class="event-player-head">
+                        <button class="icon-btn ev-back" title="Back to the list" @onclick="CloseAsync">@UiIcon.Render("chev-left", 16)</button>
+                        <div class="event-player-title">
+                            <span class="event-title">@sel.Icon @sel.Title</span>
+                            <span class="event-sub">@sel.Camera · @sel.Start.ToLocalTime().ToString("ddd d MMM HH:mm:ss") · @DurationText(sel)</span>
+                        </div>
+                        <a class="chip ev-golive" href="@LiveHref(sel.Camera)" title="Watch @sel.Camera live now">
+                            @UiIcon.Render("activity", 13) Go live
+                        </a>
+                    </div>
+
+                    @if (sel.HasClip)
+                    {
+                        <div class="event-player-media" @key="sel.Id">
+                            <video id="ev-video" controls autoplay playsinline></video>
+                        </div>
+                        <div class="player-speed">
+                            <span class="tool-label">SPEED</span>
+                            @foreach (var s in Speeds)
+                            {
+                                <button class="chip @(_speed == s ? "chip-active" : "")" @onclick="() => SetSpeedAsync(s)">@FormatSpeed(s)</button>
+                            }
+                            @if (_speed > 1 && sel.HasPreview)
+                            {
+                                <span class="event-sub">· preview quality while fast-forwarding</span>
+                            }
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="notice">No clip was recorded for this event@(sel.Ongoing ? " yet — it is still being captured" : "").</div>
+                    }
+
+                    <div class="event-player-foot">
+                        <button class="chip" disabled="@(Neighbor(1) == null)" @onclick="() => NavigateAsync(1)">← Older</button>
+                        <button class="chip" disabled="@(Neighbor(-1) == null)" @onclick="() => NavigateAsync(-1)">Newer →</button>
+                        <span class="tile-spacer"></span>
+                        @if (sel.Reviewed)
+                        {
+                            <span class="event-sub">✓ reviewed</span>
+                        }
+                        else
+                        {
+                            <span class="event-sub">marked reviewed on close</span>
+                        }
+                    </div>
+                }
+                else
+                {
+                    <div class="ev-detail-empty">
+                        <span class="ev-detail-empty-icon">@UiIcon.Render("clock", 30)</span>
+                        <span>Select an event to play it</span>
+                    </div>
+                }
+            </div>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter] public string? Camera { get; set; }
+
+    /// <summary>Deep link to one exact event: /events?event={id} auto-opens and plays it.</summary>
+    [SupplyParameterFromQuery(Name = "event")] public string? EventId { get; set; }
+
+    private string _server = "";
+    private string _origin = "";
+    private string? _token;
+
+    private readonly List<ApiCamera> _cameras = new();
+    private readonly List<ApiEvent> _events = new();     // rolling last 24h
+    private List<ApiEvent> _eventsForDate = new();       // one selected day
+    private ApiEvent? _selected;
+
+    private string _cameraFilter = "";
+    private bool _unreviewedOnly;
+    private DateTime? _date;
+    private bool _supported = true;
+    private bool _loading = true;
+    private string? _error;
+
+    private double _speed = 1;
+    private static readonly double[] Speeds = { 1, 2, 4, 8 };
+
+    private string? _pendingVideoUrl; // set when a clip needs (re)attaching after render
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            // Server + credentials come from the live view's persisted settings.
+            try
+            {
+                var json = await JS.InvokeAsync<string?>("neolink.lsGet", "neolink.view");
+                if (json != null)
+                    _server = JsonSerializer.Deserialize<PersistedView>(json)?.Server ?? "";
+                var auth = await JS.InvokeAsync<string?>("neolink.lsGet", "neolink.auth");
+                if (!string.IsNullOrWhiteSpace(auth))
+                {
+                    var el = JsonSerializer.Deserialize<JsonElement>(auth);
+                    if (el.TryGetProperty("token", out var t)) _token = t.GetString();
+                }
+            }
+            catch { }
+            try { _origin = await JS.InvokeAsync<string>("neolink.defaultServer"); } catch { }
+            if (string.IsNullOrWhiteSpace(_server))
+                _server = _origin;
+
+            // Deep link: /events/{camera} pre-filters (HA notifications land here).
+            if (!string.IsNullOrWhiteSpace(Camera))
+                _cameraFilter = Camera;
+
+            await LoadCamerasAsync();
+            await RefreshAsync();
+
+            // Deep link to one exact event (?event={id}): open and play it, even
+            // when it is older than the rolling 24h window.
+            if (!string.IsNullOrWhiteSpace(EventId))
+                await OpenEventByIdAsync(EventId);
+
+            // The push-notification flow: land straight on the newest event for
+            // the deep-linked camera so the tap shows the clip immediately. A
+            // quiet last-24h falls back to the camera's most recent stored event,
+            // however old — a per-camera link must always land on footage.
+            if (!string.IsNullOrWhiteSpace(Camera) && _selected == null)
+            {
+                var newest = Filtered.FirstOrDefault();
+                if (newest != null)
+                {
+                    await SelectAsync(newest);
+                }
+                else
+                {
+                    var latest = await GetJsonAsync<List<ApiEvent>>(
+                        $"/api/events?camera={Uri.EscapeDataString(Camera)}&limit=1");
+                    if (latest is [{ } ev]) await OpenEventAsync(ev);
+                }
+            }
+
+            StateHasChanged();
+            return;
+        }
+
+        if (_pendingVideoUrl is { } url)
+        {
+            _pendingVideoUrl = null;
+            await JS.InvokeVoidAsync("neolink.eventPlayer", "ev-video", url, _speed);
+        }
+    }
+
+    // ------------------------------------------------------------ data plumbing
+
+    private string Base => _server.TrimEnd('/');
+
+    /// <summary>Server-side fetches resolve our own origin to loopback (reverse-proxy safe).</summary>
+    private string ApiBase =>
+        _origin.Length > 0 && string.Equals(Base, _origin.TrimEnd('/'), StringComparison.OrdinalIgnoreCase)
+            ? Local.BaseUrl.TrimEnd('/')
+            : Base;
+
+    private string TokenQuery(char sep) =>
+        string.IsNullOrEmpty(_token) ? "" : $"{sep}token={Uri.EscapeDataString(_token)}";
+
+    private HttpRequestMessage Req(HttpMethod m, string path)
+    {
+        var r = new HttpRequestMessage(m, $"{ApiBase}{path}");
+        if (!string.IsNullOrEmpty(_token))
+            r.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _token);
+        return r;
+    }
+
+    private async Task<T?> GetJsonAsync<T>(string path)
+    {
+        using var res = await Http.SendAsync(Req(HttpMethod.Get, path));
+        if (res.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+        {
+            _error = "Sign in on the live view first, then reopen Events.";
+            return default;
+        }
+        if (!res.IsSuccessStatusCode) return default;
+        return await res.Content.ReadFromJsonAsync<T>();
+    }
+
+    private async Task LoadCamerasAsync()
+    {
+        try
+        {
+            var cams = await GetJsonAsync<List<ApiCamera>>("/api/cameras");
+            _cameras.Clear();
+            if (cams != null) { _cameras.AddRange(cams); _error = null; }
+        }
+        catch (Exception ex) { _error = $"Cannot reach {_server}: {ex.Message}"; }
+    }
+
+    private async Task RefreshAsync()
+    {
+        _loading = _events.Count == 0 && _eventsForDate.Count == 0;
+        try
+        {
+            var features = await GetJsonAsync<ApiFeaturesInfo>("/api/features");
+            _supported = features?.Events == true;
+            if (!_supported) { _loading = false; return; }
+
+            var list = await GetJsonAsync<List<ApiEvent>>("/api/events?limit=500");
+            if (list != null)
+            {
+                _events.Clear();
+                _events.AddRange(list);
+            }
+            if (_date != null) await LoadDayAsync();
+
+            // Keep the open player's metadata fresh (an ongoing clip finalizes).
+            if (_selected != null)
+                _selected = Source().FirstOrDefault(e => e.Id == _selected.Id) ?? _selected;
+        }
+        catch (Exception ex) { _error = $"Cannot reach {_server}: {ex.Message}"; }
+        finally { _loading = false; }
+    }
+
+    private async Task LoadDayAsync()
+    {
+        if (_date is not { } day) return;
+        var list = await GetJsonAsync<List<ApiEvent>>($"/api/events?limit=1000&date={day:yyyy-MM-dd}");
+        _eventsForDate = list ?? new List<ApiEvent>();
+    }
+
+    private async Task SetDateAsync(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw) || !DateTime.TryParse(raw, out var day))
+        {
+            _date = null;
+            _eventsForDate = new List<ApiEvent>();
+            return;
+        }
+        _date = day.Date;
+        _loading = true;
+        await LoadDayAsync();
+        _loading = false;
+    }
+
+    private void OnFilterChanged()
+    {
+        // Keep the URL honest so a refresh / share preserves the camera view.
+        var target = string.IsNullOrEmpty(_cameraFilter) ? "events" : $"events/{Uri.EscapeDataString(_cameraFilter)}";
+        Nav.NavigateTo(target, replace: true);
+    }
+
+    // ------------------------------------------------------------ selection & playback
+
+    private IEnumerable<ApiEvent> Source() =>
+        _date == null ? _events.Where(e => e.Start >= DateTime.UtcNow.AddHours(-24)) : _eventsForDate;
+
+    private IEnumerable<ApiEvent> Filtered =>
+        Source()
+            .Where(e => _cameraFilter.Length == 0 || string.Equals(e.Camera, _cameraFilter, StringComparison.OrdinalIgnoreCase))
+            .Where(e => !_unreviewedOnly || !e.Reviewed)
+            .OrderByDescending(e => e.Start);
+
+    private string Artifact(ApiEvent ev, string kind) =>
+        $"{Base}/api/events/{Uri.EscapeDataString(ev.Id)}/{kind}{TokenQuery('?')}";
+
+    private string PlayerUrl(ApiEvent ev) =>
+        _speed > 1 && ev.HasPreview ? Artifact(ev, "preview") : Artifact(ev, "clip");
+
+    /// <summary>Resolve a ?event={id} deep link: find the event (the rolling list, or a
+    /// direct lookup for older ones), bring its day into the list, and play it.</summary>
+    private async Task OpenEventByIdAsync(string id)
+    {
+        var ev = Source().FirstOrDefault(e => e.Id == id)
+                 ?? await GetJsonAsync<ApiEvent>($"/api/events/{Uri.EscapeDataString(id)}");
+        if (ev == null)
+        {
+            _error = "That event no longer exists — it may have been cleaned up.";
+            return;
+        }
+        await OpenEventAsync(ev);
+    }
+
+    /// <summary>Open a deep-linked event wherever it lives: fix up a hiding filter,
+    /// pivot the list to its day when it's outside the 24h window, and play it.</summary>
+    private async Task OpenEventAsync(ApiEvent ev)
+    {
+        // A camera filter that would hide the linked event loses to the link.
+        if (_cameraFilter.Length > 0 && !string.Equals(_cameraFilter, ev.Camera, StringComparison.OrdinalIgnoreCase))
+            _cameraFilter = ev.Camera;
+
+        // Older than the 24h window: pivot the list to the event's day so the
+        // context (and the Older/Newer buttons) line up with what's playing.
+        if (!Source().Any(e => e.Id == ev.Id))
+        {
+            _date = ev.Start.ToLocalTime().Date;
+            await LoadDayAsync();
+        }
+        await SelectAsync(ev);
+    }
+
+    private Task SelectAsync(ApiEvent ev)
+    {
+        _selected = ev;
+        _speed = 1;
+        if (ev.HasClip) _pendingVideoUrl = PlayerUrl(ev); // attach after the <video> renders
+        return Task.CompletedTask;
+    }
+
+    private async Task SetSpeedAsync(double s)
+    {
+        _speed = s;
+        if (_selected is { HasClip: true } ev)
+            await JS.InvokeVoidAsync("neolink.eventPlayer", "ev-video", PlayerUrl(ev), s);
+    }
+
+    /// <summary>Leaving an event marks it reviewed — the same "seen it" semantics as the live strip.</summary>
+    private async Task CloseAsync()
+    {
+        var ev = _selected;
+        _selected = null;
+        if (ev is { Reviewed: false }) await MarkReviewedAsync(ev);
+    }
+
+    private ApiEvent? Neighbor(int direction)
+    {
+        if (_selected == null) return null;
+        var list = Filtered.ToList();
+        int i = list.FindIndex(e => e.Id == _selected.Id);
+        int target = i + direction;
+        return i < 0 || target < 0 || target >= list.Count ? null : list[target];
+    }
+
+    private async Task NavigateAsync(int direction)
+    {
+        var watched = _selected;
+        var next = Neighbor(direction);
+        if (next == null) return;
+        await SelectAsync(next);
+        if (watched is { Reviewed: false }) await MarkReviewedAsync(watched);
+    }
+
+    private async Task MarkReviewedAsync(ApiEvent ev)
+    {
+        try
+        {
+            var req = Req(HttpMethod.Post, $"/api/events/{Uri.EscapeDataString(ev.Id)}/review");
+            req.Content = JsonContent.Create(new { reviewed = true });
+            using var res = await Http.SendAsync(req);
+            if (!res.IsSuccessStatusCode) return;
+        }
+        catch { return; }
+        Mark(_events, ev.Id);
+        Mark(_eventsForDate, ev.Id);
+        if (_selected?.Id == ev.Id) _selected = _selected with { Reviewed = true };
+    }
+
+    private static void Mark(List<ApiEvent> list, string id)
+    {
+        int i = list.FindIndex(e => e.Id == id);
+        if (i >= 0) list[i] = list[i] with { Reviewed = true };
+    }
+
+    // ------------------------------------------------------------ helpers
+
+    /// <summary>Live target: the camera's maximized view, or the wall.</summary>
+    private string LiveHref(string? camera = null) =>
+        string.IsNullOrEmpty(camera) ? "" : $"cameras/{Uri.EscapeDataString(camera)}";
+
+    private static string FormatSpeed(double s) => s == 1 ? "1×" : $"{s:0}×";
+
+    private static string DayLabel(DateTime day) =>
+        day == DateTime.Now.Date ? "TODAY"
+        : day == DateTime.Now.Date.AddDays(-1) ? "YESTERDAY"
+        : day.ToString("dddd, d MMMM").ToUpperInvariant();
+
+    private static string DurationText(ApiEvent ev) =>
+        ev.Ongoing ? "recording…"
+        : ev.Duration.TotalSeconds < 1 ? "<1s"
+        : ev.Duration.TotalSeconds < 90 ? $"{(int)Math.Ceiling(ev.Duration.TotalSeconds)}s"
+        : $"{(int)Math.Round(ev.Duration.TotalMinutes)} min";
+
+    private static string Ago(DateTime utc)
+    {
+        var span = DateTime.UtcNow - utc.ToUniversalTime();
+        if (span < TimeSpan.Zero) span = TimeSpan.Zero;
+        return span.TotalSeconds < 60 ? "just now"
+            : span.TotalMinutes < 60 ? $"{(int)span.TotalMinutes}m ago"
+            : span.TotalHours < 24 ? $"{(int)span.TotalHours}h ago"
+            : $"{(int)span.TotalDays}d ago";
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}

--- a/src/Neolink.WebClient/Components/Pages/Home.razor
+++ b/src/Neolink.WebClient/Components/Pages/Home.razor
@@ -345,8 +345,7 @@
             @if (_eventsSupported)
             {
                 <span class="tool-sep"></span>
-                <button class="tool-btn @(_showEventsPanel ? "active" : "")" title="Event history"
-                        @onclick="() => _showEventsPanel = !_showEventsPanel">@UiIcon.Render("clock", 14) <span class="tool-name">Events</span></button>
+                <a class="tool-btn" href="events" title="Recent detection events">@UiIcon.Render("clock", 14) <span class="tool-name">Events</span></a>
                 @if (_continuousSupported)
                 {
                     <a class="tool-btn" href="timeline" title="Scrub recorded footage across all cameras">@UiIcon.Render("film", 14) <span class="tool-name">Timeline</span></a>
@@ -807,7 +806,7 @@
                         @AdminField("State directory (accounts/settings)", "ui.stateDir", "text")
                         @AdminToggle("Allow admin-password reset on login", "ui.resetAdminPassword")
                         <div class="control-row">
-                            <span>Two-way talk <span class="beta-tag">BETA</span></span>
+                            <span>Two-way talk</span>
                             <button class="chip @(AdminBool("ui.talk") ? "" : "chip-off")"
                                     @onclick=@(() => _adminEdits["ui.talk"] = (!AdminBool("ui.talk")).ToString().ToLowerInvariant())>
                                 @(AdminBool("ui.talk") ? "on" : "off")</button>
@@ -888,93 +887,6 @@
                     </div>
                 </div>
             }
-        </aside>
-    }
-
-    @if (_showEventsPanel)
-    {
-        <div class="backdrop panel-backdrop" @onclick="() => _showEventsPanel = false"></div>
-        <aside class="campanel events-panel" role="dialog" aria-label="Event history">
-            <div class="campanel-head events-head">
-                <span class="events-head-title">@UiIcon.Render("clock", 14) Events
-                    <span class="event-day-count">@PanelEvents.Count()</span>
-                </span>
-                <span class="events-head-sub">@(_eventsDate is { } d0 ? d0.ToString("ddd, d MMM yyyy") : "last 24 hours")</span>
-                <span class="tile-spacer"></span>
-                <select class="event-filter" @bind="_eventCameraFilter" title="Filter by camera">
-                    <option value="">all cameras</option>
-                    @foreach (var c in _cameras)
-                    {
-                        <option value="@c.Name">@c.Name</option>
-                    }
-                </select>
-                <button class="chip @(_eventsUnreviewedOnly ? "chip-active" : "chip-off")" title="Only show unreviewed events"
-                        @onclick="() => _eventsUnreviewedOnly = !_eventsUnreviewedOnly">unreviewed</button>
-                <input class="event-filter event-date-input" type="date" title="Jump to a specific day"
-                       max="@DateTime.Today.ToString("yyyy-MM-dd")"
-                       value="@(_eventsDate?.ToString("yyyy-MM-dd") ?? "")"
-                       @onchange="e => SetEventsDateAsync((string?)e.Value)" />
-                @if (_eventsDate != null)
-                {
-                    <button class="chip" title="Back to the rolling last 24 hours"
-                            @onclick="() => SetEventsDateAsync(null)">↺ 24h</button>
-                }
-                <button class="icon-btn" title="Close" @onclick="() => _showEventsPanel = false">✕</button>
-            </div>
-
-            <div class="events-panel-scroll">
-                @if (_eventsDateLoading)
-                {
-                    <div class="notice">Loading @(_eventsDate?.ToString("d MMM"))…</div>
-                }
-                else if (!PanelEvents.Any())
-                {
-                    <div class="notice">
-                        @(_eventsUnreviewedOnly ? "Nothing awaiting review — all clear."
-                            : _eventsDate != null ? "No events on this day."
-                            : "No events in the last 24 hours.")
-                    </div>
-                }
-                @foreach (var day in PanelEvents.GroupBy(e => e.Start.ToLocalTime().Date))
-                {
-                    <div class="campanel-section events-day">
-                        <div class="campanel-section-title events-day-head">
-                            @DayLabel(day.Key) <span class="event-day-count">@day.Count()</span>
-                        </div>
-                        @foreach (var ev in day)
-                        {
-                            <div class="event-row @(ev.Reviewed ? "reviewed" : "")" @key="ev.Id"
-                                 title="Click to play" @onclick="() => OpenEvent(ev)">
-                                <div class="event-row-thumb">
-                                    @if (ev.HasThumb)
-                                    {
-                                        <img src="@EventArtifactUrl(ev, "thumb")" loading="lazy" alt="" />
-                                    }
-                                    else
-                                    {
-                                        <span class="event-thumb-icon">@ev.Icon</span>
-                                    }
-                                    <span class="event-row-dur">@DurationText(ev)</span>
-                                    @if (ev.Ongoing)
-                                    {
-                                        <span class="event-live">● REC</span>
-                                    }
-                                </div>
-                                <div class="event-row-main">
-                                    <span class="event-title">@ev.Icon @ev.Title</span>
-                                    <span class="event-sub">@ev.Camera · @ev.Start.ToLocalTime().ToString("HH:mm:ss")</span>
-                                </div>
-                                @if (!ev.Reviewed)
-                                {
-                                    <span class="event-new-dot" title="Unreviewed"></span>
-                                    <button class="icon-btn" title="Dismiss (mark reviewed)"
-                                            @onclick="() => DismissAsync(ev)" @onclick:stopPropagation="true">✕</button>
-                                }
-                            </div>
-                        }
-                    </div>
-                }
-            </div>
         </aside>
     }
 
@@ -1115,9 +1027,6 @@
     private string? _adminStatus;
     private bool _confirmRestart;
     private readonly Dictionary<string, string> _adminEdits = new();
-    private bool _showEventsPanel;
-    private string _eventCameraFilter = "";
-    private bool _eventsUnreviewedOnly;
     private ApiEvent? _playEvent;
 
     // Web-UI authentication (enabled once the first account exists server-side)
@@ -1154,11 +1063,6 @@
     private int _stripHeight = 160;
     private bool _secWarnDismissed;
     private DotNetObjectReference<Home>? _selfRef;
-
-    // Events panel: rolling last-24h by default, or one server-fetched calendar day
-    private DateTime? _eventsDate;
-    private List<ApiEvent> _eventsForDate = new();
-    private bool _eventsDateLoading;
 
     protected override void OnInitialized() => EnsureSlots();
 
@@ -2051,59 +1955,6 @@
 
     // ------------------------------------------------------------ recorded events
 
-    /// <summary>
-    /// What the events panel shows: the rolling last 24 hours (from the regular
-    /// poll) or, when a date is picked, that server-fetched calendar day.
-    /// </summary>
-    private IEnumerable<ApiEvent> PanelEvents
-    {
-        get
-        {
-            var source = _eventsDate == null
-                ? _events.Where(e => e.Start >= DateTime.UtcNow.AddHours(-24))
-                : _eventsForDate.AsEnumerable();
-            return source
-                .Where(e => _eventCameraFilter.Length == 0 || e.Camera == _eventCameraFilter)
-                .Where(e => !_eventsUnreviewedOnly || !e.Reviewed)
-                .OrderByDescending(e => e.Start);
-        }
-    }
-
-    /// <summary>Blank/invalid input returns to the rolling 24-hour view.</summary>
-    private async Task SetEventsDateAsync(string? raw)
-    {
-        if (string.IsNullOrWhiteSpace(raw) || !DateTime.TryParse(raw, out var day))
-        {
-            _eventsDate = null;
-            _eventsForDate = new List<ApiEvent>();
-            return;
-        }
-        _eventsDate = day.Date;
-        await LoadEventsForDateAsync();
-    }
-
-    private async Task LoadEventsForDateAsync()
-    {
-        if (_eventsDate is not { } day) return;
-        _eventsDateLoading = true;
-        try
-        {
-            using var res = await Http.SendAsync(ApiRequest(HttpMethod.Get,
-                $"/api/events?limit=1000&date={day:yyyy-MM-dd}"));
-            _eventsForDate = res.IsSuccessStatusCode
-                ? await res.Content.ReadFromJsonAsync<List<ApiEvent>>() ?? new List<ApiEvent>()
-                : new List<ApiEvent>();
-        }
-        catch
-        {
-            _eventsForDate = new List<ApiEvent>();
-        }
-        finally
-        {
-            _eventsDateLoading = false;
-        }
-    }
-
     private string EventArtifactUrl(ApiEvent ev, string kind) =>
         $"{_server.TrimEnd('/')}/api/events/{Uri.EscapeDataString(ev.Id)}/{kind}{TokenQuery('?')}";
 
@@ -2225,8 +2076,6 @@
         if (!await PostEventReviewAsync(ev, reviewed: true)) return;
         int i = _events.FindIndex(e => e.Id == ev.Id);
         if (i >= 0) _events[i] = _events[i] with { Reviewed = true };
-        int j = _eventsForDate.FindIndex(e => e.Id == ev.Id);
-        if (j >= 0) _eventsForDate[j] = _eventsForDate[j] with { Reviewed = true };
         if (_playEvent?.Id == ev.Id) _playEvent = _playEvent with { Reviewed = true };
     }
 
@@ -2280,11 +2129,6 @@
             : span.TotalHours < 24 ? $"{(int)span.TotalHours}h ago"
             : $"{(int)span.TotalDays}d ago";
     }
-
-    private static string DayLabel(DateTime day) =>
-        day == DateTime.Now.Date ? "TODAY"
-        : day == DateTime.Now.Date.AddDays(-1) ? "YESTERDAY"
-        : day.ToString("dddd, d MMMM").ToUpperInvariant();
 
     private static string DurationText(ApiEvent ev) =>
         ev.Ongoing ? "recording…"

--- a/src/Neolink.WebClient/Components/Pages/Timeline.razor
+++ b/src/Neolink.WebClient/Components/Pages/Timeline.razor
@@ -13,57 +13,114 @@
 
 <div class="tl-page">
     <div class="toolbar tl-toolbar">
-        <a class="tool-btn" href="" title="Back to live view">‹ Live</a>
+        <a class="tool-btn" href="" title="Back to live view">@UiIcon.Render("chev-left", 16) <span class="tool-name">Live</span></a>
         <span class="tool-label">TIMELINE</span>
-        @* Day navigation uses thin chevrons; the transport cluster below uses a solid
-           accent pill and filled glyphs, so the two can't be mistaken for each other. *@
-        <button class="tool-btn tl-daynav" title="Previous day" @onclick="() => ChangeDayAsync(-1)">@UiIcon.Render("chev-left", 16)</button>
-        <span class="tl-date">@_date.ToString("ddd, d MMMM yyyy")</span>
-        <button class="tool-btn tl-daynav" title="Next day" disabled="@(_date >= DateTime.Today)"
-                @onclick="() => ChangeDayAsync(1)">@UiIcon.Render("chev-right", 16)</button>
-        <span class="tool-sep"></span>
-        @* Precision transport: event hops, coarse and fine steps around play/pause.
-           Every control names its keyboard twin — the fastest way to learn them. *@
-        <button class="tool-btn tl-step" title="Previous event   —   [" @onclick="() => JumpEventAsync(-1)">@UiIcon.Render("skip-back", 13)</button>
-        <button class="tool-btn tl-step" title="Back 10 seconds   —   J or Shift+←" @onclick="() => StepAsync(-10)">−10s</button>
-        <button class="tool-btn tl-step" title="Back 1 second   —   ←   (Ctrl+← or , for 0.1 s)" @onclick="() => StepAsync(-1)">−1s</button>
-        <button class="tl-play @(_playing ? "playing" : "")"
-                title="@(_playing ? "Pause — Space or K" : "Play — Space or K")" @onclick="TogglePlayAsync">
-            @UiIcon.Render(_playing ? "pause" : "play", 14) <span class="tool-name">@(_playing ? "Pause" : "Play")</span>
-        </button>
-        <button class="tool-btn tl-step" title="Forward 1 second   —   →   (Ctrl+→ or . for 0.1 s)" @onclick="() => StepAsync(1)">+1s</button>
-        <button class="tool-btn tl-step" title="Forward 10 seconds   —   L or Shift+→" @onclick="() => StepAsync(10)">+10s</button>
-        <button class="tool-btn tl-step" title="Next event   —   ]" @onclick="() => JumpEventAsync(1)">@UiIcon.Render("skip-fwd", 13)</button>
-        @* Slow motion through fast skim; the choice sticks (localStorage). *@
-        @foreach (var s in SpeedOptions)
-        {
-            var sp = s;
-            <button class="chip tl-speed @(_speed == sp ? "chip-active" : "")"
-                    title="Play at @SpeedLabel(sp) speed (beta)" @onclick="() => SetSpeedAsync(sp)">@SpeedLabel(sp)</button>
-        }
-        <span class="beta-tag" title="Fast playback is new — expect rough edges and report anything odd">BETA</span>
+
+        @* --- Date group: prev/next day flanking a calendar-dropdown button. --- *@
+        <div class="tl-group tl-date-group">
+            <button class="tool-btn tl-daynav" title="Previous day" @onclick="() => ChangeDayAsync(-1)">@UiIcon.Render("chev-left", 16)</button>
+            <button class="tool-btn tl-date-btn @(_showCalendar ? "active" : "")"
+                    title="Pick a day — days with footage are highlighted"
+                    @onclick="ToggleCalendarAsync">
+                @UiIcon.Render("calendar", 13) <span class="tl-date-text">@_date.ToString("ddd, d MMM yyyy")</span> @UiIcon.Render("chev-down", 12)
+            </button>
+            <button class="tool-btn tl-daynav" title="Next day" disabled="@(_date >= DateTime.Today)"
+                    @onclick="() => ChangeDayAsync(1)">@UiIcon.Render("chev-right", 16)</button>
+        </div>
+
+        @* --- Transport group: event hops + coarse/fine steps around play/pause.
+           Every control names its keyboard twin — the fastest way to learn them. --- *@
+        <div class="tl-group tl-transport">
+            <button class="tool-btn tl-step" title="Previous event   —   [" @onclick="() => JumpEventAsync(-1)">@UiIcon.Render("skip-back", 13)</button>
+            <button class="tool-btn tl-step" title="Back 10 seconds   —   J or Shift+←" @onclick="() => StepAsync(-10)">−10s</button>
+            <button class="tool-btn tl-step" title="Back 1 second   —   ←   (Ctrl+← or , for 0.1 s)" @onclick="() => StepAsync(-1)">−1s</button>
+            <button class="tl-play @(_playing ? "playing" : "")"
+                    title="@(_playing ? "Pause — Space or K" : "Play — Space or K")" @onclick="TogglePlayAsync">
+                @UiIcon.Render(_playing ? "pause" : "play", 14) <span class="tool-name">@(_playing ? "Pause" : "Play")</span>
+            </button>
+            <button class="tool-btn tl-step" title="Forward 1 second   —   →   (Ctrl+→ or . for 0.1 s)" @onclick="() => StepAsync(1)">+1s</button>
+            <button class="tool-btn tl-step" title="Forward 10 seconds   —   L or Shift+→" @onclick="() => StepAsync(10)">+10s</button>
+            <button class="tool-btn tl-step" title="Next event   —   ]" @onclick="() => JumpEventAsync(1)">@UiIcon.Render("skip-fwd", 13)</button>
+        </div>
+
+        @* --- Speed group: slow motion through fast skim; the choice sticks. --- *@
+        <div class="tl-group tl-speed-group">
+            @foreach (var s in SpeedOptions)
+            {
+                var sp = s;
+                <button class="chip tl-speed @(_speed == sp ? "chip-active" : "")"
+                        title="Play at @SpeedLabel(sp) speed" @onclick="() => SetSpeedAsync(sp)">@SpeedLabel(sp)</button>
+            }
+        </div>
+
         @if (Lagging)
         {
             <span class="tl-lag" title="The streams can't sustain @SpeedLabel(_speed) right now (server delivery or browser decoding is the limit) — the timeline slows down until they catch up">
                 ⏳ catching up…
             </span>
         }
-        <button class="tool-btn tl-keys-btn @(_showKeys ? "active" : "")" title="Keyboard shortcuts"
-                @onclick="() => _showKeys = !_showKeys">?</button>
-        <button class="chip tl-zoom-chip @(Zoomed ? "chip-active" : "chip-off")"
-                title="@(Zoomed ? "Zoomed in — click (or press 0) to see the whole day again" : "Scroll or pinch on the timeline to zoom in for fine seeking")"
-                @onclick="ResetZoomAsync">@UiIcon.Render("zoom", 12) @SpanLabel(_viewSpan)</button>
-        @if (_editClock)
-        {
-            <input id="tl-clock-edit" class="tl-clock-edit" value="@TimeText(_t)" spellcheck="false"
-                   placeholder="HH:mm:ss" @onchange="ClockEditedAsync" @onblur="() => _editClock = false" />
-        }
-        else
-        {
-            <span class="tl-clock tl-clock-btn" role="button" title="Click (or press T) to type an exact time"
-                  @onclick="OpenClockEdit">@TimeText(_t)</span>
-        }
+
+        <span class="tool-spacer"></span>
+
+        @* --- View group: clock, zoom, keyboard help. --- *@
+        <div class="tl-group tl-view-group">
+            @if (_editClock)
+            {
+                <input id="tl-clock-edit" class="tl-clock-edit" value="@TimeText(_t)" spellcheck="false"
+                       placeholder="HH:mm:ss" @onchange="ClockEditedAsync" @onblur="() => _editClock = false" />
+            }
+            else
+            {
+                <span class="tl-clock tl-clock-btn" role="button" title="Click (or press T) to type an exact time"
+                      @onclick="OpenClockEdit">@TimeText(_t)</span>
+            }
+            <button class="chip tl-zoom-chip @(Zoomed ? "chip-active" : "chip-off")"
+                    title="@(Zoomed ? "Zoomed in — click (or press 0) to see the whole day again" : "Scroll or pinch on the timeline to zoom in for fine seeking")"
+                    @onclick="ResetZoomAsync">@UiIcon.Render("zoom", 12) @SpanLabel(_viewSpan)</button>
+            <button class="tool-btn tl-keys-btn @(_showKeys ? "active" : "")" title="Keyboard shortcuts"
+                    @onclick="() => _showKeys = !_showKeys">?</button>
+        </div>
     </div>
+
+    @if (_showCalendar)
+    {
+        <div class="tl-cal-backdrop" @onclick="() => _showCalendar = false"></div>
+        <div class="tl-cal" @onclick:stopPropagation="true">
+            <div class="tl-cal-head">
+                <button class="tool-btn tl-daynav" title="Previous month" @onclick="() => ShiftMonth(-1)">@UiIcon.Render("chev-left", 15)</button>
+                <span class="tl-cal-month">@_calMonth.ToString("MMMM yyyy")</span>
+                <button class="tool-btn tl-daynav" title="Next month"
+                        disabled="@(_calMonth >= new DateTime(DateTime.Today.Year, DateTime.Today.Month, 1))"
+                        @onclick="() => ShiftMonth(1)">@UiIcon.Render("chev-right", 15)</button>
+            </div>
+            <div class="tl-cal-grid">
+                @foreach (var d in new[] { "Mo", "Tu", "We", "Th", "Fr", "Sa", "Su" })
+                {
+                    <span class="tl-cal-dow">@d</span>
+                }
+                @foreach (var cell in CalendarCells())
+                {
+                    @if (cell is { } day)
+                    {
+                        bool hasFootage = _contentDays.Contains(day);
+                        bool isFuture = day > DateTime.Today;
+                        <button class="tl-cal-day @(day == _date ? "sel" : "") @(hasFootage ? "has" : "") @(day == DateTime.Today ? "today" : "")"
+                                disabled="@isFuture"
+                                title="@(hasFootage ? "Footage on this day" : isFuture ? "" : "No footage")"
+                                @onclick="() => PickDayAsync(day)">@day.Day</button>
+                    }
+                    else
+                    {
+                        <span class="tl-cal-day empty"></span>
+                    }
+                }
+            </div>
+            <div class="tl-cal-foot">
+                <span class="tl-cal-legend"><span class="tl-cal-dot"></span> has footage</span>
+                <button class="chip" @onclick="() => PickDayAsync(DateTime.Today)">Today</button>
+            </div>
+        </div>
+    }
 
     @if (_showKeys)
     {
@@ -245,6 +302,11 @@
     private DateTime _lastTick;
     private bool _scrubInit;
     private bool _booted;
+
+    // Calendar date-picker: days that hold footage are highlighted at a glance.
+    private bool _showCalendar;
+    private DateTime _calMonth = new(DateTime.Today.Year, DateTime.Today.Month, 1);
+    private readonly HashSet<DateTime> _contentDays = new();
 
     /// <summary>One recording segment: seconds-of-day start, span and playback URL.</summary>
     private sealed record Seg(double Start, double Span, string Url);
@@ -888,6 +950,56 @@
         if (next > DateTime.Today) return;
         _date = next;
         await LoadDayAsync();
+    }
+
+    // ------------------------------------------------------------ calendar picker
+
+    /// <summary>Loads the set of days that hold footage (once) and opens the calendar on the current month.</summary>
+    private async Task ToggleCalendarAsync()
+    {
+        if (_showCalendar) { _showCalendar = false; return; }
+        _calMonth = new DateTime(_date.Year, _date.Month, 1);
+        await LoadContentDaysAsync();
+        _showCalendar = true;
+    }
+
+    private async Task LoadContentDaysAsync()
+    {
+        try
+        {
+            var days = await GetJsonAsync<List<string>>("/api/events/days");
+            _contentDays.Clear();
+            if (days != null)
+                foreach (var s in days)
+                    if (DateTime.TryParseExact(s, "yyyy-MM-dd", null,
+                            System.Globalization.DateTimeStyles.None, out var d))
+                        _contentDays.Add(d.Date);
+        }
+        catch { /* highlighting is a nicety; the picker still works without it */ }
+    }
+
+    private void ShiftMonth(int months)
+    {
+        var next = _calMonth.AddMonths(months);
+        var thisMonth = new DateTime(DateTime.Today.Year, DateTime.Today.Month, 1);
+        _calMonth = next > thisMonth ? thisMonth : next;
+    }
+
+    private async Task PickDayAsync(DateTime day)
+    {
+        _showCalendar = false;
+        if (day > DateTime.Today || day.Date == _date) return;
+        _date = day.Date;
+        await LoadDayAsync();
+    }
+
+    /// <summary>Month grid, Monday-first: leading blanks (null) then each day of the month.</summary>
+    private IEnumerable<DateTime?> CalendarCells()
+    {
+        int lead = ((int)_calMonth.DayOfWeek + 6) % 7; // Mon=0 … Sun=6
+        for (int i = 0; i < lead; i++) yield return null;
+        int days = DateTime.DaysInMonth(_calMonth.Year, _calMonth.Month);
+        for (int d = 1; d <= days; d++) yield return new DateTime(_calMonth.Year, _calMonth.Month, d);
     }
 
     private async Task ToggleCameraAsync(string name)

--- a/src/Neolink.WebClient/Models.cs
+++ b/src/Neolink.WebClient/Models.cs
@@ -210,6 +210,8 @@ public static class UiIcon
             "pause" => "<rect x=\"5\" y=\"4\" width=\"5\" height=\"16\" rx=\"1\" fill=\"currentColor\"/><rect x=\"14\" y=\"4\" width=\"5\" height=\"16\" rx=\"1\" fill=\"currentColor\"/>",
             "chev-left" => "<polyline points=\"15 18 9 12 15 6\"/>",
             "chev-right" => "<polyline points=\"9 18 15 12 9 6\"/>",
+            "chev-down" => "<polyline points=\"6 9 12 15 18 9\"/>",
+            "calendar" => "<rect x=\"3\" y=\"4\" width=\"18\" height=\"18\" rx=\"2\"/><line x1=\"16\" y1=\"2\" x2=\"16\" y2=\"6\"/><line x1=\"8\" y1=\"2\" x2=\"8\" y2=\"6\"/><line x1=\"3\" y1=\"10\" x2=\"21\" y2=\"10\"/>",
             "skip-back" => "<polygon points=\"19 20 9 12 19 4 19 20\" fill=\"currentColor\"/><line x1=\"5\" y1=\"19\" x2=\"5\" y2=\"5\"/>",
             "skip-fwd" => "<polygon points=\"5 4 15 12 5 20 5 4\" fill=\"currentColor\"/><line x1=\"19\" y1=\"5\" x2=\"19\" y2=\"19\"/>",
             "zoom" => "<circle cx=\"11\" cy=\"11\" r=\"7\"/><line x1=\"21\" y1=\"21\" x2=\"16\" y2=\"16\"/>",

--- a/src/Neolink.WebClient/wwwroot/css/app.css
+++ b/src/Neolink.WebClient/wwwroot/css/app.css
@@ -907,21 +907,6 @@ video[data-live="1"] ~ .tile-status { display: none; }
 body.is-fullscreen .fs-enter { display: none; }
 body.is-fullscreen .fs-exit { display: inline-flex; }
 
-/* Small pill marking a feature as beta (settings toggles) */
-.beta-tag {
-    display: inline-block;
-    margin-left: 6px;
-    padding: 1px 6px;
-    font-size: 9px;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    border-radius: 999px;
-    color: var(--accent);
-    border: 1px solid color-mix(in srgb, var(--accent) 55%, transparent);
-    background: var(--accent-soft);
-    vertical-align: 1px;
-}
-
 /* Two-way talk mic: pulses red while the mic is live, dimmed while connecting */
 .talk-btn.talk-live {
     color: #fff;
@@ -1923,6 +1908,138 @@ body.is-fullscreen .fs-exit { display: inline-flex; }
     outline: none;
 }
 
+/* ---------- dedicated Events page (/events) ---------- */
+/* Master–detail: a scrollable recent-events list beside the selected clip.
+   Deep-linkable (/events/{camera}) so a phone push notification lands here. */
+.ev-page {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    height: 100dvh;
+    background: var(--bg);
+}
+
+.ev-toolbar { flex: 0 0 auto; }
+
+/* Events ⇄ Live segmented toggle in the toolbar */
+.ev-switch {
+    display: inline-flex;
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    overflow: hidden;
+    background: var(--panel-2);
+}
+.ev-switch-opt {
+    padding: 4px 14px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--muted);
+    text-decoration: none;
+    cursor: pointer;
+}
+.ev-switch-opt.active { background: var(--accent); color: #fff; }
+.ev-switch-opt:not(.active):hover { color: var(--fg); }
+
+.ev-body {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    gap: 14px;
+    padding: 14px;
+}
+
+/* The list: fixed-width column on desktop, full width on phones */
+.ev-list {
+    flex: 0 0 400px;
+    min-width: 0;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding-right: 4px;
+}
+
+.ev-day { margin-bottom: 6px; }
+.ev-day-head {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--bg);
+    padding: 8px 4px 4px;
+    font-size: 10px;
+    letter-spacing: 1.5px;
+    color: var(--muted);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.ev-list .event-row.selected {
+    background: var(--accent-soft);
+    outline: 1px solid color-mix(in srgb, var(--accent) 45%, transparent);
+}
+.ev-row-live { flex: 0 0 auto; color: var(--muted); }
+.ev-row-live:hover { color: var(--accent); }
+
+/* The detail pane: the selected event's clip + transport */
+.ev-detail {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 12px;
+    overflow: hidden;
+}
+
+.ev-detail .event-player-media { flex: 1; min-height: 0; }
+.ev-detail #ev-video {
+    display: block;
+    width: 100%;
+    height: 100%;
+    max-height: calc(100vh - 220px);
+    object-fit: contain;
+    background: #000;
+    outline: none;
+}
+
+.ev-back { display: none; } /* only shown when the list is hidden (phones) */
+.ev-golive { flex: 0 0 auto; align-self: center; white-space: nowrap; }
+
+.ev-detail-empty {
+    margin: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    color: var(--muted);
+    font-size: 13px;
+}
+.ev-detail-empty-icon { opacity: 0.5; }
+
+/* Phones: single column. The list fills the screen; picking an event slides the
+   detail over it (the ‹ back button returns to the list). */
+@media (max-width: 760px) {
+    .ev-body { padding: 8px; gap: 0; }
+    .ev-list { flex: 1 1 auto; padding-right: 0; }
+    .ev-list .event-row-thumb { width: 108px; }
+    .ev-list .ev-row-live { display: none; } /* the detail's Go-live is enough */
+    .ev-detail { display: none; }             /* hidden until an event is picked */
+
+    .ev-page.has-selection .ev-list { display: none; }
+    .ev-page.has-selection .ev-detail {
+        display: flex;
+        border: none;
+        border-radius: 0;
+        padding: 8px;
+    }
+    .ev-detail .ev-back { display: inline-flex; }
+    .ev-detail #ev-video { max-height: calc(100dvh - 200px); }
+}
+
 /* Quick view: temporary pop-up live player (sidebar ⛶) — the layout underneath
    is untouched; closing it simply returns to whatever was on screen. */
 .quick-view {
@@ -2032,13 +2149,119 @@ body.is-fullscreen .fs-exit { display: inline-flex; }
     overflow: hidden;
 }
 
-.tl-toolbar { flex: 0 0 auto; }
-.tl-date { font-size: 13px; font-weight: 600; min-width: 150px; text-align: center; }
+.tl-toolbar { flex: 0 0 auto; gap: 8px; }
+
+/* Related controls cluster inside a subtle pill so the toolbar reads as a few
+   groups (date · transport · speed · view) instead of one long button run. */
+.tl-group {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    padding: 2px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--panel-2) 60%, transparent);
+    border: 1px solid color-mix(in srgb, var(--line) 60%, transparent);
+}
+.tl-group .tool-btn, .tl-group .chip { border: none; }
+
+/* Pushes the view group (clock/zoom/help) to the right edge */
+.tool-spacer { flex: 1 1 auto; }
+
+/* The calendar-dropdown date button: the day, flanked by prev/next chevrons */
+.tl-date-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    font-weight: 600;
+    padding: 5px 10px;
+}
+.tl-date-btn .tl-date-text { font-variant-numeric: tabular-nums; }
+.tl-date-btn.active { color: var(--accent); background: var(--accent-soft); }
 
 /* Day-selector chevrons stay quiet so the transport control can stand out */
 .tl-daynav { color: var(--muted); }
 .tl-daynav:hover:not(:disabled) { color: var(--text); }
 .tl-daynav:disabled { opacity: 0.35; cursor: default; }
+
+/* ---- calendar popover: pick a day, footage days highlighted ---- */
+.tl-cal-backdrop { position: fixed; inset: 0; z-index: 60; }
+.tl-cal {
+    position: absolute;
+    top: 46px;
+    left: 12px;
+    z-index: 61;
+    width: 272px;
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    box-shadow: 0 18px 50px rgba(0, 0, 0, 0.55);
+    padding: 10px;
+    animation: talk-overlay-in 0.14s ease;
+}
+.tl-cal-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+}
+.tl-cal-month { font-size: 13px; font-weight: 700; }
+.tl-cal-grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 2px;
+}
+.tl-cal-dow {
+    font-size: 10px;
+    font-weight: 700;
+    color: var(--muted);
+    text-align: center;
+    padding-bottom: 4px;
+}
+.tl-cal-day {
+    position: relative;
+    aspect-ratio: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: none;
+    color: var(--text);
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    border-radius: 8px;
+    cursor: pointer;
+}
+.tl-cal-day.empty { cursor: default; }
+.tl-cal-day:disabled { color: color-mix(in srgb, var(--muted) 45%, transparent); cursor: default; }
+.tl-cal-day:not(:disabled):hover { background: var(--accent-soft); }
+/* A dot under the number marks days that hold footage — visible at a glance */
+.tl-cal-day.has::after {
+    content: "";
+    position: absolute;
+    bottom: 3px;
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background: var(--accent);
+}
+.tl-cal-day.today { outline: 1px solid color-mix(in srgb, var(--muted) 55%, transparent); }
+.tl-cal-day.sel {
+    background: var(--accent);
+    color: #0a1424;
+    font-weight: 700;
+}
+.tl-cal-day.sel.has::after { background: #0a1424; }
+.tl-cal-foot {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid var(--line);
+}
+.tl-cal-legend { display: inline-flex; align-items: center; gap: 6px; font-size: 11px; color: var(--muted); }
+.tl-cal-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--accent); }
 
 /* The play/pause transport: a solid accent pill with a filled glyph — nothing
    like the thin date chevrons, so the two can't be confused again. */
@@ -2068,7 +2291,6 @@ body.is-fullscreen .fs-exit { display: inline-flex; }
 }
 
 .tl-clock {
-    margin-left: auto;
     font-size: 15px;
     font-weight: 700;
     font-variant-numeric: tabular-nums;
@@ -2080,7 +2302,6 @@ body.is-fullscreen .fs-exit { display: inline-flex; }
 
 /* The clock swapped for direct input: type 16:39:12, Enter, you're there. */
 .tl-clock-edit {
-    margin-left: auto;
     width: 108px;
     background: var(--bg);
     border: 1px solid var(--accent);

--- a/src/Neolink.WebClient/wwwroot/js/neolink.js
+++ b/src/Neolink.WebClient/wwwroot/js/neolink.js
@@ -2,6 +2,15 @@
 (function () {
     'use strict';
 
+    // Has anyone actually touched this page yet? A clip that auto-opens from a
+    // deep link on a FULL page load (notification tap) starts muted — nobody
+    // asked for audio, and unmuted autoplay is usually blocked anyway. Any real
+    // interaction before playback (clicking an event row) keeps sound on.
+    let userGestureSeen = false;
+    for (const evt of ['pointerdown', 'keydown', 'touchstart'])
+        window.addEventListener(evt, () => { userGestureSeen = true; },
+            { once: true, capture: true, passive: true });
+
     // Latency tuning: like VLC, keep a jitter buffer between the live edge and the
     // playhead. Cameras deliver video anywhere from per-frame to whole multi-second
     // GOP batches, so the cushion adapts to the observed delivery cadence: it must
@@ -492,7 +501,12 @@
                     v.removeEventListener('loadedmetadata', onMeta);
                     try { if (at > 0 && at < v.duration) v.currentTime = at; } catch { }
                     v.defaultPlaybackRate = v.playbackRate = rate;
-                    v.play().catch(() => { });
+                    // Fresh full-page load (notification deep link): start muted
+                    // by design. Otherwise autoplay policy can still veto sound —
+                    // retry muted so the clip starts either way; the user can
+                    // unmute on the controls.
+                    if (!userGestureSeen) v.muted = true;
+                    v.play().catch(() => { v.muted = true; v.play().catch(() => { }); });
                 };
                 v.addEventListener('loadedmetadata', onMeta);
                 try { v.load(); } catch { }


### PR DESCRIPTION
## What's in here

The 0.8.5 feature set: a dedicated Events page built for the phone-notification flow, deep links down to the exact clip, and a Home Assistant sensor that makes those links generatable from an automation.

### Dedicated `/events` page
- Master-detail: recent-events list (thumbnails, camera, time; filters for camera / day / unreviewed) beside the player on desktop, stacked on phones.
- Events ⇄ Live segmented toggle plus per-event **Go live** jumps to the camera feed.
- Reviewed-on-close semantics, Older/Newer navigation, playback speed chips.
- Replaces the old pop-up events panel on the live view (the ambient event strip stays).

### Deep links
- `/events/{camera}` — filters to the camera and opens its newest event; a quiet last-24h falls back to the camera's most recent stored event, so the link always lands on footage.
- `/events?event={id}` — opens one exact clip, even older than the recent list (the page pivots to its day). Backed by a new `GET /api/events/{id}` lookup.
- Clips that auto-open on a fresh page load start **muted** — no surprise audio, no autoplay-blocked freeze. A real user click keeps sound on.

### Home Assistant "Last event" sensor
- Each camera that records events gets an MQTT `sensor.<cam>_last_event` whose state is the newest event's id, published **retained the instant the event starts** — same moment as the motion trigger — with labels/start time as attributes.
- A notification automation can point its tap action at `…/events?event={{ states('sensor.<cam>_last_event') }}` for one-tap alert-to-clip (README has the full recipe), or trigger on the sensor itself.

### Timeline & misc
- Date button now drops down a month calendar with footage days highlighted (new `GET /api/events/days`); toolbar grouped into labelled clusters.
- Update checker: suffixed builds (e.g. `0.8.5-events-test`) compare by numeric prefix instead of falling back to 0.0 (which made every release look like an update).
- Beta tags retired (two-way talk, fast playback, scheduled capture); version bumped to 0.8.5.

## Verification
- Selftest: **31 passed, 0 failed** on a clean `-warnaserror` Release build; new assertions for the update-checker suffix fix and a staged-event round-trip through `/api/events/{id}` (list, lookup, 404).
- Live-verified in the browser: `?event={id}` cold navigation (day pivot + muted autoplay), `/events/{camera}` fallback past an empty 24h window, unmuted playback after a real click.
- MQTT verified against a live broker: discovery configs announced per camera, and triggering an event published `neolink/driveway/last_event = Driveway~…` (retained) plus attributes at event start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)