### PR TITLE
Tiered storage: clips/archive tiers, capacity watch, archiving (BETA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,75 @@ Release notes for Neolink.NET. Releasing works by tagging `vX.Y.Z` — the docke
 workflow bakes the tag into the app as its version (see "Versioning & releases"
 in the README). Paste the matching section below into the GitHub release.
 
+## 0.8.7
+
+### New
+
+- **Tiered storage** — all optional, zero config changes required; a plain
+  `recording.path` install behaves exactly as before:
+  - **Fast clips tier** (`"clips_path"`): point it at an SSD and new event
+    clips are written there for fast review, while continuous 24/7 footage
+    stays on the main volume. Existing footage is found on both.
+  - **Archive tier** (`"archive_path"`, BETA): with it configured, every camera's
+    RECORDING settings gain **Archive event clips** and **Archive continuous
+    footage** switches (both off by default). Retention stays the single
+    clock: when an enabled type's retention expires, its footage is **moved**
+    to the archive instead of deleted — e.g. "Keep event clips: 30" moves
+    clips to the archive on day 30. One per-camera knob sets how long the
+    archive keeps footage (blank = forever). Events, the timeline and
+    continuous playback read archived footage transparently. Deletion from
+    the archive keeps honoring the configured window even if archiving is
+    later switched off. Use a separate drive for the archive — in Docker,
+    map a second volume (e.g. `-v /mnt/bigdisk:/archive`), and map a volume
+    for EVERY tier path you configure: an unmapped container path is created
+    in the container's writable layer, where footage survives restarts but
+    is destroyed with the container. On the Home Assistant add-on, point the
+    paths at a NAS share under `/share` or `/media` instead — no mapping
+    needed.
+  - **Capacity watch**: at 90% used on any configured location the web UI
+    shows an amber warning banner (dismissible for the session); when a
+    location runs out of space, recording to it halts cleanly with a red
+    banner (no partial files, one log line per transition) and resumes
+    automatically once space is freed. New `GET /api/storage` reports every
+    location; with split storage configured the Monitor page shows a live
+    STORAGE section with per-location free space and warn/full states.
+
+### Changed
+
+- **Event playback speed is now a sticky preference**: pick 2× (or any speed)
+  in the event player and every event you open afterwards — on the Events
+  page or in the live view's popup — starts at that speed. Persisted in the
+  browser, shared between both players; the timeline already remembered its
+  speed the same way.
+- **Camera settings panel redesign**: the dialog is now roomier
+  (~1080 px on desktop) with the section cards flowing into two columns,
+  each marked with a small icon; cards keep their grouping and collapse to
+  the familiar single column on tablets and phones. Archiving controls sit
+  under an ARCHIVE sub-heading flagged BETA.
+- **RECORDING card restructured around a footage-lifecycle strip**: the card
+  is grouped into EVENTS / CONTINUOUS (24/7) / ARCHIVE blocks, the archive's
+  purpose is explained up-front (before anything is switched on), and a live
+  FOOTAGE LIFECYCLE strip at the bottom traces each recording type through
+  colored stages — e.g. "30 days on this server → archive · forever" — built
+  from the settings as currently toggled, so flipping a switch shows exactly
+  what it changes.
+
+### Fixed
+
+- Disk-write failures can no longer take the service down. The clip writer's
+  final buffer flush runs on a raw thread — a volume that filled or vanished
+  mid-clip could crash the whole process there; it now logs and marks the
+  clip faulted instead. A dead clips volume no longer kills a detection
+  event either (the event still registers and reaches Home Assistant,
+  metadata-only), and settings/event-metadata persistence failures of any
+  kind log a warning instead of bubbling up.
+
+### Compatibility
+
+- Existing `settings.json` files without the new per-camera archive fields
+  load unchanged (archiving simply stays off), and servers without
+  `archive_path` reject attempts to enable archiving with a clear message.
+
 ## 0.8.6
 
 ### New

--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ The cameras are unmodified and no Reolink NVR is required.
 - **Battery cameras** (Argus etc.) are auto-detected: charge badge in the sidebar,
   sleep-friendly by default (the camera dozes while nobody watches), `always_on`
   per camera to hold it awake — see [Battery cameras](#battery-cameras-argus-etc)
+- **Tiered storage (optional)**: an SSD tier for fresh event clips and a cold
+  archive tier that expired footage **moves** to instead of being deleted
+  (per camera, per recording type, BETA) — with capacity watching: an amber
+  banner at 90% used, a red banner when a disk is full (recording halts
+  cleanly and auto-resumes), per-location storage cards on the Monitor page,
+  and a live "footage lifecycle" strip in each camera's recording settings —
+  see [Tiered storage](#tiered-storage-optional)
 - Everything persists in browser localStorage: server address, layout, tile
   assignments, window geometry
 - Adaptive jitter buffer that measures each stream's delivery cadence
@@ -392,6 +399,8 @@ config file (in Docker: the `/config` mount), so they survive restarts:
 | Option | Default | Description |
 |---|---|---|
 | `path` | *required* | Storage directory. In Docker, mount a volume here (e.g. `./recordings:/recordings`) |
+| `clips_path` | = `path` | Optional fast tier: new event clips are written here (point it at an SSD for snappy event playback); continuous footage stays on `path` |
+| `archive_path` | *unset* | Optional cold tier: enables per-camera archiving — aged footage is **moved** here instead of deleted. Use a different (bigger/slower) drive; in Docker, map a second volume (e.g. `-v /mnt/bigdisk:/archive`) |
 | `retention_days` | `7` | Events older than this are deleted (`0` = keep forever) |
 | `pre_seconds` | `5` | Video included from before the detection (pre-roll) |
 | `post_seconds` | `8` | Quiet time after the last detection before the event closes |
@@ -412,6 +421,43 @@ versions (events directly under the date folder, continuous under
 startup — directory renames, instant regardless of footage size. Set
 `"record": false` on a camera to start with events off (the UI switch can
 re-enable it).
+
+#### Tiered storage (optional)
+
+Everything works with the single `path` folder — the tiers below are strictly
+opt-in and existing setups keep behaving exactly as before:
+
+- **Fast clips tier** (`clips_path`): point it at an SSD and new event clips
+  land there for instant review scrubbing, while bulky 24/7 footage stays on
+  the big disk.
+- **Archive tier** (`archive_path`): once set, each camera's ⚙ → RECORDING
+  section gains **Archive event clips** and **Archive continuous footage**
+  switches. Retention stays the single clock: when footage reaches the end of
+  its retention window, an enabled type is **moved** to the archive instead of
+  deleted (e.g. "Keep event clips: 30" moves clips to the archive on day 30).
+  One extra knob sets how long the archive keeps footage (blank = forever).
+  The events list and the timeline read archived footage transparently. Use a
+  different drive for the archive — in Docker, map a second volume
+  (e.g. `-v /mnt/bigdisk:/archive` with `"archive_path": "/archive"`;
+  `docker-compose.yml` ships commented examples for both tiers). On the Home
+  Assistant add-on no extra mapping is needed: point `archive_path` at a
+  folder under `/share` or `/media` — NAS shares added in HA under
+  Settings → System → Storage appear there automatically.
+
+Capacity is watched for you: when any configured location climbs past **90%
+used**, the web UI shows an amber warning banner; if one actually runs out of
+space, recording to it halts cleanly (no partial files) with a **red** banner
+until space is freed — recording resumes automatically. When split storage is
+configured, the 📈 Monitor page grows a STORAGE section showing every
+location's free space live.
+
+> ⚠ **Docker: map a volume for every configured tier.** Missing directories
+> are created at startup so recording never blocks — but if a configured
+> container path has no volume behind it, that directory lands in the
+> container's writable layer: footage records fine yet lives inside the
+> container (gone on `docker rm`) and fills the Docker host's disk. If the
+> Monitor's STORAGE section shows a tier with the same capacity as the root
+> disk, that's the sign.
 
 ### Per camera
 
@@ -838,6 +884,14 @@ by channel, nonce-derived AES session keys, binary-mode switching via
   `mainStream`, use `stream: "subStream"` or close the app.
 - **Choppy browser video on Firefox for main streams**: that's H.265 — use the sub
   stream or a Chromium/Safari browser with hardware HEVC.
+- **Configured `clips_path`/`archive_path` but the folders look empty on the
+  host (Docker)**: recording never blocks on a missing directory — Neolink
+  creates it at startup. If no volume is mapped at that container path, the
+  directory is created **inside the container's writable layer**: footage
+  records fine but lives in the container (surviving restarts, destroyed by
+  `docker rm`) and eats the Docker host's disk. Map a volume for every
+  configured tier. The Monitor page's STORAGE section is the tell: tiers on
+  the container layer report the same total/free bytes as the root disk.
 
 ## Compared to the original Rust neolink
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,5 +20,12 @@ services:
       # Event recording storage: uncomment and set "recording": { "path": "/recordings" }
       # in config.json to capture detection events (clips + thumbnails) here.
       # - ./recordings:/recordings
+      # Optional tiered storage (see "Tiered storage" in the README):
+      # fast SSD tier for event clips — pair with "clips_path": "/clips"
+      # - /mnt/fast-ssd/neolink:/clips
+      # cold archive tier on a different (bigger/slower) drive — pair with
+      # "archive_path": "/archive"; expired footage moves here instead of
+      # being deleted once archiving is enabled per camera in the web UI
+      # - /mnt/bigdisk/neolink:/archive
     # For RTSP over UDP transport, prefer host networking instead of port maps:
     # network_mode: host

--- a/neolink-addon/DOCS.md
+++ b/neolink-addon/DOCS.md
@@ -42,6 +42,24 @@ well as in Neolink's own review strip and timeline. Retention, per-camera
 switches, event-type filters and capture schedules are managed in the web UI
 (camera ⚙ → RECORDING).
 
+### Tiered storage & archiving (BETA)
+
+Two optional extra locations can be added to the `recording` section of
+`config.json` (reachable via the Samba/SSH add-ons — plain JSON edits keep
+the add-on's config merging working):
+
+- `"clips_path"` — a fast tier where new event clips are written (24/7
+  footage stays on the main path).
+- `"archive_path"` — a cold tier that unlocks per-camera **Archive** switches
+  in the web UI (camera ⚙ → RECORDING): footage whose retention expires is
+  *moved* there instead of deleted, and stays playable in Events and the
+  timeline.
+
+Point either at a NAS share added under **Settings → System → Storage**
+(`/media/<name>` or `/share/<name>`) and restart the add-on. The Monitor
+page shows every configured location's free space, and the web UI warns at
+90% used / halts recording cleanly when a disk is actually full.
+
 ### Recording to a NAS
 
 Add the share in Home Assistant first: **Settings → System → Storage → Add

--- a/neolink-addon/config.yaml
+++ b/neolink-addon/config.yaml
@@ -4,7 +4,7 @@
 # pulls ghcr.io/borexola/neolink.net-addon-{arch}:<version>, which the docker
 # workflow publishes on every tag. Version here ≠ tag ⇒ users see no update.
 name: Neolink.NET
-version: "0.8.6"
+version: "0.8.7"
 slug: neolink
 description: >-
   Reolink camera bridge — live RTSP restreaming, a full web UI with recording

--- a/src/Neolink.Server/Config/NeolinkConfig.cs
+++ b/src/Neolink.Server/Config/NeolinkConfig.cs
@@ -184,6 +184,8 @@ public sealed class NeolinkConfig
             switch (Key(prop.Name))
             {
                 case "path": path = prop.Value.GetString(); break;
+                case "clipspath": rec.ClipsPath = prop.Value.GetString() ?? ""; break;
+                case "archivepath": rec.ArchivePath = prop.Value.GetString() ?? ""; break;
                 case "retentiondays": rec.RetentionDays = prop.Value.GetInt32(); break;
                 case "preseconds": rec.PreSeconds = prop.Value.GetInt32(); break;
                 case "postseconds": rec.PostSeconds = prop.Value.GetInt32(); break;
@@ -310,6 +312,8 @@ public sealed class NeolinkConfig
             {
                 Path = MiniToml.GetString(rec, "path")
                     ?? throw new FormatException("[recording] needs a 'path' (the storage directory)"),
+                ClipsPath = MiniToml.GetString(rec, "clips_path") ?? "",
+                ArchivePath = MiniToml.GetString(rec, "archive_path") ?? "",
                 RetentionDays = (int)(MiniToml.GetInt(rec, "retention_days") ?? 7),
                 PreSeconds = (int)(MiniToml.GetInt(rec, "pre_seconds") ?? 5),
                 PostSeconds = (int)(MiniToml.GetInt(rec, "post_seconds") ?? 8),
@@ -580,6 +584,19 @@ public sealed class RecordingConfig
 
     /// <summary>Storage directory for clips/thumbnails/event metadata (mount a volume here in Docker).</summary>
     public string Path { get; set; } = "";
+
+    /// <summary>Optional fast tier: event clips/thumbnails/metadata are written here
+    /// instead of <see cref="Path"/> (continuous 24/7 footage stays on Path). Point
+    /// it at an SSD for quick event review. Empty = keep everything under Path.</summary>
+    public string ClipsPath { get; set; } = "";
+
+    /// <summary>Optional archive tier: aged footage is MOVED here instead of being
+    /// deleted — but only for cameras whose Archive switch is turned ON in the web
+    /// UI (per-camera move/delete ages live there too). Point this at a DIFFERENT
+    /// drive than <see cref="Path"/> (in Docker, map a second volume). Empty =
+    /// no archive tier; expired footage is deleted as always.</summary>
+    public string ArchivePath { get; set; } = "";
+
     /// <summary>Days to keep events; 0 keeps them forever.</summary>
     public int RetentionDays { get; set; } = 7;
     /// <summary>Seconds of video kept from before the detection.</summary>

--- a/src/Neolink.Server/Neolink.Server.csproj
+++ b/src/Neolink.Server/Neolink.Server.csproj
@@ -11,7 +11,7 @@
          log, /api/features and the web UI. Release builds override it with the
          git tag (docker.yml passes -p:Version), so tagging vX.Y.Z is what
          increments the released version. -->
-    <Version>0.8.6</Version>
+    <Version>0.8.7</Version>
     <InvariantGlobalization>true</InvariantGlobalization>
     <ServerGarbageCollection>false</ServerGarbageCollection>
     <TieredPgo>true</TieredPgo>

--- a/src/Neolink.Server/Program.cs
+++ b/src/Neolink.Server/Program.cs
@@ -141,11 +141,14 @@ HomeAssistantMqtt? mqtt = null;
 // Recording (detection events + continuous), when a storage path is configured.
 EventStore? eventStore = null;
 RecordingSettings? recordingSettings = null;
+StorageLocations? storage = null;
 if (config.Recording is { } recCfg)
 {
     try
     {
-        eventStore = new EventStore(recCfg.Path);
+        storage = new StorageLocations(recCfg);
+        eventStore = new EventStore(storage.MainRoot,
+            storage.HasClipsTier ? storage.ClipsRoot : null, storage.ArchiveRoot);
         eventStore.Load();
         // Runtime switches live in the state dir; older locations (config dir,
         // recordings root) are checked once for migration.
@@ -154,26 +157,37 @@ if (config.Recording is { } recCfg)
                  $"(default retention — events: {(recCfg.RetentionDays > 0 ? $"{recCfg.RetentionDays} days" : "forever")}, " +
                  $"continuous: {(recCfg.EffectiveContinuousRetentionDays > 0 ? $"{recCfg.EffectiveContinuousRetentionDays} days" : "forever")}; " +
                  "per-camera overrides apply)");
-        // Per-camera retention: the cleanup pass sees storage-directory names, so map
-        // them back to camera names to look up each camera's override (null = default).
+        if (storage.HasClipsTier)
+            Log.Info($"Recording: event clips go to the fast tier at {storage.ClipsRoot}");
+        if (storage.ArchiveRoot is { } archRoot)
+            Log.Info($"Recording: archive tier at {archRoot} — cameras opt in from the web UI");
+        // Per-camera lifecycle: the cleanup pass sees storage-directory names, so map
+        // them back to camera names to look up each camera's settings. Archiving is
+        // a per-camera opt-in and needs the archive tier to exist.
         var store = eventStore;
         var settings = recordingSettings;
+        bool hasArchive = storage.HasArchiveTier;
         var camerasByDir = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var c in config.Cameras)
             camerasByDir.TryAdd(EventStore.SafeName(c.Name), c.Name);
-        (int, int) RetentionFor(string dirName)
+        EventStore.CameraStoragePolicy PolicyFor(string dirName)
         {
             var name = camerasByDir.TryGetValue(dirName, out var n) ? n : dirName;
             var s = settings.Get(name);
-            return (s.EventRetentionDays ?? recCfg.RetentionDays,
-                    s.ContinuousRetentionDays ?? recCfg.EffectiveContinuousRetentionDays);
+            return new EventStore.CameraStoragePolicy(
+                s.EventRetentionDays ?? recCfg.RetentionDays,
+                s.ContinuousRetentionDays ?? recCfg.EffectiveContinuousRetentionDays,
+                ArchiveEvents: hasArchive && s.ArchiveEvents,
+                ArchiveContinuous: hasArchive && s.ArchiveContinuous,
+                ArchiveDeleteDays: s.ArchiveRetentionDays ?? 0);
         }
-        tasks.Add(Task.Run(() => store.RunRetentionAsync(RetentionFor, shutdown.Token)));
+        tasks.Add(Task.Run(() => store.RunRetentionAsync(PolicyFor, shutdown.Token)));
     }
     catch (Exception ex)
     {
         Log.Error($"Recording disabled: cannot use storage path '{recCfg.Path}': {ex.Message}");
         eventStore = null;
+        storage = null;
     }
 }
 
@@ -282,7 +296,8 @@ foreach (var cam in config.Cameras)
                 var previewStream = webStreams.FirstOrDefault(s => s.Kind == "subStream");
                 if (previewStream == recordStream) previewStream = null;
                 var recorder = new EventRecorder(cam.Name, recordStream.Hub, control, eventStore,
-                    config.Recording, recordingSettings, previewStream?.Hub, hubsByKind);
+                    config.Recording, recordingSettings, previewStream?.Hub, hubsByKind,
+                    hasRoom: storage == null ? null : () => storage.HasRoom(StorageRole.Clips));
                 recorderSink = recorder.OnMotion;
                 eventRecorder = recorder;
                 tasks.Add(Task.Run(() => recorder.RunAsync(shutdown.Token)));
@@ -293,7 +308,8 @@ foreach (var cam in config.Cameras)
             if (RecordingConfig.ContinuousEnabled)
             {
                 var continuous = new ContinuousRecorder(cam.Name, recordStream.Hub, eventStore,
-                    recordingSettings, config.Recording, hubsByKind);
+                    recordingSettings, config.Recording, hubsByKind,
+                    hasRoom: storage == null ? null : () => storage.HasRoom(StorageRole.Main));
                 continuousRecorder = continuous;
                 tasks.Add(Task.Run(() => continuous.RunAsync(shutdown.Token)));
             }
@@ -390,6 +406,8 @@ if (config.WebPort > 0)
         Events = eventStore,
         RecordingSettings = recordingSettings,
         Recording = config.Recording,
+        ArchiveAvailable = storage?.HasArchiveTier ?? false,
+        Storage = storage,
         UserStore = userStore,
         ResetAdminPassword = config.EffectiveResetAdminPassword,
         TrickleSpeed = config.Ui.TrickleSpeed,

--- a/src/Neolink.Server/Recording/ClipWriter.cs
+++ b/src/Neolink.Server/Recording/ClipWriter.cs
@@ -333,7 +333,18 @@ public sealed class ClipWriter : IDisposable
                 }
             }
         }
-        file?.Dispose();
+        try
+        {
+            file?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            // Dispose flushes the write buffer — a volume that filled or vanished
+            // can throw HERE, and an unhandled exception on this raw thread would
+            // take down the whole process.
+            _faulted = true;
+            Log.Warn($"{_path}: closing clip file failed: {ex.Message}");
+        }
         _done.TrySetResult();
     }
 

--- a/src/Neolink.Server/Recording/ContinuousRecorder.cs
+++ b/src/Neolink.Server/Recording/ContinuousRecorder.cs
@@ -30,16 +30,21 @@ public sealed class ContinuousRecorder
     private readonly RecordingSettings _settings;
     private readonly double _segmentSeconds;
     private readonly long _maxSegmentBytes;
+    private readonly Func<bool>? _hasRoom;
     private volatile bool _writing;
+    private bool _fullLogged;
 
     /// <summary>True while 24/7 footage is actually being written to disk (feeds the UI's REC badge).</summary>
     public bool IsWriting => _writing;
 
     /// <param name="hubsByKind">The camera's streams by kind, enabling the per-camera
     /// "record from main/sub" runtime choice; null pins recording to <paramref name="hub"/>.</param>
+    /// <param name="hasRoom">Free-space guard: false = the recordings volume is full,
+    /// so no new segment is opened (retried on a backoff). Null = never blocks.</param>
     public ContinuousRecorder(string camera, IStreamHub hub, EventStore store,
         RecordingSettings settings, RecordingConfig cfg,
-        IReadOnlyDictionary<string, IStreamHub>? hubsByKind = null)
+        IReadOnlyDictionary<string, IStreamHub>? hubsByKind = null,
+        Func<bool>? hasRoom = null)
     {
         _camera = camera;
         _hub = hub;
@@ -48,6 +53,7 @@ public sealed class ContinuousRecorder
         _settings = settings;
         _segmentSeconds = cfg.SegmentMinutes * 60.0;
         _maxSegmentBytes = (long)cfg.MaxSegmentSizeMb * 1024 * 1024;
+        _hasRoom = hasRoom;
     }
 
     /// <summary>The stream taped right now: the user's per-camera choice when set (and served).</summary>
@@ -141,6 +147,25 @@ public sealed class ContinuousRecorder
                 {
                     // Every segment starts on a keyframe so it plays standalone.
                     if (!v.Keyframe || DateTime.UtcNow < retryAfter) continue;
+                    // Free-space guard: a full volume halts new segments cleanly
+                    // (instead of failing mid-write) until the hourly cleanup or
+                    // the user frees space. One log per transition, not per try.
+                    if (_hasRoom?.Invoke() == false)
+                    {
+                        if (!_fullLogged)
+                        {
+                            Log.Error($"{_camera}: recordings storage is FULL — continuous recording halted until space is freed");
+                            _fullLogged = true;
+                        }
+                        _writing = false;
+                        retryAfter = DateTime.UtcNow + WriteErrorBackoff;
+                        continue;
+                    }
+                    if (_fullLogged)
+                    {
+                        Log.Info($"{_camera}: storage has room again — continuous recording resumes");
+                        _fullLogged = false;
+                    }
                     try
                     {
                         // Never blocks on disk: the file is opened and written by the

--- a/src/Neolink.Server/Recording/EventRecorder.cs
+++ b/src/Neolink.Server/Recording/EventRecorder.cs
@@ -56,7 +56,8 @@ public sealed class EventRecorder
     /// "record from main/sub" runtime choice; null pins recording to <paramref name="hub"/>.</param>
     public EventRecorder(string camera, IStreamHub hub, ICameraControl control,
         EventStore store, RecordingConfig cfg, RecordingSettings settings,
-        IStreamHub? previewHub = null, IReadOnlyDictionary<string, IStreamHub>? hubsByKind = null)
+        IStreamHub? previewHub = null, IReadOnlyDictionary<string, IStreamHub>? hubsByKind = null,
+        Func<bool>? hasRoom = null)
     {
         _camera = camera;
         _hub = hub;
@@ -66,7 +67,12 @@ public sealed class EventRecorder
         _store = store;
         _cfg = cfg;
         _settings = settings;
+        _hasRoom = hasRoom;
     }
+
+    /// <summary>Free-space guard for the clips tier; null = never blocks.</summary>
+    private readonly Func<bool>? _hasRoom;
+    private bool _fullLogged;
 
     /// <summary>The hub clips are cut from right now: the user's per-camera stream
     /// choice when set (and served), otherwise the configured default.</summary>
@@ -538,6 +544,24 @@ public sealed class EventRecorder
     {
         lock (_mediaGate)
         {
+            // Free-space guard: a full clips volume records the event's metadata
+            // only (still visible in the strip) instead of failing mid-write.
+            if (_hasRoom?.Invoke() == false)
+            {
+                if (!_fullLogged)
+                {
+                    Log.Error($"{_camera}: clips storage is FULL — events are stored without video until space is freed");
+                    _fullLogged = true;
+                }
+                _preroll.Clear();
+                _previewPreroll.Clear();
+                return;
+            }
+            if (_fullLogged)
+            {
+                Log.Info($"{_camera}: storage has room again — event clips resume");
+                _fullLogged = false;
+            }
             try
             {
                 _writer = ClipWriter.TryCreate(Path.Combine(_store.EventDir(rec), "clip.mp4"),

--- a/src/Neolink.Server/Recording/EventStore.cs
+++ b/src/Neolink.Server/Recording/EventStore.cs
@@ -45,40 +45,65 @@ public sealed class EventStore
     };
 
     private readonly string _root;
+    private readonly string _clipsRoot;   // where NEW event folders go (== _root unless tiered)
+    private readonly string? _archiveRoot; // aged footage moves here instead of being deleted
     private readonly object _gate = new();
     private readonly Dictionary<string, (EventRecord Record, string Dir)> _byId = new();
 
-    public EventStore(string root)
+    public EventStore(string root, string? clipsRoot = null, string? archiveRoot = null)
     {
         _root = Path.GetFullPath(root);
+        _clipsRoot = clipsRoot == null ? _root : Path.GetFullPath(clipsRoot);
+        _archiveRoot = archiveRoot == null ? null : Path.GetFullPath(archiveRoot);
         Directory.CreateDirectory(_root);
+        Directory.CreateDirectory(_clipsRoot);
+        if (_archiveRoot != null) Directory.CreateDirectory(_archiveRoot);
     }
 
     public string Root => _root;
 
-    /// <summary>Scans the storage directory and rebuilds the in-memory index.</summary>
+    /// <summary>Every distinct root that can hold footage, main first (then the
+    /// clips tier and the archive, when configured and distinct).</summary>
+    private IEnumerable<string> Roots
+    {
+        get
+        {
+            yield return _root;
+            if (!SamePath(_clipsRoot, _root)) yield return _clipsRoot;
+            if (_archiveRoot != null && !SamePath(_archiveRoot, _root) && !SamePath(_archiveRoot, _clipsRoot))
+                yield return _archiveRoot;
+        }
+    }
+
+    private static bool SamePath(string a, string b) =>
+        string.Equals(a, b, OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+
+    /// <summary>Scans every storage root and rebuilds the in-memory index.</summary>
     public void Load()
     {
         try { MigrateLegacyLayout(); }
         catch (Exception ex) { Log.Warn($"Recordings: layout migration pass failed: {ex.Message}"); }
         int loaded = 0;
-        foreach (var file in Directory.EnumerateFiles(_root, "event.json", SearchOption.AllDirectories))
+        foreach (var root in Roots)
         {
-            try
+            foreach (var file in Directory.EnumerateFiles(root, "event.json", SearchOption.AllDirectories))
             {
-                var rec = JsonSerializer.Deserialize<EventRecord>(File.ReadAllText(file), JsonOpts);
-                if (rec == null) continue;
-                rec.Ongoing = false; // whatever was ongoing did not survive the restart
-                lock (_gate) { _byId[rec.Id] = (rec, Path.GetDirectoryName(file)!); }
-                loaded++;
-            }
-            catch (Exception ex)
-            {
-                Log.Warn($"Events: skipping unreadable {file}: {ex.Message}");
+                try
+                {
+                    var rec = JsonSerializer.Deserialize<EventRecord>(File.ReadAllText(file), JsonOpts);
+                    if (rec == null) continue;
+                    rec.Ongoing = false; // whatever was ongoing did not survive the restart
+                    lock (_gate) { _byId[rec.Id] = (rec, Path.GetDirectoryName(file)!); }
+                    loaded++;
+                }
+                catch (Exception ex)
+                {
+                    Log.Warn($"Events: skipping unreadable {file}: {ex.Message}");
+                }
             }
         }
         if (loaded > 0)
-            Log.Info($"Events: indexed {loaded} stored event(s) under {_root}");
+            Log.Info($"Events: indexed {loaded} stored event(s) under {string.Join(" + ", Roots)}");
     }
 
     /// <summary>Creates a new event and its directory, and persists the initial record.</summary>
@@ -88,8 +113,19 @@ public sealed class EventStore
         var suffix = Convert.ToHexString(Guid.NewGuid().ToByteArray()[..2]).ToLowerInvariant();
         var folder = $"{local:HHmmss}-{suffix}";
         var id = $"{camera}~{local:yyyy-MM-dd}~{folder}";
-        var dir = Path.Combine(_root, SafeName(camera), $"{local:yyyy-MM-dd}", "detections", folder);
-        Directory.CreateDirectory(dir);
+        // New detections land on the clips tier (the fast/SSD path when configured).
+        var dir = Path.Combine(_clipsRoot, SafeName(camera), $"{local:yyyy-MM-dd}", "detections", folder);
+        try
+        {
+            Directory.CreateDirectory(dir);
+        }
+        catch (Exception ex)
+        {
+            // A dead/full clips volume must not kill the event: it still registers
+            // (in memory, so the UI and HA see it) — only its artifacts are lost,
+            // and every artifact write logs its own failure.
+            Log.Error($"{camera}: cannot create event folder {dir}: {ex.Message}");
+        }
 
         var rec = new EventRecord
         {
@@ -120,7 +156,7 @@ public sealed class EventStore
             File.WriteAllText(tmp, JsonSerializer.Serialize(rec, JsonOpts));
             File.Move(tmp, Path.Combine(dir, "event.json"), overwrite: true);
         }
-        catch (IOException ex)
+        catch (Exception ex)
         {
             Log.Warn($"Events: cannot persist {rec.Id}: {ex.Message}");
         }
@@ -180,9 +216,10 @@ public sealed class EventStore
     public List<string> ListContentDays()
     {
         var days = new HashSet<string>(StringComparer.Ordinal);
-        if (Directory.Exists(_root))
+        foreach (var root in Roots)
         {
-            foreach (var camDir in Directory.EnumerateDirectories(_root))
+            if (!Directory.Exists(root)) continue;
+            foreach (var camDir in Directory.EnumerateDirectories(root))
                 foreach (var dayDir in Directory.EnumerateDirectories(camDir))
                 {
                     var name = Path.GetFileName(dayDir)!;
@@ -202,38 +239,58 @@ public sealed class EventStore
         return Path.Combine(dir, $"{local:HH-mm-ss}.mp4");
     }
 
-    /// <summary>Days with continuous footage for a camera, newest first ("yyyy-MM-dd").</summary>
-    public List<string> ListContinuousDays(string camera)
+    /// <summary>The live root plus the archive (when configured): everywhere
+    /// continuous footage can live. The timeline reads both transparently.</summary>
+    private IEnumerable<string> ContinuousRoots
     {
-        var camDir = Path.Combine(_root, SafeName(camera));
-        if (!Directory.Exists(camDir)) return new List<string>();
-        return Directory.EnumerateDirectories(camDir)
-            .Select(d => Path.GetFileName(d)!)
-            .Where(d => IsDayName(d) && Directory.Exists(Path.Combine(camDir, d, "continuous")))
-            .OrderByDescending(d => d)
-            .ToList();
+        get
+        {
+            yield return _root;
+            if (_archiveRoot != null && !SamePath(_archiveRoot, _root)) yield return _archiveRoot;
+        }
     }
 
-    /// <summary>Segment files of one day, oldest first: (file name, size in bytes).</summary>
+    /// <summary>Days with continuous footage for a camera (live or archived), newest first ("yyyy-MM-dd").</summary>
+    public List<string> ListContinuousDays(string camera)
+    {
+        var days = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var root in ContinuousRoots)
+        {
+            var camDir = Path.Combine(root, SafeName(camera));
+            if (!Directory.Exists(camDir)) continue;
+            foreach (var d in Directory.EnumerateDirectories(camDir).Select(d => Path.GetFileName(d)!))
+                if (IsDayName(d) && Directory.Exists(Path.Combine(camDir, d, "continuous")))
+                    days.Add(d);
+        }
+        return days.OrderByDescending(d => d).ToList();
+    }
+
+    /// <summary>Segment files of one day (live and archived merged), oldest first: (file name, size in bytes).</summary>
     public List<(string File, long Size)> ListSegments(string camera, string date)
     {
         if (!IsDayName(date)) return new List<(string, long)>();
-        var dir = Path.Combine(_root, SafeName(camera), date, "continuous");
-        if (!Directory.Exists(dir)) return new List<(string, long)>();
-        return Directory.EnumerateFiles(dir, "*.mp4")
-            .Select(f => new FileInfo(f))
-            .Where(f => IsSegmentName(f.Name))
-            .OrderBy(f => f.Name)
-            .Select(f => (f.Name, f.Length))
-            .ToList();
+        var seen = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+        foreach (var root in ContinuousRoots)
+        {
+            var dir = Path.Combine(root, SafeName(camera), date, "continuous");
+            if (!Directory.Exists(dir)) continue;
+            foreach (var f in Directory.EnumerateFiles(dir, "*.mp4").Select(f => new FileInfo(f)))
+                if (IsSegmentName(f.Name) && !seen.ContainsKey(f.Name))
+                    seen[f.Name] = f.Length;
+        }
+        return seen.OrderBy(kv => kv.Key).Select(kv => (kv.Key, kv.Value)).ToList();
     }
 
-    /// <summary>Absolute path of one segment; strict name validation (no traversal).</summary>
+    /// <summary>Absolute path of one segment (live first, then archive); strict name validation (no traversal).</summary>
     public string? SegmentPath(string camera, string date, string file)
     {
         if (!IsDayName(date) || !IsSegmentName(file)) return null;
-        var path = Path.Combine(_root, SafeName(camera), date, "continuous", file);
-        return File.Exists(path) ? path : null;
+        foreach (var root in ContinuousRoots)
+        {
+            var path = Path.Combine(root, SafeName(camera), date, "continuous", file);
+            if (File.Exists(path)) return path;
+        }
+        return null;
     }
 
     private static bool IsDayName(string s) =>
@@ -246,62 +303,231 @@ public sealed class EventStore
 
     // ------------------------------------------------------------------ retention
 
+    /// <summary>
+    /// One camera's storage lifecycle. Archiving is the per-camera, per-type
+    /// opt-in: with <paramref name="ArchiveEvents"/>/<paramref name="ArchiveContinuous"/>
+    /// (and an archive root configured), footage whose live retention window
+    /// (EventDays/ContinuousDays) expires is MOVED to the archive instead of
+    /// deleted, then finally deleted from the archive after
+    /// <paramref name="ArchiveDeleteDays"/> (0 = never). With both flags off,
+    /// EventDays/ContinuousDays delete exactly as they always have.
+    /// </summary>
+    public sealed record CameraStoragePolicy(int EventDays, int ContinuousDays,
+        bool ArchiveEvents = false, bool ArchiveContinuous = false, int ArchiveDeleteDays = 0);
+
     /// <summary>Same retention window for every camera (used by tests and simple hosts).</summary>
     public void Cleanup(int retentionDays, int continuousRetentionDays) =>
         Cleanup(_ => (retentionDays, continuousRetentionDays));
 
-    /// <summary>
-    /// Deletes detections and continuous footage older than their retention windows.
-    /// The two live side by side in each date folder, so expiry is per type; the
-    /// date folder itself goes once both halves are gone.
-    /// <paramref name="retentionFor"/> maps a camera storage-directory name to its
-    /// (event days, continuous days) — 0 in either slot means keep forever.
-    /// </summary>
-    public void Cleanup(Func<string, (int EventDays, int ContinuousDays)> retentionFor)
-    {
-        int events = 0, segments = 0;
-        foreach (var cameraDir in Directory.EnumerateDirectories(_root))
+    /// <summary>Delete-only cleanup (no archiving) — the pre-archive signature.</summary>
+    public void Cleanup(Func<string, (int EventDays, int ContinuousDays)> retentionFor) =>
+        Cleanup(cam =>
         {
-            var (retentionDays, continuousRetentionDays) = retentionFor(Path.GetFileName(cameraDir)!);
-            // Clamp to 100 years: an absurd day count (hand-edited settings/config)
-            // would overflow AddDays and abort the whole pass for every camera.
-            retentionDays = Math.Min(retentionDays, 36500);
-            continuousRetentionDays = Math.Min(continuousRetentionDays, 36500);
-            var eventCutoff = DateTime.Now.Date.AddDays(-retentionDays);
-            var contCutoff = DateTime.Now.Date.AddDays(-continuousRetentionDays);
+            var (e, c) = retentionFor(cam);
+            return new CameraStoragePolicy(e, c);
+        });
 
-            foreach (var dayDir in Directory.EnumerateDirectories(cameraDir))
+    /// <summary>
+    /// Applies each camera's storage lifecycle: expired footage is deleted — or,
+    /// for cameras with archiving enabled, moved to the archive tier and deleted
+    /// from there once past the archive window. Detections and continuous footage
+    /// expire independently; a date folder disappears once both halves are gone.
+    /// <paramref name="policyFor"/> maps a camera storage-directory name to its policy.
+    /// </summary>
+    public void Cleanup(Func<string, CameraStoragePolicy> policyFor)
+    {
+        int events = 0, segments = 0, archivedHalves = 0, archiveDeleted = 0;
+        // The live pass covers every root that holds fresh footage (main +
+        // the clips tier when distinct); the archive root is handled after.
+        foreach (var root in Roots.Where(r => _archiveRoot == null || !SamePath(r, _archiveRoot)))
+        {
+            foreach (var cameraDir in Directory.EnumerateDirectories(root))
             {
-                if (!DateTime.TryParseExact(Path.GetFileName(dayDir), "yyyy-MM-dd",
-                        null, System.Globalization.DateTimeStyles.None, out var day))
-                    continue; // e.g. a pre-migration "continuous" tree, swept below
-                if (retentionDays > 0 && day < eventCutoff)
-                    events += DeleteEventEntries(dayDir);
-                if (continuousRetentionDays > 0 && day < contCutoff
-                    && DeleteTree(Path.Combine(dayDir, "continuous")))
-                    segments++;
-                TryDeleteIfEmpty(dayDir); // both halves expired: the day is gone
-            }
+                var camName = Path.GetFileName(cameraDir)!;
+                var policy = policyFor(camName);
+                // Clamp to 100 years: an absurd day count (hand-edited settings/config)
+                // would overflow AddDays and abort the whole pass for every camera.
+                int retentionDays = Math.Min(policy.EventDays, 36500);
+                int continuousRetentionDays = Math.Min(policy.ContinuousDays, 36500);
+                // Archiving changes what happens at the SAME moment: when a
+                // type's retention expires, its footage moves to the archive
+                // instead of being deleted (retention 0 = forever = nothing
+                // ever expires, so nothing archives either).
+                bool archiveEvents = policy.ArchiveEvents && _archiveRoot != null;
+                bool archiveCont = policy.ArchiveContinuous && _archiveRoot != null;
 
-            // Pre-migration leftovers ({camera}/continuous/{date}) — only present
-            // when a migration pass could not complete; expire them all the same.
-            var legacyCont = Path.Combine(cameraDir, "continuous");
-            if (continuousRetentionDays > 0 && Directory.Exists(legacyCont))
-            {
-                foreach (var dateDir in Directory.EnumerateDirectories(legacyCont))
+                var eventCutoff = DateTime.Now.Date.AddDays(-retentionDays);
+                var contCutoff = DateTime.Now.Date.AddDays(-continuousRetentionDays);
+                bool eventActs = retentionDays > 0;
+                bool contActs = continuousRetentionDays > 0;
+
+                foreach (var dayDir in Directory.EnumerateDirectories(cameraDir))
                 {
-                    if (DateTime.TryParseExact(Path.GetFileName(dateDir), "yyyy-MM-dd",
-                            null, System.Globalization.DateTimeStyles.None, out var day)
-                        && day < contCutoff && DeleteTree(dateDir))
-                        segments++;
+                    var dayName = Path.GetFileName(dayDir)!;
+                    if (!DateTime.TryParseExact(dayName, "yyyy-MM-dd",
+                            null, System.Globalization.DateTimeStyles.None, out var day))
+                        continue; // e.g. a pre-migration "continuous" tree, swept below
+                    if (eventActs && day < eventCutoff)
+                    {
+                        if (archiveEvents)
+                            archivedHalves += ArchiveEventEntries(dayDir, camName, dayName) ? 1 : 0;
+                        else
+                            events += DeleteEventEntries(dayDir);
+                    }
+                    if (contActs && day < contCutoff)
+                    {
+                        var contDir = Path.Combine(dayDir, "continuous");
+                        if (archiveCont)
+                        {
+                            if (Directory.Exists(contDir) && MoveTree(contDir,
+                                    Path.Combine(_archiveRoot!, camName, dayName, "continuous")))
+                                archivedHalves++;
+                        }
+                        else if (DeleteTree(contDir))
+                        {
+                            segments++;
+                        }
+                    }
+                    TryDeleteIfEmpty(dayDir); // both halves gone: the day is done here
                 }
-                TryDeleteIfEmpty(legacyCont);
+
+                // Pre-migration leftovers ({camera}/continuous/{date}) — only present
+                // when a migration pass could not complete; expire them all the same
+                // (delete-only: anything this old predates archiving entirely).
+                var legacyCont = Path.Combine(cameraDir, "continuous");
+                if (!archiveCont && continuousRetentionDays > 0 && Directory.Exists(legacyCont))
+                {
+                    foreach (var dateDir in Directory.EnumerateDirectories(legacyCont))
+                    {
+                        if (DateTime.TryParseExact(Path.GetFileName(dateDir), "yyyy-MM-dd",
+                                null, System.Globalization.DateTimeStyles.None, out var day)
+                            && day < contCutoff && DeleteTree(dateDir))
+                            segments++;
+                    }
+                    TryDeleteIfEmpty(legacyCont);
+                }
             }
         }
+
+        archiveDeleted = CleanupArchive(policyFor);
+
         if (events > 0)
             Log.Info($"Events: retention removed {events} expired detection folder(s)");
         if (segments > 0)
             Log.Info($"Recordings: retention removed {segments} expired continuous day folder(s)");
+        if (archivedHalves > 0)
+            Log.Info($"Recordings: retention archived {archivedHalves} aged folder(s) to {_archiveRoot}");
+        if (archiveDeleted > 0)
+            Log.Info($"Recordings: archive retention removed {archiveDeleted} expired day folder(s)");
+    }
+
+    /// <summary>Deletes archived days that have outlived their camera's archive window.</summary>
+    private int CleanupArchive(Func<string, CameraStoragePolicy> policyFor)
+    {
+        if (_archiveRoot == null || !Directory.Exists(_archiveRoot)) return 0;
+        int removed = 0;
+        foreach (var cameraDir in Directory.EnumerateDirectories(_archiveRoot))
+        {
+            var policy = policyFor(Path.GetFileName(cameraDir)!);
+            // The archive window applies even if the user has since switched
+            // archiving off — footage they chose to expire should still expire.
+            int deleteDays = Math.Min(policy.ArchiveDeleteDays, 36500);
+            if (deleteDays <= 0) continue; // keep forever
+            var cutoff = DateTime.Now.Date.AddDays(-deleteDays);
+            foreach (var dayDir in Directory.EnumerateDirectories(cameraDir))
+            {
+                if (!DateTime.TryParseExact(Path.GetFileName(dayDir), "yyyy-MM-dd",
+                        null, System.Globalization.DateTimeStyles.None, out var day) || day >= cutoff)
+                    continue;
+                DropIndexEntriesUnder(dayDir);
+                if (DeleteTree(dayDir)) removed++;
+            }
+            TryDeleteIfEmpty(cameraDir);
+        }
+        return removed;
+    }
+
+    /// <summary>Moves a day's event storage into the archive, keeping the index
+    /// pointed at the new location so archived events stay playable.</summary>
+    private bool ArchiveEventEntries(string dayDir, string camName, string dayName)
+    {
+        bool any = false;
+        foreach (var entry in Directory.EnumerateDirectories(dayDir))
+        {
+            var half = Path.GetFileName(entry)!;
+            if (half.Equals("continuous", StringComparison.OrdinalIgnoreCase)) continue;
+            var target = Path.Combine(_archiveRoot!, camName, dayName, half);
+            if (!MoveTree(entry, target)) continue;
+            any = true;
+            lock (_gate)
+            {
+                var srcPrefix = entry + Path.DirectorySeparatorChar;
+                foreach (var id in _byId.Keys.ToList())
+                {
+                    var dir = _byId[id].Dir;
+                    if (dir.Equals(entry, StringComparison.OrdinalIgnoreCase))
+                        _byId[id] = (_byId[id].Record, target);
+                    else if (dir.StartsWith(srcPrefix, StringComparison.OrdinalIgnoreCase))
+                        _byId[id] = (_byId[id].Record, Path.Combine(target, dir[srcPrefix.Length..]));
+                }
+            }
+        }
+        return any;
+    }
+
+    /// <summary>Forgets every indexed event living under a directory (used before
+    /// an archive day is finally deleted).</summary>
+    private void DropIndexEntriesUnder(string dir)
+    {
+        lock (_gate)
+        {
+            var prefix = dir + Path.DirectorySeparatorChar;
+            foreach (var id in _byId
+                         .Where(kv => kv.Value.Dir.Equals(dir, StringComparison.OrdinalIgnoreCase)
+                                   || kv.Value.Dir.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                         .Select(kv => kv.Key).ToList())
+                _byId.Remove(id);
+        }
+    }
+
+    /// <summary>
+    /// Moves a directory tree, surviving both cross-volume moves (Directory.Move
+    /// can't cross filesystems — files are moved one by one instead, and File.Move
+    /// handles the copy+delete) and an existing target (contents merge). True when
+    /// the source is gone afterwards.
+    /// </summary>
+    internal static bool MoveTree(string src, string dst)
+    {
+        if (!Directory.Exists(src)) return false;
+        try
+        {
+            if (!Directory.Exists(dst))
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(dst)!);
+                try
+                {
+                    Directory.Move(src, dst); // same volume: instant rename
+                    return true;
+                }
+                catch (IOException) { /* cross-volume or racing writer: merge below */ }
+            }
+            Directory.CreateDirectory(dst);
+            foreach (var dir in Directory.EnumerateDirectories(src))
+                MoveTree(dir, Path.Combine(dst, Path.GetFileName(dir)!));
+            foreach (var file in Directory.EnumerateFiles(src))
+            {
+                var target = Path.Combine(dst, Path.GetFileName(file)!);
+                if (File.Exists(target)) File.Delete(file); // already archived earlier
+                else File.Move(file, target);                // cross-volume safe
+            }
+            TryDeleteIfEmpty(src);
+            return !Directory.Exists(src);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Log.Warn($"Archive: cannot move {src} -> {dst}: {ex.Message} (will retry next pass)");
+            return false;
+        }
     }
 
     /// <summary>
@@ -439,12 +665,11 @@ public sealed class EventStore
     }
 
     /// <summary>Runs retention cleanup once at start and then hourly.</summary>
-    public async Task RunRetentionAsync(Func<string, (int EventDays, int ContinuousDays)> retentionFor,
-        CancellationToken ct)
+    public async Task RunRetentionAsync(Func<string, CameraStoragePolicy> policyFor, CancellationToken ct)
     {
         while (!ct.IsCancellationRequested)
         {
-            try { Cleanup(retentionFor); }
+            try { Cleanup(policyFor); }
             catch (Exception ex) { Log.Warn($"Events: retention pass failed: {Log.Flatten(ex)}"); }
             try { await Task.Delay(TimeSpan.FromHours(1), ct).ConfigureAwait(false); }
             catch (OperationCanceledException) { return; }

--- a/src/Neolink.Server/Recording/RecordingSettings.cs
+++ b/src/Neolink.Server/Recording/RecordingSettings.cs
@@ -16,12 +16,22 @@ namespace Neolink.Recording;
 /// be switched off without losing it. ScheduleDays lists the enabled days
 /// ("mon".."sun", null = every day) and ScheduleStart/ScheduleEnd bound the
 /// time of day ("HH:mm"; null = midnight, so both null = all day).
+///
+/// Archiving (requires recording.archive_path on the server) is a strict opt-in
+/// per camera and per recording type: with ArchiveEvents/ArchiveContinuous on,
+/// footage whose normal retention expires is MOVED to the archive instead of
+/// deleted — retention stays the single knob for when footage leaves the live
+/// tier; archiving only changes what happens then. Archived footage is deleted
+/// after ArchiveRetentionDays (null or 0 = keep forever). All these fields are
+/// absent from pre-existing settings.json files and default to the old
+/// delete-only behavior.
 /// </summary>
 public sealed record CameraRecordingSettings(bool Events, bool Continuous, List<string>? EventTypes,
     int? EventRetentionDays = null, int? ContinuousRetentionDays = null,
     string? RecordStream = null,
     List<string>? ScheduleDays = null, string? ScheduleStart = null, string? ScheduleEnd = null,
-    bool ScheduleEnabled = false)
+    bool ScheduleEnabled = false,
+    bool ArchiveEvents = false, bool ArchiveContinuous = false, int? ArchiveRetentionDays = null)
 {
     /// <summary>Known detection labels (what the UI offers as event-type filters).</summary>
     public static readonly string[] KnownLabels =
@@ -171,7 +181,9 @@ public sealed class RecordingSettings
         List<string>? scheduleDays = null, bool setScheduleDays = false,
         string? scheduleStart = null, bool setScheduleStart = false,
         string? scheduleEnd = null, bool setScheduleEnd = false,
-        bool? scheduleEnabled = null)
+        bool? scheduleEnabled = null,
+        bool? archiveEvents = null, bool? archiveContinuous = null,
+        int? archiveRetentionDays = null, bool setArchiveRetention = false)
     {
         lock (_gate)
         {
@@ -188,7 +200,10 @@ public sealed class RecordingSettings
                 setScheduleDays ? scheduleDays : cur.ScheduleDays,
                 setScheduleStart ? scheduleStart : cur.ScheduleStart,
                 setScheduleEnd ? scheduleEnd : cur.ScheduleEnd,
-                scheduleEnabled ?? cur.ScheduleEnabled);
+                scheduleEnabled ?? cur.ScheduleEnabled,
+                archiveEvents ?? cur.ArchiveEvents,
+                archiveContinuous ?? cur.ArchiveContinuous,
+                setArchiveRetention ? archiveRetentionDays : cur.ArchiveRetentionDays);
             _cameras[camera] = next;
             SaveLocked();
             return next;
@@ -203,8 +218,10 @@ public sealed class RecordingSettings
             File.WriteAllText(tmp, JsonSerializer.Serialize(_cameras, JsonOpts));
             File.Move(tmp, _file, overwrite: true);
         }
-        catch (IOException ex)
+        catch (Exception ex)
         {
+            // Never let a broken state volume take the settings update down with
+            // it — the in-memory switch already applied; only persistence failed.
             Log.Warn($"Cannot persist recording settings: {ex.Message}");
         }
     }

--- a/src/Neolink.Server/Recording/StorageLocations.cs
+++ b/src/Neolink.Server/Recording/StorageLocations.cs
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Oluwabori Olaleye
+// Licensed under the GNU Affero General Public License v3.0; see the LICENSE file
+// in the repository root.
+using Neolink.Config;
+
+namespace Neolink.Recording;
+
+/// <summary>Which tier a storage location serves.</summary>
+public enum StorageRole
+{
+    /// <summary>The bulk recordings volume — continuous footage, and the default for everything.</summary>
+    Main,
+    /// <summary>Optional fast tier holding event clips (SSD).</summary>
+    Clips,
+    /// <summary>Optional cold tier that aged footage is moved to instead of deleted.</summary>
+    Archive,
+}
+
+/// <summary>One configured storage location and its role.</summary>
+public sealed record StorageLocation(StorageRole Role, string Path)
+{
+    public string Label => Role switch
+    {
+        StorageRole.Main => "Recordings",
+        StorageRole.Clips => "Clips (fast)",
+        StorageRole.Archive => "Archive",
+        _ => Role.ToString(),
+    };
+}
+
+/// <summary>A point-in-time capacity reading of one location's volume.</summary>
+public sealed record StorageStatus(
+    StorageRole Role, string Label, string Path, long TotalBytes, long FreeBytes, bool Online)
+{
+    public double UsedPercent => TotalBytes > 0 ? (TotalBytes - FreeBytes) * 100.0 / TotalBytes : 0;
+
+    /// <summary>Near-capacity: the UI shows an amber "getting full" banner.</summary>
+    public bool Warn => Online && TotalBytes > 0 && UsedPercent >= StorageLocations.WarnPercent;
+
+    /// <summary>Effectively full: recording to this tier halts and the UI shows a red banner.</summary>
+    public bool Full => Online && TotalBytes > 0 && FreeBytes < StorageLocations.MinFreeBytes;
+}
+
+/// <summary>
+/// Resolves the configured storage tiers (main, optional clips, optional archive)
+/// and reports each distinct volume's capacity. All tiers are optional: an unset
+/// clips/archive path resolves back to the main path, so a plain single-folder
+/// install behaves exactly as before. The volume probe is injectable so the
+/// resolution and threshold logic can be tested without real drives.
+/// </summary>
+public sealed class StorageLocations
+{
+    /// <summary>Percent-used at which a location is flagged as getting full (amber).</summary>
+    public const double WarnPercent = 90.0;
+
+    /// <summary>Headroom kept free; below this a tier is "full" and recording halts.
+    /// One gibibyte comfortably covers a rolling segment plus filesystem slack.</summary>
+    public const long MinFreeBytes = 1L * 1024 * 1024 * 1024;
+
+    private readonly string _main;
+    private readonly string _clips;   // == _main when not separately configured
+    private readonly string _archive; // "" when not configured
+    private readonly Func<string, (long Total, long Free)?> _probe;
+
+    /// <param name="probe">Volume sampler for a path (total, free), or null when the
+    /// volume can't be read; defaults to <see cref="DriveInfo"/>.</param>
+    public StorageLocations(RecordingConfig cfg, Func<string, (long, long)?>? probe = null)
+    {
+        _main = Full(cfg.Path);
+        _clips = string.IsNullOrWhiteSpace(cfg.ClipsPath) ? _main : Full(cfg.ClipsPath);
+        _archive = string.IsNullOrWhiteSpace(cfg.ArchivePath) ? "" : Full(cfg.ArchivePath);
+        _probe = probe ?? DefaultProbe;
+
+        // Create every distinct tier up front so writers never race on mkdir.
+        foreach (var loc in Locations)
+        {
+            try { Directory.CreateDirectory(loc.Path); }
+            catch (Exception ex) { Log.Warn($"Storage: cannot create {loc.Label} path '{loc.Path}': {ex.Message}"); }
+        }
+    }
+
+    private static string Full(string p) => Path.GetFullPath(p);
+
+    /// <summary>The bulk/main recordings root (continuous footage; default for all).</summary>
+    public string MainRoot => _main;
+
+    /// <summary>Where new event clips are written — the clips tier when set, else main.</summary>
+    public string ClipsRoot => _clips;
+
+    /// <summary>The archive root, or null when archiving is off.</summary>
+    public string? ArchiveRoot => _archive.Length == 0 ? null : _archive;
+
+    /// <summary>True when a separate SSD clips tier is configured (distinct from main).</summary>
+    public bool HasClipsTier => !PathEquals(_clips, _main);
+
+    /// <summary>True when an archive tier is configured.</summary>
+    public bool HasArchiveTier => _archive.Length > 0;
+
+    /// <summary>Every DISTINCT configured location (by path), main first. Two roles on
+    /// the same folder collapse to one entry (main wins).</summary>
+    public IReadOnlyList<StorageLocation> Locations
+    {
+        get
+        {
+            var list = new List<StorageLocation> { new(StorageRole.Main, _main) };
+            if (HasClipsTier) list.Add(new(StorageRole.Clips, _clips));
+            if (HasArchiveTier && !PathEquals(_archive, _main) && !PathEquals(_archive, _clips))
+                list.Add(new(StorageRole.Archive, _archive));
+            return list;
+        }
+    }
+
+    /// <summary>Capacity reading of every distinct location.</summary>
+    public List<StorageStatus> Sample() =>
+        Locations.Select(l =>
+        {
+            var v = SafeProbe(l.Path);
+            return new StorageStatus(l.Role, l.Label, l.Path,
+                v?.Total ?? 0, v?.Free ?? 0, v.HasValue);
+        }).ToList();
+
+    /// <summary>Is there room to keep writing to the tier that backs this role?
+    /// Unknown/unreadable volumes are treated as writable (fail open — never block
+    /// recording just because a stat call hiccuped).</summary>
+    public bool HasRoom(StorageRole role)
+    {
+        var path = role switch
+        {
+            StorageRole.Clips => _clips,
+            StorageRole.Archive => _archive.Length == 0 ? _main : _archive,
+            _ => _main,
+        };
+        var v = SafeProbe(path);
+        return v is not { } vol || vol.Free >= MinFreeBytes;
+    }
+
+    private (long Total, long Free)? SafeProbe(string path)
+    {
+        try { return _probe(path); }
+        catch { return null; }
+    }
+
+    private static (long, long)? DefaultProbe(string path)
+    {
+        try
+        {
+            var d = new DriveInfo(Path.GetFullPath(path));
+            return (d.TotalSize, d.AvailableFreeSpace);
+        }
+        catch { return null; }
+    }
+
+    private static bool PathEquals(string a, string b) =>
+        string.Equals(
+            a.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+            b.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+            OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+}

--- a/src/Neolink.Server/SelfTest.cs
+++ b/src/Neolink.Server/SelfTest.cs
@@ -178,6 +178,12 @@ public static class SelfTest
                   // a comment
                   "bind": "127.0.0.1",
                   "bind_port": 8555,
+                  "recording": {
+                    "path": "/recordings",
+                    "clips_path": "/clips",
+                    "archive_path": "/archive",
+                    "retention_days": 14,
+                  },
                   "users": [ { "name": "me", "pass": "mepass" } ],
                   "cameras": [
                     {
@@ -214,6 +220,12 @@ public static class SelfTest
                 // Battery cameras: always_on is tri-state — unset means auto.
                 Assert(cfg.Cameras[0].AlwaysOn == null, "always_on defaults to auto");
                 Assert(cfg.Cameras[1].AlwaysOn == true, "always_on parsed");
+                // Tiered-storage keys must round-trip through the parser — the
+                // archive UI only appears when archive_path survives loading.
+                AssertEq(cfg.Recording!.Path, "/recordings");
+                AssertEq(cfg.Recording.ClipsPath, "/clips");
+                AssertEq(cfg.Recording.ArchivePath, "/archive");
+                AssertEq(cfg.Recording.RetentionDays, 14);
             }
             finally
             {
@@ -662,6 +674,158 @@ public static class SelfTest
             finally
             {
                 try { Directory.Delete(dir, recursive: true); } catch { }
+            }
+        });
+
+        Test("storage locations: tier resolution + capacity thresholds", () =>
+        {
+            var baseDir = Path.Combine(Path.GetTempPath(), $"neolink-selftest-{Guid.NewGuid():N}");
+            var mainP = Path.Combine(baseDir, "recordings");
+            var clipsP = Path.Combine(baseDir, "ssd");
+            var archiveP = Path.Combine(baseDir, "archive");
+            try
+            {
+                // Unconfigured tiers collapse to main — a plain install has one location.
+                var plain = new Recording.StorageLocations(
+                    new Config.RecordingConfig { Path = mainP });
+                Assert(!plain.HasClipsTier, "no clips tier by default");
+                Assert(!plain.HasArchiveTier, "no archive tier by default");
+                AssertEq(plain.Locations.Count, 1);
+                AssertEq(Path.GetFullPath(plain.ClipsRoot), Path.GetFullPath(mainP)); // clips fall back to main
+                Assert(plain.ArchiveRoot == null, "archive root null when unset");
+
+                // All three tiers configured and distinct → three locations.
+                // A fake probe drives the capacity thresholds deterministically (GB-scale,
+                // so the 1 GiB free-space reserve behaves as it would on a real drive).
+                const long GB = 1024L * 1024 * 1024;
+                var caps = new Dictionary<string, (long, long)?>(StringComparer.OrdinalIgnoreCase)
+                {
+                    [Path.GetFullPath(mainP)] = (1000 * GB, 40 * GB),    // 96% used → warn, plenty free
+                    [Path.GetFullPath(clipsP)] = (1000 * GB, 500 * GB),  // 50% used → healthy
+                    [Path.GetFullPath(archiveP)] = (1000 * GB, GB / 2),  // 0.5 GB free → full
+                };
+                var full = new Recording.StorageLocations(
+                    new Config.RecordingConfig { Path = mainP, ClipsPath = clipsP, ArchivePath = archiveP },
+                    probe: p => caps.TryGetValue(Path.GetFullPath(p), out var v) ? v : null);
+
+                Assert(full.HasClipsTier && full.HasArchiveTier, "all tiers detected");
+                AssertEq(full.Locations.Count, 3);
+                AssertEq(Path.GetFullPath(full.ClipsRoot), Path.GetFullPath(clipsP));
+                AssertEq(Path.GetFullPath(full.ArchiveRoot!), Path.GetFullPath(archiveP));
+
+                var sample = full.Sample();
+                var mainS = sample.First(s => s.Role == Recording.StorageRole.Main);
+                var clipsS = sample.First(s => s.Role == Recording.StorageRole.Clips);
+                var archiveS = sample.First(s => s.Role == Recording.StorageRole.Archive);
+                Assert(mainS.UsedPercent >= 90 && mainS.Warn && !mainS.Full, "main warns at 96% used, plenty free");
+                Assert(!clipsS.Warn && !clipsS.Full, "healthy tier is neither warn nor full");
+                Assert(archiveS.Full, "archive under the free-space reserve is full");
+                Assert(!full.HasRoom(Recording.StorageRole.Archive), "no room to write the near-full archive");
+                Assert(full.HasRoom(Recording.StorageRole.Clips), "room to write the healthy clips tier");
+
+                // Threshold logic keys off the byte reserve, not just percent.
+                var tiny = new Recording.StorageStatus(Recording.StorageRole.Main, "m", mainP,
+                    TotalBytes: 10_000_000_000, FreeBytes: 100_000_000, Online: true); // 100 MB free < 1 GiB reserve
+                Assert(tiny.Full, "under the free-space reserve is full");
+                var roomy = tiny with { FreeBytes = 5L * 1024 * 1024 * 1024 };
+                Assert(!roomy.Full, "well above the reserve is not full");
+
+                // HasRoom fails open when a volume can't be read.
+                var blind = new Recording.StorageLocations(
+                    new Config.RecordingConfig { Path = mainP }, probe: _ => null);
+                Assert(blind.HasRoom(Recording.StorageRole.Main), "unreadable volume does not block recording");
+            }
+            finally
+            {
+                try { Directory.Delete(baseDir, recursive: true); } catch { }
+            }
+        });
+
+        Test("archive lifecycle: move at age, serve from archive, delete from archive", () =>
+        {
+            var baseDir = Path.Combine(Path.GetTempPath(), $"neolink-selftest-{Guid.NewGuid():N}");
+            var live = Path.Combine(baseDir, "recordings");
+            var arch = Path.Combine(baseDir, "archive");
+            try
+            {
+                // Stage a 10-day-old day (event + continuous) and a fresh event.
+                string dayOld = $"{DateTime.Now.Date.AddDays(-10):yyyy-MM-dd}";
+                var oldEvDir = Path.Combine(live, "cam1", dayOld, "detections", "080000-arc1");
+                Directory.CreateDirectory(oldEvDir);
+                File.WriteAllText(Path.Combine(oldEvDir, "event.json"),
+                    $$"""{"id":"cam1~{{dayOld}}~080000-arc1","camera":"cam1","startUtc":"{{dayOld}}T08:00:00Z","endUtc":"{{dayOld}}T08:00:30Z","labels":["person"],"hasClip":true}""");
+                File.WriteAllText(Path.Combine(oldEvDir, "clip.mp4"), "clip-bytes");
+                var oldCont = Path.Combine(live, "cam1", dayOld, "continuous");
+                Directory.CreateDirectory(oldCont);
+                File.WriteAllText(Path.Combine(oldCont, "08-00-00.mp4"), "seg-bytes");
+                // A 40-day-old day already IN the archive: past the delete window.
+                string dayAncient = $"{DateTime.Now.Date.AddDays(-40):yyyy-MM-dd}";
+                var ancient = Path.Combine(arch, "cam1", dayAncient, "continuous");
+                Directory.CreateDirectory(ancient);
+                File.WriteAllText(Path.Combine(ancient, "01-00-00.mp4"), "x");
+
+                var store = new Recording.EventStore(live, clipsRoot: null, archiveRoot: arch);
+                store.Load();
+                Assert(store.Find($"cam1~{dayOld}~080000-arc1") != null, "old event indexed from live");
+
+                // Archive on for both types: retention 7 days = footage moves at
+                // day 7 (instead of deletion); archive deletes after 30.
+                store.Cleanup(_ => new Recording.EventStore.CameraStoragePolicy(
+                    EventDays: 7, ContinuousDays: 7,
+                    ArchiveEvents: true, ArchiveContinuous: true, ArchiveDeleteDays: 30));
+
+                Assert(!Directory.Exists(Path.Combine(live, "cam1", dayOld)), "aged day left the live tier");
+                Assert(File.Exists(Path.Combine(arch, "cam1", dayOld, "detections", "080000-arc1", "clip.mp4")),
+                    "event clip moved to the archive");
+                Assert(File.Exists(Path.Combine(arch, "cam1", dayOld, "continuous", "08-00-00.mp4")),
+                    "continuous segment moved to the archive");
+                // The index followed the move: the event still resolves and plays.
+                var moved = store.ArtifactPath($"cam1~{dayOld}~080000-arc1", "clip.mp4");
+                Assert(moved != null && moved.StartsWith(Path.GetFullPath(arch), StringComparison.OrdinalIgnoreCase),
+                    "archived event's clip resolves inside the archive");
+                // The timeline sees archived footage transparently.
+                Assert(store.ListContinuousDays("cam1").Contains(dayOld), "archived day listed for the timeline");
+                AssertEq(store.ListSegments("cam1", dayOld).Count, 1);
+                Assert(store.SegmentPath("cam1", dayOld, "08-00-00.mp4") != null, "archived segment path resolves");
+                // The ancient archived day fell past the 30-day archive window.
+                Assert(!Directory.Exists(Path.Combine(arch, "cam1", dayAncient)), "expired archive day deleted");
+
+                // A second pass is a no-op (idempotent), and 0 = keep forever.
+                store.Cleanup(_ => new Recording.EventStore.CameraStoragePolicy(
+                    EventDays: 7, ContinuousDays: 7,
+                    ArchiveEvents: true, ArchiveContinuous: true, ArchiveDeleteDays: 0));
+                Assert(File.Exists(Path.Combine(arch, "cam1", dayOld, "continuous", "08-00-00.mp4")),
+                    "archived footage survives with delete window 0 (forever)");
+
+                // The per-type split: events archive while continuous deletes.
+                string daySplit = $"{DateTime.Now.Date.AddDays(-9):yyyy-MM-dd}";
+                var splitEv = Path.Combine(live, "cam2", daySplit, "detections", "090000-arc2");
+                Directory.CreateDirectory(splitEv);
+                File.WriteAllText(Path.Combine(splitEv, "event.json"),
+                    $$"""{"id":"cam2~{{daySplit}}~090000-arc2","camera":"cam2","startUtc":"{{daySplit}}T09:00:00Z","endUtc":"{{daySplit}}T09:00:30Z","labels":["person"],"hasClip":true}""");
+                File.WriteAllText(Path.Combine(splitEv, "clip.mp4"), "clip-bytes");
+                var splitCont = Path.Combine(live, "cam2", daySplit, "continuous");
+                Directory.CreateDirectory(splitCont);
+                File.WriteAllText(Path.Combine(splitCont, "09-00-00.mp4"), "seg-bytes");
+                store.Cleanup(_ => new Recording.EventStore.CameraStoragePolicy(
+                    EventDays: 7, ContinuousDays: 7,
+                    ArchiveEvents: true, ArchiveContinuous: false));
+                Assert(File.Exists(Path.Combine(arch, "cam2", daySplit, "detections", "090000-arc2", "clip.mp4")),
+                    "events-only archiving moved the event clip");
+                Assert(!Directory.Exists(Path.Combine(arch, "cam2", daySplit, "continuous"))
+                    && !Directory.Exists(splitCont),
+                    "events-only archiving still DELETED expired continuous footage");
+
+                // Old settings.json without the archive fields deserializes to archive-off.
+                var legacy = System.Text.Json.JsonSerializer.Deserialize<Recording.CameraRecordingSettings>(
+                    """{"events":true,"continuous":false,"eventTypes":null}""",
+                    new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                Assert(legacy != null && !legacy.ArchiveEvents && !legacy.ArchiveContinuous
+                    && legacy.ArchiveRetentionDays == null, "pre-archive settings default to archive off");
+            }
+            finally
+            {
+                try { Directory.Delete(baseDir, recursive: true); } catch { }
             }
         });
 

--- a/src/Neolink.Server/Web/WebApi.cs
+++ b/src/Neolink.Server/Web/WebApi.cs
@@ -49,6 +49,10 @@ public sealed class WebApiOptions
     public RecordingSettings? RecordingSettings { get; init; }
     /// <summary>Recording defaults (retention etc.) reported to the UI; null when recording is off.</summary>
     public RecordingConfig? Recording { get; init; }
+    /// <summary>An archive storage tier is configured, so per-camera archiving can be offered.</summary>
+    public bool ArchiveAvailable { get; init; }
+    /// <summary>Configured storage tiers and their capacity (feeds the monitor and the full-storage banners).</summary>
+    public StorageLocations? Storage { get; init; }
     public required UserStore UserStore { get; init; }
     public bool ResetAdminPassword { get; init; }
     public double TrickleSpeed { get; init; } = 4;
@@ -108,7 +112,8 @@ public static class WebApi
     private sealed record RecordingSettingsRequest(bool? Events, bool? Continuous, List<string>? EventTypes,
         int? EventRetentionDays = null, int? ContinuousRetentionDays = null, string? RecordStream = null,
         List<string>? ScheduleDays = null, string? ScheduleStart = null, string? ScheduleEnd = null,
-        bool? ScheduleEnabled = null);
+        bool? ScheduleEnabled = null,
+        bool? ArchiveEvents = null, bool? ArchiveContinuous = null, int? ArchiveRetentionDays = null);
     private sealed record CredentialsRequest(string? Username, string? Password);
 
     /// <summary>
@@ -491,7 +496,28 @@ public static class WebApi
             version = o.Version,
             latestVersion = o.Updates?.Latest,
             repoUrl = UpdateChecker.RepoUrl,
+            // Worst storage tier state, for the live view's banner: "warn" when
+            // any tier is >= 90% used, "full" when one is out of space (recording
+            // to it has halted). Rides this endpoint so the wall needs no extra poll.
+            storage = ShapeStorage(o.Storage),
         }));
+
+        // Every configured storage location and its capacity (monitor page).
+        app.MapGet("/api/storage", () =>
+            o.Storage == null
+                ? Results.Json(new { error = "recording is not configured" }, statusCode: 404)
+                : Results.Json(o.Storage.Sample().Select(s => new
+                {
+                    role = s.Role.ToString().ToLowerInvariant(),
+                    label = s.Label,
+                    path = s.Path,
+                    totalBytes = s.TotalBytes,
+                    freeBytes = s.FreeBytes,
+                    usedPercent = Math.Round(s.UsedPercent, 1),
+                    online = s.Online,
+                    warn = s.Warn,
+                    full = s.Full,
+                })));
 
         app.MapGet("/api/cameras", () =>
         {
@@ -1037,6 +1063,13 @@ public static class WebApi
                 scheduleDays = (IEnumerable<string>?)s.ScheduleDays ?? CameraRecordingSettings.WeekDays,
                 scheduleStart = s.ScheduleStart ?? "",
                 scheduleEnd = s.ScheduleEnd ?? "",
+                // Archiving: available only when the server config maps an archive
+                // tier; per camera AND per type (strict opt-in). Footage moves to
+                // the archive when its normal retention above expires.
+                archiveAvailable = o.ArchiveAvailable,
+                archiveEvents = s.ArchiveEvents,
+                archiveContinuous = s.ArchiveContinuous,
+                archiveRetentionDays = s.ArchiveRetentionDays,
             };
 
             app.MapGet("/api/cameras/{name}/recording", (string name, HttpContext ctx) =>
@@ -1091,6 +1124,16 @@ public static class WebApi
                 }
                 static string? SchedTime(string? v) =>
                     v != null && CameraRecordingSettings.ParseMinutes(v) is int m && m > 0 ? v : null;
+                // Archiving is inert without the server-side archive tier — the
+                // switches can't be turned on for a destination that doesn't exist.
+                var archiveEvents = o.ArchiveAvailable ? req.ArchiveEvents : null;
+                var archiveContinuous = o.ArchiveAvailable ? req.ArchiveContinuous : null;
+                if ((req.ArchiveEvents == true || req.ArchiveContinuous == true) && !o.ArchiveAvailable)
+                    return Results.Json(new
+                    {
+                        error = "archiving requires \"archive_path\" in the server recording config " +
+                                "(ideally a different drive — in Docker, map a second volume)",
+                    }, statusCode: 409);
                 var updated = recordingSettings.Update(cam.Name, req.Events, continuous,
                     types, setEventTypes: req.EventTypes != null,
                     eventRetentionDays: Retention(req.EventRetentionDays),
@@ -1102,7 +1145,11 @@ public static class WebApi
                     scheduleDays: schedDays, setScheduleDays: req.ScheduleDays != null,
                     scheduleStart: SchedTime(req.ScheduleStart), setScheduleStart: req.ScheduleStart != null,
                     scheduleEnd: SchedTime(req.ScheduleEnd), setScheduleEnd: req.ScheduleEnd != null,
-                    scheduleEnabled: req.ScheduleEnabled);
+                    scheduleEnabled: req.ScheduleEnabled,
+                    archiveEvents: archiveEvents,
+                    archiveContinuous: archiveContinuous,
+                    archiveRetentionDays: Retention(req.ArchiveRetentionDays),
+                    setArchiveRetention: req.ArchiveRetentionDays != null);
                 return Results.Json(ShapeSettings(cam, updated));
             });
         }
@@ -1322,6 +1369,21 @@ public static class WebApi
     /// reach clients without a typed model. Leaves: numbers stay numbers; repeated
     /// element names become arrays; attributes are prefixed with '@'.
     /// </summary>
+    /// <summary>The worst storage-tier state for the wall banner: null when recording
+    /// is off or every tier is healthy, else the most urgent tier's summary.</summary>
+    private static object? ShapeStorage(StorageLocations? storage)
+    {
+        if (storage == null) return null;
+        var sample = storage.Sample();
+        var worst = sample.FirstOrDefault(s => s.Full) ?? sample.FirstOrDefault(s => s.Warn);
+        return worst == null ? null : new
+        {
+            label = worst.Label,
+            usedPercent = Math.Round(worst.UsedPercent, 1),
+            full = worst.Full,
+        };
+    }
+
     /// <summary>The floodlight-task fields the UI binds to, out of the camera's
     /// (much larger) FloodlightTask XML. Field names follow the wire format.</summary>
     private static object ShapeFloodlight(XElement task) => new

--- a/src/Neolink.Server/config.example.json
+++ b/src/Neolink.Server/config.example.json
@@ -44,6 +44,14 @@
   // Remove this section to disable. In Docker, mount a volume at "path".
   // "recording": {
   //   "path": "/recordings",           // storage directory
+  //   "clips_path": "/clips",          // optional fast tier (SSD): new event clips land here,
+  //                                    // 24/7 footage stays on "path"; unset = everything on "path"
+  //   "archive_path": "/archive",      // optional cold tier: enables per-camera archiving in the
+  //                                    // web UI — expired footage MOVES here instead of being
+  //                                    // deleted. Use a different drive; in Docker, a second volume.
+  //                                    // NOTE (Docker): map a volume at EVERY tier path you set —
+  //                                    // an unmapped path is silently created inside the container
+  //                                    // and that footage is lost when the container is recreated
   //   "retention_days": 7,             // delete events older than this (0 = keep forever)
   //   "pre_seconds": 5,                // video kept from before the detection
   //   "post_seconds": 8,               // quiet time before an event closes

--- a/src/Neolink.WebClient/Components/CameraPanel.razor
+++ b/src/Neolink.WebClient/Components/CameraPanel.razor
@@ -8,7 +8,7 @@
    close it mid-adjustment. *@
 
 <div class="backdrop panel-backdrop"></div>
-<aside class="campanel" role="dialog" aria-label="Camera settings">
+<aside class="campanel campanel-wide" role="dialog" aria-label="Camera settings">
     <div class="campanel-head">
         <span class="dot @(_caps?.Online == true ? "on" : "off")"></span>
         <span class="campanel-title">@CameraName</span>
@@ -30,8 +30,11 @@
     }
     else if (_caps != null)
     {
+        @* Masonry body: sections flow into two columns on wide screens (one on
+           mobile) — each card keeps its grouping and never splits across columns. *@
+        <div class="campanel-body">
         <div class="campanel-section">
-            <div class="campanel-section-title">DEVICE</div>
+            <div class="campanel-section-title">@UiIcon.Render("info", 13) DEVICE</div>
             <table class="kv">
                 @if (!string.IsNullOrEmpty(_caps.Version?.Model)) { <tr><td>Model</td><td>@_caps.Version!.Model</td></tr> }
                 @if (!string.IsNullOrEmpty(_caps.Version?.Name)) { <tr><td>Name</td><td>@_caps.Version!.Name</td></tr> }
@@ -46,7 +49,7 @@
         {
             var canSetStream = _caps.Features?.StreamSettings == true;
             <div class="campanel-section">
-                <div class="campanel-section-title">STREAMS</div>
+                <div class="campanel-section-title">@UiIcon.Render("film", 13) STREAMS</div>
                 @foreach (var group in _profiles.GroupBy(p => p.Type))
                 {
                     @* The camera reports one encode table per selectable resolution;
@@ -117,7 +120,7 @@
         @if (_caps.Features?.Battery == true && _battery != null)
         {
             <div class="campanel-section">
-                <div class="campanel-section-title">BATTERY</div>
+                <div class="campanel-section-title">@UiIcon.Render("battery", 13) BATTERY</div>
                 <table class="kv">
                     @if (Num(_battery, "batteryPercent") is { } pct) { <tr><td>Charge</td><td>@pct%</td></tr> }
                     @if (Str(_battery, "chargeStatus") is { Length: > 0 } cs) { <tr><td>Status</td><td>@cs</td></tr> }
@@ -129,7 +132,7 @@
         @if (_caps.Features?.Ptz == true)
         {
             <div class="campanel-section">
-                <div class="campanel-section-title">PAN / TILT</div>
+                <div class="campanel-section-title">@UiIcon.Render("move", 13) PAN / TILT</div>
                 <div class="ptz-row">
                     <div class="ptz-pad">
                         <span></span>
@@ -157,7 +160,7 @@
         @if (_caps.Features?.Zoom == true && _zoomFocus?.Zoom is { Max: > 0 } zr)
         {
             <div class="campanel-section">
-                <div class="campanel-section-title">ZOOM / FOCUS</div>
+                <div class="campanel-section-title">@UiIcon.Render("zoom", 13) ZOOM / FOCUS</div>
                 @* Live controls like PTZ: the lens moves when you let go of the
                    slider — an absolute position, so there is nothing to stage. *@
                 <div class="control-row">
@@ -186,7 +189,7 @@
         @if (_caps.Features?.Led == true && _led != null)
         {
             <div class="campanel-section">
-                <div class="campanel-section-title">LIGHTS</div>
+                <div class="campanel-section-title">@UiIcon.Render("sun", 13) LIGHTS</div>
                 @* LedState semantics (per the BC protocol): "state" drives the IR
                    night-vision LEDs, "lightState" the little status/power LED. *@
                 @if (Str(_led, "state") is { Length: > 0 } irState)
@@ -238,7 +241,7 @@
         @if (_caps.Features?.Siren == true)
         {
             <div class="campanel-section">
-                <div class="campanel-section-title">SIREN</div>
+                <div class="campanel-section-title">@UiIcon.Render("siren", 13) SIREN</div>
                 <div class="control-row">
                     <span>@(_sirenOn == true ? "Sounding now" : "Sound the siren")</span>
                     @if (_sirenOn == true)
@@ -261,7 +264,7 @@
         @if (_caps.Features?.Privacy == true)
         {
             <div class="campanel-section">
-                <div class="campanel-section-title">PRIVACY MODE <span class="beta-tag">BETA</span></div>
+                <div class="campanel-section-title">@UiIcon.Render("eye-off", 13) PRIVACY MODE <span class="beta-tag">BETA</span></div>
                 <div class="control-row">
                     <span>Camera dark (no video, no detections)</span>
                     @if (_privacyOn == true)
@@ -289,7 +292,7 @@
         @if (_caps.Features?.Pir == true && _pir != null)
         {
             <div class="campanel-section">
-                <div class="campanel-section-title">PIR MOTION SENSOR</div>
+                <div class="campanel-section-title">@UiIcon.Render("activity", 13) PIR MOTION SENSOR</div>
                 <div class="control-row">
                     <span>Enabled @PendingMark(_pendingPir?.ToString())</span>
                     <button class="chip @((_pendingPir ?? PirEnabled) ? "" : "chip-off") @(_pendingPir != null ? "chip-pending" : "")"
@@ -303,7 +306,7 @@
         @if (_recording != null)
         {
             <div class="campanel-section">
-                <div class="campanel-section-title">RECORDING</div>
+                <div class="campanel-section-title">@UiIcon.Render("rec", 13) RECORDING</div>
                 <div class="notice small">
                     These are <b>Neolink server</b> settings — what this server records from the
                     camera's streams. Nothing here is sent to the camera or changes its own
@@ -324,6 +327,7 @@
                         </select>
                     </div>
                 }
+                <div class="campanel-subtitle">@UiIcon.Render("bolt", 12) EVENTS</div>
                 @if (_recording.EventsAvailable)
                 {
                     <div class="control-row">
@@ -414,8 +418,9 @@
                 {
                     @* Hairline between the event-based half above and 24/7 below. *@
                     <div class="campanel-divider"></div>
+                    <div class="campanel-subtitle">@UiIcon.Render("clock", 12) CONTINUOUS (24/7)</div>
                     <div class="control-row">
-                        <span>Continuous (24/7)</span>
+                        <span>Record around the clock</span>
                         <button class="chip @(_recording.Continuous ? "" : "chip-off")"
                                 @onclick="() => SetRecordingAsync(continuous: !_recording.Continuous)">
                             @(_recording.Continuous ? "on" : "off")
@@ -433,11 +438,67 @@
                         </div>
                     }
                 }
-                @if (_recording.Events || _recording.Continuous)
+                @if (_recording.ArchiveAvailable)
                 {
-                    <div class="notice small">
-                        Retention is per camera and per recording type: blank uses the server default,
-                        0 keeps footage forever. Expired days are removed by the hourly cleanup.
+                    <div class="campanel-divider"></div>
+                    <div class="campanel-subtitle">@UiIcon.Render("archive", 12) ARCHIVE <span class="beta-tag">BETA</span></div>
+                    @* Purpose up-front — visible BEFORE anything is switched on. *@
+                    <div class="event-sub lc-explain">
+                        Normally footage is deleted when its retention ends. Archiving moves it
+                        to the server's archive drive instead — still playable, just off the
+                        main disk. Watch the lifecycle strip below react as you toggle.
+                    </div>
+                    <div class="control-row">
+                        <span>Archive event clips</span>
+                        <button class="chip @(_recording.ArchiveEvents ? "" : "chip-off")"
+                                title="@(_recording.ArchiveEvents
+                                    ? "When their retention expires, event clips MOVE to the archive drive instead of being deleted — click for plain deletion"
+                                    : "Expired event clips are deleted — click to move them to the archive drive instead")"
+                                @onclick="() => SetRecordingAsync(archiveEvents: !_recording.ArchiveEvents)">
+                            @(_recording.ArchiveEvents ? "on" : "off")
+                        </button>
+                    </div>
+                    <div class="control-row">
+                        <span>Archive continuous footage</span>
+                        <button class="chip @(_recording.ArchiveContinuous ? "" : "chip-off")"
+                                title="@(_recording.ArchiveContinuous
+                                    ? "When its retention expires, 24/7 footage MOVES to the archive drive instead of being deleted — click for plain deletion"
+                                    : "Expired 24/7 footage is deleted — click to move it to the archive drive instead")"
+                                @onclick="() => SetRecordingAsync(archiveContinuous: !_recording.ArchiveContinuous)">
+                            @(_recording.ArchiveContinuous ? "on" : "off")
+                        </button>
+                    </div>
+                    @if (_recording.ArchiveEvents || _recording.ArchiveContinuous)
+                    {
+                        <div class="control-row">
+                            <span>Keep in archive (days)</span>
+                            <input class="ret-input" type="number" min="0" step="1"
+                                   placeholder="forever"
+                                   title="How long archived footage is kept before final deletion. Blank or 0 = keep forever."
+                                   value="@(_recording.ArchiveRetentionDays?.ToString() ?? "")"
+                                   @onchange="e => SetArchiveDaysAsync((string?)e.Value)" />
+                        </div>
+                    }
+                }
+                @if ((_recording.EventsAvailable && _recording.Events) || _recording.Continuous)
+                {
+                    @* The story of this camera's footage, told with the CURRENT settings —
+                       it re-renders on every toggle, so cause and effect are immediate. *@
+                    <div class="lifecycle"
+                         title="Applied by the hourly cleanup. Blank retention = the server default; 0 = keep forever.">
+                        <div class="lc-title">FOOTAGE LIFECYCLE</div>
+                        @if (_recording.EventsAvailable && _recording.Events)
+                        {
+                            @LifecycleRow("Events", _recording.EventRetentionDays ?? _recording.DefaultEventRetentionDays, _recording.ArchiveEvents)
+                        }
+                        @if (_recording.Continuous)
+                        {
+                            @LifecycleRow("24/7", _recording.ContinuousRetentionDays ?? _recording.DefaultContinuousRetentionDays, _recording.ArchiveContinuous)
+                        }
+                        @if (_recording.ArchiveEvents || _recording.ArchiveContinuous)
+                        {
+                            <div class="event-sub">Archived footage stays playable in Events and the Timeline.</div>
+                        }
                     </div>
                 }
             </div>
@@ -446,7 +507,7 @@
         @if (_caps.Features?.Reboot != false)
         {
             <div class="campanel-section">
-                <div class="campanel-section-title">MAINTENANCE</div>
+                <div class="campanel-section-title">@UiIcon.Render("wrench", 13) MAINTENANCE</div>
                 <div class="control-row">
                     <span>Restart the camera</span>
                     @if (!_confirmReboot)
@@ -461,6 +522,7 @@
                 </div>
             </div>
         }
+        </div> @* /campanel-body *@
 
         @if (_status != null)
         {
@@ -854,15 +916,24 @@
     private async Task SetRecordingAsync(bool? events = null, bool? continuous = null, List<string>? eventTypes = null,
         int? eventRetentionDays = null, int? continuousRetentionDays = null, string? recordStream = null,
         List<string>? scheduleDays = null, string? scheduleStart = null, string? scheduleEnd = null,
-        bool? scheduleEnabled = null)
+        bool? scheduleEnabled = null,
+        bool? archiveEvents = null, bool? archiveContinuous = null, int? archiveRetentionDays = null)
     {
         object body = new
         {
             events, continuous, eventTypes, eventRetentionDays, continuousRetentionDays, recordStream,
             scheduleDays, scheduleStart, scheduleEnd, scheduleEnabled,
+            archiveEvents, archiveContinuous, archiveRetentionDays,
         };
         if (await PostAsync("recording", body))
             _recording = await GetAsync<ApiRecordingSettings>("recording");
+    }
+
+    /// <summary>Blank/invalid input clears the override (the API takes negative = clear).</summary>
+    private Task SetArchiveDaysAsync(string? raw)
+    {
+        int days = int.TryParse(raw?.Trim(), out var d) && d >= 0 ? d : -1;
+        return SetRecordingAsync(archiveRetentionDays: days);
     }
 
     private static string StreamLabel(string? kind) => kind switch
@@ -875,6 +946,40 @@
 
     private static string RetentionLabel(int days) =>
         days > 0 ? $"default ({days}d)" : "default (forever)";
+
+    private static string DaysLabel(int days) => days == 1 ? "1 day" : $"{days} days";
+
+    /// <summary>One lifecycle-strip line: live window → archive → deletion, from
+    /// the settings as they stand right now (retention 0 = nothing ever expires).</summary>
+    private RenderFragment LifecycleRow(string name, int days, bool archives) => __builder =>
+    {
+        <div class="lc-row">
+            <span class="lc-name">@name</span>
+            @if (days <= 0)
+            {
+                <span class="lc-pill lc-live">kept forever</span>
+            }
+            else
+            {
+                <span class="lc-pill lc-live">@DaysLabel(days) on this server</span>
+                <span class="lc-arrow">→</span>
+                @if (archives)
+                {
+                    var keep = _recording?.ArchiveRetentionDays ?? 0;
+                    <span class="lc-pill lc-archive">archive@(keep > 0 ? $" · {DaysLabel(keep)}" : " · forever")</span>
+                    @if (keep > 0)
+                    {
+                        <span class="lc-arrow">→</span>
+                        <span class="lc-pill lc-del">deleted</span>
+                    }
+                }
+                else
+                {
+                    <span class="lc-pill lc-del">deleted</span>
+                }
+            }
+        </div>
+    };
 
     /// <summary>Blank/invalid input resets to the server default (the API takes negative = clear).</summary>
     private Task SetRetentionAsync(bool forEvents, string? raw)

--- a/src/Neolink.WebClient/Components/Pages/Events.razor
+++ b/src/Neolink.WebClient/Components/Pages/Events.razor
@@ -231,6 +231,17 @@
             }
             catch { }
             try { _sd = await JS.InvokeAsync<string?>("neolink.lsGet", "neolink.eventSd") == "1"; } catch { }
+            // Playback speed is a sticky preference (shared with the live view's
+            // event popup): pick 2× once and every next event opens at 2×.
+            try
+            {
+                if (double.TryParse(await JS.InvokeAsync<string?>("neolink.lsGet", "neolink.eventSpeed"),
+                        System.Globalization.NumberStyles.Float,
+                        System.Globalization.CultureInfo.InvariantCulture, out var sp)
+                    && Speeds.Contains(sp))
+                    _speed = sp;
+            }
+            catch { }
             try { _origin = await JS.InvokeAsync<string>("neolink.defaultServer"); } catch { }
             if (string.IsNullOrWhiteSpace(_server))
                 _server = _origin;
@@ -425,8 +436,8 @@
 
     private Task SelectAsync(ApiEvent ev)
     {
+        // _speed deliberately survives: the user's last pick applies to every event.
         _selected = ev;
-        _speed = 1;
         if (ev.HasClip) _pendingVideoUrl = PlayerUrl(ev); // attach after the <video> renders
         return Task.CompletedTask;
     }
@@ -434,6 +445,12 @@
     private async Task SetSpeedAsync(double s)
     {
         _speed = s;
+        try
+        {
+            await JS.InvokeVoidAsync("neolink.lsSet", "neolink.eventSpeed",
+                s.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        }
+        catch { }
         if (_selected is { HasClip: true } ev)
             await JS.InvokeVoidAsync("neolink.eventPlayer", "ev-video", PlayerUrl(ev), s);
     }

--- a/src/Neolink.WebClient/Components/Pages/Home.razor
+++ b/src/Neolink.WebClient/Components/Pages/Home.razor
@@ -48,6 +48,27 @@
             </div>
         }
 
+        @if (_storage is { Full: true })
+        {
+            @* Not dismissible: recording is actually stopped until space is freed. *@
+            <div class="storage-banner storage-banner-full">
+                <span class="sec-banner-text">⛔ @_storage.Label storage is FULL — recording has stopped. Free up space or extend retention/archive settings.</span>
+                <div class="sec-banner-actions">
+                    <a class="chip" href="monitor">Monitor</a>
+                </div>
+            </div>
+        }
+        else if (_storage is { } sw && !_storageWarnDismissed)
+        {
+            <div class="storage-banner">
+                <span class="sec-banner-text">⚠ @sw.Label storage is @sw.UsedPercent.ToString("0")% full — recording stops when it runs out.</span>
+                <div class="sec-banner-actions">
+                    <a class="chip" href="monitor">Monitor</a>
+                    <button class="icon-btn" title="Dismiss for this session" @onclick="DismissStorageWarnAsync">✕</button>
+                </div>
+            </div>
+        }
+
         @if (_showSettings)
         {
             <div class="settings">
@@ -1216,9 +1237,15 @@
             // session — an unsecured server re-warns on every fresh visit.
             _setupDismissed = await JS.InvokeAsync<string?>("neolink.lsGet", SetupDismissKey) == "1";
             _secWarnDismissed = await JS.InvokeAsync<string?>("neolink.ssGet", SecWarnDismissKey) == "1";
+            _storageWarnDismissed = await JS.InvokeAsync<string?>("neolink.ssGet", StorageWarnDismissKey) == "1";
             _mainWarned = await JS.InvokeAsync<string?>("neolink.lsGet", MainWarnKey) == "1";
             _updateDismissedVersion = await JS.InvokeAsync<string?>("neolink.lsGet", "neolink.updateDismissed");
             _playSd = await JS.InvokeAsync<string?>("neolink.lsGet", "neolink.eventSd") == "1";
+            if (double.TryParse(await JS.InvokeAsync<string?>("neolink.lsGet", "neolink.eventSpeed"),
+                    System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture, out var evSpeed)
+                && PlaybackSpeeds.Contains(evSpeed))
+                _playSpeed = evSpeed;
         }
         catch { }
     }
@@ -1235,6 +1262,20 @@
         // Session-scoped on purpose: hiding a security warning forever defeats it.
         _secWarnDismissed = true;
         await JS.InvokeVoidAsync("neolink.ssSet", SecWarnDismissKey, "1");
+    }
+
+    // ---------------------------------------------------------------- storage banners
+
+    /// <summary>Worst storage tier's state from /api/features; null = healthy.</summary>
+    private ApiStorageState? _storage;
+    private bool _storageWarnDismissed;
+    private string StorageWarnDismissKey => $"neolink.storageWarnDismissed:{_server.TrimEnd('/')}";
+
+    private async Task DismissStorageWarnAsync()
+    {
+        // Session-scoped: a nearly-full disk should re-warn on the next visit.
+        _storageWarnDismissed = true;
+        await JS.InvokeVoidAsync("neolink.ssSet", StorageWarnDismissKey, "1");
     }
 
     // One-time performance nudge, shown the first time the wall holds more than
@@ -2021,6 +2062,7 @@
                 _version = features.Version;
                 _latestVersion = features.LatestVersion;
                 if (!string.IsNullOrEmpty(features.RepoUrl)) _repoUrl = features.RepoUrl;
+                _storage = features.Storage;
             }
         }
         catch
@@ -2075,6 +2117,14 @@
     private async Task SetPlaySpeedAsync(double s)
     {
         _playSpeed = s;
+        // Sticky preference, shared with the Events page ("neolink.eventSpeed"):
+        // the next event opened — here or there — starts at this speed.
+        try
+        {
+            await JS.InvokeVoidAsync("neolink.lsSet", "neolink.eventSpeed",
+                s.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        }
+        catch { }
         await JS.InvokeVoidAsync("neolink.eventPlayer", "event-player-video", PlayerUrl, s);
     }
 
@@ -2085,7 +2135,8 @@
         await JS.InvokeVoidAsync("neolink.eventPlayer", "event-player-video", PlayerUrl, _playSpeed);
     }
 
-    private void OpenEvent(ApiEvent ev) { _playEvent = ev; _playSpeed = 1; }
+    // _playSpeed deliberately survives across events (loaded once per session).
+    private void OpenEvent(ApiEvent ev) => _playEvent = ev;
 
     /// <summary>Closing the player counts as reviewing: the event leaves the top strip.</summary>
     private async Task ClosePlayerAsync()

--- a/src/Neolink.WebClient/Components/Pages/Monitor.razor
+++ b/src/Neolink.WebClient/Components/Pages/Monitor.razor
@@ -136,6 +136,30 @@
                 }
             </div>
 
+            @* ---------------- storage tiers ---------------- *@
+            @* Only when split storage is configured — a single-volume install is
+               already covered by the DISK FREE card above. *@
+            @if (_storage.Count > 1)
+            {
+                <div class="mon-section">
+                    <span class="mon-section-title">STORAGE</span>
+                    <span class="mon-section-sub">configured recording locations</span>
+                </div>
+
+                <div class="mon-cards">
+                    @foreach (var loc in _storage)
+                    {
+                        <div class="mon-card">
+                            <span class="mon-card-label">@loc.Label.ToUpperInvariant()</span>
+                            <span class="mon-card-value" style="color:@StorageColor(loc)">
+                                @(loc.Online ? $"{Bytes(loc.FreeBytes)} free" : "offline")
+                            </span>
+                            <span class="mon-card-sub">@loc.Path@(loc.Online && loc.TotalBytes > 0 ? $" · {loc.UsedPercent:0}% of {Bytes(loc.TotalBytes)} used" : "")@(loc.Full ? " · FULL — recording halted" : loc.Warn ? " · getting full" : "")</span>
+                        </div>
+                    }
+                </div>
+            }
+
             @* ---------------- cameras ---------------- *@
             @if (_avail.Count > 0)
             {
@@ -249,6 +273,8 @@
 
     private ApiSystemInfo? _info;
     private List<ApiCamAvail> _avail = new();
+    private List<ApiStorageLocation> _storage = new();
+    private DateTime _storageNext = DateTime.MinValue;
     private readonly List<ApiSystemSample> _samples = new();
     private readonly List<BrowserSample> _browser = new();
     private PeriodicTimer? _timer;
@@ -356,6 +382,25 @@
         {
             _error = _samples.Count == 0 ? $"Cannot reach {ApiBase}: {ex.Message}" : _error;
         }
+        await FetchStorageAsync();
+    }
+
+    /// <summary>Storage-tier capacities (only rendered when split storage is
+    /// configured). Refreshed every ~10s — disks don't fill within a poll tick.</summary>
+    private async Task FetchStorageAsync()
+    {
+        if (DateTime.UtcNow < _storageNext) return;
+        _storageNext = DateTime.UtcNow.AddSeconds(10);
+        try
+        {
+            var req = new HttpRequestMessage(HttpMethod.Get, $"{ApiBase}/api/storage");
+            if (!string.IsNullOrEmpty(_token))
+                req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _token);
+            using var res = await Http.SendAsync(req);
+            if (!res.IsSuccessStatusCode) return; // older server or recording off
+            _storage = await res.Content.ReadFromJsonAsync<List<ApiStorageLocation>>() ?? new();
+        }
+        catch { /* the section just stays hidden */ }
     }
 
     private async Task FetchAuthAsync()
@@ -544,6 +589,11 @@
 
     private string DiskColor() => Last is { DTot: > 0 } s && s.DFree < s.DTot / 10
         ? "var(--err)"
+        : "var(--text)";
+
+    private static string StorageColor(ApiStorageLocation loc) =>
+        loc.Full || !loc.Online ? "var(--err)"
+        : loc.Warn ? "#ffb020"
         : "var(--text)";
 
     public async ValueTask DisposeAsync()

--- a/src/Neolink.WebClient/Models.cs
+++ b/src/Neolink.WebClient/Models.cs
@@ -78,7 +78,15 @@ public sealed record LocalApiInfo(string BaseUrl);
 
 /// <summary>Server capability flags (GET /api/features).</summary>
 public sealed record ApiFeaturesInfo(bool Events, bool Continuous, double TrickleSpeed = 4,
-    string? Version = null, string? LatestVersion = null, string? RepoUrl = null);
+    string? Version = null, string? LatestVersion = null, string? RepoUrl = null,
+    ApiStorageState? Storage = null);
+
+/// <summary>The worst storage tier's state (in /api/features); null = all healthy.</summary>
+public sealed record ApiStorageState(string Label, double UsedPercent, bool Full);
+
+/// <summary>GET /api/storage — one configured storage location and its capacity.</summary>
+public sealed record ApiStorageLocation(string Role, string Label, string Path,
+    long TotalBytes, long FreeBytes, double UsedPercent, bool Online, bool Warn, bool Full);
 
 /// <summary>GET /api/admin/config — the editable server settings.</summary>
 public sealed record ApiAdminConfig(string Path, bool Writable, JsonElement Settings);
@@ -104,7 +112,9 @@ public sealed record ApiRecordingSettings(bool Events, bool Continuous,
     bool EventsAvailable = true, string? RecordStream = null,
     string? DefaultRecordStream = null, List<string>? AvailableStreams = null,
     List<string>? ScheduleDays = null, string? ScheduleStart = null, string? ScheduleEnd = null,
-    bool ScheduleEnabled = false)
+    bool ScheduleEnabled = false,
+    bool ArchiveAvailable = false, bool ArchiveEvents = false,
+    bool ArchiveContinuous = false, int? ArchiveRetentionDays = null)
 {
     /// <summary>null EventTypes = every detection type is recorded.</summary>
     public bool TypeEnabled(string label) => EventTypes == null || EventTypes.Contains(label);
@@ -228,6 +238,14 @@ public static class UiIcon
             "zoom" => "<circle cx=\"11\" cy=\"11\" r=\"7\"/><line x1=\"21\" y1=\"21\" x2=\"16\" y2=\"16\"/>",
             // Record: ring with a filled core — the classic ⏺ shape.
             "rec" => "<circle cx=\"12\" cy=\"12\" r=\"9\"/><circle cx=\"12\" cy=\"12\" r=\"4.5\" fill=\"currentColor\" stroke=\"none\"/>",
+            // Camera-panel section markers.
+            "info" => "<circle cx=\"12\" cy=\"12\" r=\"10\"/><line x1=\"12\" y1=\"16\" x2=\"12\" y2=\"12\"/><line x1=\"12\" y1=\"8\" x2=\"12.01\" y2=\"8\"/>",
+            "move" => "<polyline points=\"5 9 2 12 5 15\"/><polyline points=\"9 5 12 2 15 5\"/><polyline points=\"15 19 12 22 9 19\"/><polyline points=\"19 9 22 12 19 15\"/><line x1=\"2\" y1=\"12\" x2=\"22\" y2=\"12\"/><line x1=\"12\" y1=\"2\" x2=\"12\" y2=\"22\"/>",
+            "sun" => "<circle cx=\"12\" cy=\"12\" r=\"5\"/><line x1=\"12\" y1=\"1\" x2=\"12\" y2=\"3\"/><line x1=\"12\" y1=\"21\" x2=\"12\" y2=\"23\"/><line x1=\"4.22\" y1=\"4.22\" x2=\"5.64\" y2=\"5.64\"/><line x1=\"18.36\" y1=\"18.36\" x2=\"19.78\" y2=\"19.78\"/><line x1=\"1\" y1=\"12\" x2=\"3\" y2=\"12\"/><line x1=\"21\" y1=\"12\" x2=\"23\" y2=\"12\"/><line x1=\"4.22\" y1=\"19.78\" x2=\"5.64\" y2=\"18.36\"/><line x1=\"18.36\" y1=\"5.64\" x2=\"19.78\" y2=\"4.22\"/>",
+            "siren" => "<polygon points=\"11 5 6 9 2 9 2 15 6 15 11 19 11 5\"/><path d=\"M15.54 8.46a5 5 0 0 1 0 7.07\"/><path d=\"M19.07 4.93a10 10 0 0 1 0 14.14\"/>",
+            "eye-off" => "<path d=\"M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94\"/><path d=\"M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19\"/><line x1=\"1\" y1=\"1\" x2=\"23\" y2=\"23\"/>",
+            "wrench" => "<path d=\"M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z\"/>",
+            "archive" => "<polyline points=\"21 8 21 21 3 21 3 8\"/><rect x=\"1\" y=\"3\" width=\"22\" height=\"5\"/><line x1=\"10\" y1=\"12\" x2=\"14\" y2=\"12\"/>",
             _ => "",
         };
         return new MarkupString(

--- a/src/Neolink.WebClient/wwwroot/css/app.css
+++ b/src/Neolink.WebClient/wwwroot/css/app.css
@@ -1335,6 +1335,31 @@ body.is-fullscreen .fs-exit { display: inline-flex; }
     padding: 10px 12px;
 }
 
+/* Camera settings dialog: roomier than the base panel, with the section cards
+   flowing masonry-style into two columns (cards never split across columns).
+   Below the breakpoint it falls back to the familiar single column. */
+.campanel-wide { width: min(1080px, 94vw); }
+
+.campanel-body {
+    columns: 2;
+    column-gap: 12px;
+}
+
+.campanel-body > * {
+    break-inside: avoid;
+    margin: 0 0 12px;
+}
+
+.campanel-body .campanel-section { transition: border-color 0.15s ease; }
+
+.campanel-body .campanel-section:hover {
+    border-color: color-mix(in srgb, var(--accent) 30%, var(--line));
+}
+
+@media (max-width: 860px) {
+    .campanel-body { columns: 1; }
+}
+
 /* Staged-edits bar: pinned to the panel's bottom edge (mirror of .campanel-head)
    so Apply/Discard and the disruption warning never scroll out of sight. */
 .campanel-pending {
@@ -1416,6 +1441,100 @@ body.is-fullscreen .fs-exit { display: inline-flex; }
     color: var(--muted);
     letter-spacing: 2px;
     margin-bottom: 8px;
+}
+
+.campanel-section-title .nl-icon {
+    vertical-align: -2.5px;
+    margin-right: 5px;
+    opacity: 0.7;
+}
+
+/* Sub-grouping inside a section (e.g. the RECORDING card's ARCHIVE block). */
+.campanel-subtitle {
+    font-size: 11px;
+    color: var(--muted);
+    letter-spacing: 2px;
+    margin: 2px 0 8px;
+}
+
+.campanel-subtitle .nl-icon {
+    vertical-align: -2px;
+    margin-right: 5px;
+    opacity: 0.7;
+}
+
+/* Doubled class: .event-sub (later in this file) ellipsizes single lines;
+   an explanation must wrap, so this needs the higher specificity. */
+.event-sub.lc-explain {
+    margin: -2px 0 8px;
+    line-height: 1.4;
+    white-space: normal;
+}
+
+/* The lifecycle strip's footer line must wrap too. */
+.lifecycle .event-sub { white-space: normal; }
+
+/* Footage-lifecycle strip: the RECORDING card's living summary — colored pills
+   trace each recording type from live disk to archive to deletion, built from
+   the settings as currently toggled (so flipping a switch explains itself). */
+.lifecycle {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 10px;
+    padding: 8px 10px;
+    border: 1px dashed var(--line);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--panel) 55%, transparent);
+}
+
+.lc-title {
+    font-size: 10px;
+    color: var(--muted);
+    letter-spacing: 2px;
+}
+
+.lc-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.lc-name {
+    min-width: 44px;
+    font-size: 10px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    color: var(--muted);
+}
+
+.lc-arrow { color: var(--muted); font-size: 12px; }
+
+.lc-pill {
+    font-size: 11px;
+    border-radius: 999px;
+    padding: 1px 9px;
+    white-space: nowrap;
+    border: 1px solid;
+}
+
+.lc-live {
+    color: var(--ok);
+    border-color: color-mix(in srgb, var(--ok) 45%, transparent);
+    background: color-mix(in srgb, var(--ok) 8%, transparent);
+}
+
+.lc-archive {
+    color: #e8b054;
+    border-color: color-mix(in srgb, #e8b054 45%, transparent);
+    background: color-mix(in srgb, #e8b054 8%, transparent);
+}
+
+.lc-del {
+    color: color-mix(in srgb, var(--err) 80%, var(--text));
+    border-color: color-mix(in srgb, var(--err) 40%, transparent);
+    background: color-mix(in srgb, var(--err) 7%, transparent);
 }
 
 .kv {
@@ -2745,6 +2864,28 @@ body.is-fullscreen .fs-exit { display: inline-flex; }
 
 .update-banner-text { font-size: 12px; color: var(--text); line-height: 1.35; }
 .update-banner a.chip { text-decoration: none; }
+
+/* Storage capacity banners: amber = a tier is >= 90% used (dismissible for the
+   session), red = a tier is out of space and recording to it has halted. */
+.storage-banner {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin: 4px 10px;
+    padding: 8px 10px;
+    border: 1px solid #ffb020;
+    border-radius: 8px;
+    background: color-mix(in srgb, #ffb020 12%, transparent);
+}
+
+.storage-banner a.chip { text-decoration: none; }
+
+.storage-banner-full {
+    border-color: #ff5252;
+    background: color-mix(in srgb, #ff5252 14%, transparent);
+}
+
+.storage-banner-full .sec-banner-text { color: #ff8a80; }
 
 /* Event player speed control */
 .player-speed {


### PR DESCRIPTION
## Summary

Optional tiered storage for recordings, with capacity watching and per-camera archiving. A plain `recording.path` install behaves exactly as before -- every tier is opt-in and absent settings default to the current delete-only behavior.

### Storage tiers

- `clips_path` (optional fast tier): new event clips are written here (point it at an SSD for snappy review); continuous 24/7 footage stays on `path`. Existing footage is found on both roots.
- `archive_path` (optional cold tier, BETA): unlocks per-camera **Archive event clips** and **Archive continuous footage** switches in the web UI. Retention stays the single clock: when an enabled type's retention expires, its footage is **moved** to the archive instead of deleted. One per-camera knob sets how long the archive keeps footage (blank = forever). Events, the timeline and continuous playback read archived footage transparently, and archive deletion keeps honoring its window even if archiving is later switched off.

### Capacity watch

- Amber banner in the web UI at 90% used on any configured location (session-dismissible); red banner when a location is out of space -- recording to it halts cleanly (no partial files, one log line per transition) and resumes automatically when space frees up.
- New `GET /api/storage` lists every location with capacity and warn/full state; `/api/features` carries the worst tier for the wall's banner.
- With split storage configured the Monitor page shows a STORAGE section with live per-location cards.

### UI

- Camera settings dialog redesigned: roomier (~1080 px), section cards flow into two columns with per-section icons, collapsing to one column on tablets/phones.
- RECORDING card restructured into EVENTS / CONTINUOUS / ARCHIVE blocks with the archive's purpose explained before anything is switched on, plus a live FOOTAGE LIFECYCLE strip that traces each recording type through colored stages (live -> archive -> deleted) built from the current settings.
- Event playback speed is now a sticky preference shared by the Events page and the live view's popup (the timeline already persisted its speed).

### Fixes

- Disk-write failures can no longer crash the service: the clip writer's final buffer flush runs on a raw thread and an unhandled exception there killed the process when a volume filled mid-clip; it now logs and marks the clip faulted. A dead clips volume no longer kills a detection event (it still registers and reaches Home Assistant, metadata-only), and settings/event-metadata persistence failures log instead of bubbling up.
- Config parser now reads `clips_path`/`archive_path` (JSON and TOML), covered by a selftest so the keys cannot silently regress.

### Docs

README (tiered storage section, features list, troubleshooting entry for unmapped Docker tier paths), config.example.json, docker-compose.yml volume examples, and the Home Assistant add-on DOCS. Version bumped to 0.8.7 across csproj, addon config.yaml and the changelog.

## Testing

- Selftest: 34 passed, 0 failed (locally and inside the Docker image). New tests: storage-tier resolution and thresholds (fail-open on unreadable volumes), archive lifecycle (move at retention age, serve from archive, delete from archive, per-type split, idempotent second pass, legacy settings.json compatibility), and config parsing of the new keys.
- Browser-verified against a harness serving the real web UI: amber/warn and red/full banners (including session dismiss and full overriding a dismissed warn), monitor storage cards in all three states, archive settings roundtrip into settings.json, two-column panel at desktop widths and single column at 768/375 px, lifecycle strip reacting to toggles, and playback-speed persistence across reloads in both players.
- End-to-end in the image: a config with both tier paths boots and `GET /api/storage` reports all three locations.

Generated with Claude Code (https://claude.com/claude-code)
