### PR TITLE
Add-on manifest: 0.8.5 (release prerequisite)

### DIFF
--- a/neolink-addon/config.yaml
+++ b/neolink-addon/config.yaml
@@ -4,7 +4,7 @@
 # pulls ghcr.io/borexola/neolink.net-addon-{arch}:<version>, which the docker
 # workflow publishes on every tag. Version here ≠ tag ⇒ users see no update.
 name: Neolink.NET
-version: "0.8.4"
+version: "0.8.5"
 slug: neolink
 description: >-
   Reolink camera bridge — live RTSP restreaming, a full web UI with recording


### PR DESCRIPTION
One line that missed the #31 merge by a few minutes: `neolink-addon/config.yaml` must say `0.8.5` before the `v0.8.5` tag is cut — the HA Supervisor only offers the exact manifest version, so without this Docker users would get the release while add-on users see no update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)